### PR TITLE
CSS-5072 add web-proxy as a config value

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -24,6 +24,10 @@ options:
     description: |
       Client password from Google Oauth setup
     type: string
+  web-proxy:
+    description: |
+      The address of the web proxy
+    type: string 
   ranger-acl-enabled:
     description: |
       Enabling/disabling Ranger plugin for Trino

--- a/config.yaml
+++ b/config.yaml
@@ -26,7 +26,8 @@ options:
     type: string
   web-proxy:
     description: |
-      The address of the web proxy
+      The address of the web proxy. To be used in combination
+      with google-client-id and google-client-secret values.
     type: string 
   ranger-acl-enabled:
     description: |

--- a/src/charm.py
+++ b/src/charm.py
@@ -313,6 +313,8 @@ class TrinoK8SCharm(CharmBase):
 
         Raises:
             ValueError: in case of invalid log configuration.
+                        in case of invalid trino-password
+                        in case of web-proxy as empty string
             RuntimeError: in case keystore does not exist
         """
         valid_log_levels = ["info", "debug", "warn", "error"]
@@ -328,6 +330,10 @@ class TrinoK8SCharm(CharmBase):
         path = f"{CONF_PATH}/keystore.p12"
         if not container.exists(path):
             raise RuntimeError(f"{path} does not exist, check TLS relation")
+
+        web_proxy = self.config.get("web-proxy")
+        if web_proxy == "":
+            raise ValueError("Web-proxy value cannot be an empty string")
 
     def get_params(self):
         """Create Jinja file specific dictionaries from relevant config values.
@@ -355,6 +361,7 @@ class TrinoK8SCharm(CharmBase):
                 "KEYSTORE_PATH": f"{CONF_PATH}/keystore.p12",
                 "OAUTH_CLIENT_ID": self.config.get("google-client-id"),
                 "OAUTH_CLIENT_SECRET": self.config.get("google-client-secret"),
+                "WEB_PROXY": self.config.get("web-proxy"),
             }
         )
         return log_context, config_context

--- a/src/charm.py
+++ b/src/charm.py
@@ -312,7 +312,7 @@ class TrinoK8SCharm(CharmBase):
             container: Trino container
 
         Raises:
-            ValueError: in case of invalid log configuration.
+            ValueError: in case of invalid log configuration
                         in case of invalid trino-password
                         in case of web-proxy as empty string
             RuntimeError: in case keystore does not exist
@@ -332,7 +332,7 @@ class TrinoK8SCharm(CharmBase):
             raise RuntimeError(f"{path} does not exist, check TLS relation")
 
         web_proxy = self.config.get("web-proxy")
-        if web_proxy == "":
+        if web_proxy and not web_proxy.strip():
             raise ValueError("Web-proxy value cannot be an empty string")
 
     def get_params(self):

--- a/templates/config.jinja
+++ b/templates/config.jinja
@@ -19,7 +19,9 @@ http-server.authentication.oauth2.principal-field=email
 http-server.authentication.oauth2.scopes=https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/userinfo.profile,openid
 http-server.authentication.oauth2.client-id={{ OAUTH_CLIENT_ID }}
 http-server.authentication.oauth2.client-secret={{ OAUTH_CLIENT_SECRET }}
-
+    {% if WEB_PROXY is not none %}
+oauth2-jwk.http-client.http-proxy={{ WEB_PROXY }}
+    {% endif %}
 {% else %}
 http-server.authentication.type=PASSWORD
 {% endif %}

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -110,6 +110,7 @@ class TestCharm(TestCase):
                         "LOG_LEVEL": "info",
                         "OAUTH_CLIENT_ID": None,
                         "OAUTH_CLIENT_SECRET": None,
+                        "WEB_PROXY": None,
                     },
                 }
             },
@@ -187,6 +188,7 @@ class TestCharm(TestCase):
             {
                 "google-client-id": "test-client-id",
                 "google-client-secret": "test-client-secret",
+                "web-proxy": "proxy:port"
             }
         )
 
@@ -205,6 +207,7 @@ class TestCharm(TestCase):
                         "LOG_LEVEL": "info",
                         "OAUTH_CLIENT_ID": "test-client-id",
                         "OAUTH_CLIENT_SECRET": "test-client-secret",
+                        "WEB_PROXY": "proxy:port",
                     },
                 }
             },


### PR DESCRIPTION
Adds `web-proxy` as a config value and updates `config.jinja` to include this value when provided if google oauth credentials are also provided. 