### PR TITLE
CSS-5261 Add worker function

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,8 +67,11 @@ juju debug-log
 # Pack the charm:
 charmcraft pack
 
-# Deploy the charm:
+# Deploy the coordinator:
 juju deploy ./trino-k8s_ubuntu-22.04-amd64.charm --resource trino-image=trinodb/trino:418
+
+# Deploy the worker:
+juju deploy ./trino-k8s_ubuntu-22.04-amd64.charm --resource trino-image=trinodb/trino:418 --config charm-function=worker trino-k8s-worker
 
 # Check deployment was successful:
 kubectl get pods -n trino-k8s

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ juju deploy ./trino-k8s_ubuntu-22.04-amd64.charm --resource trino-image=trinodb/
 kubectl get pods -n trino-k8s
 ```
 
-Note: due to the requirements of the `discovery_uri`, when using a separate coordinator and worker, the trino coordinator deployment must be named `trino-k8s` and cannot use any other alias.
+Note: due to the requirements of the `discovery_uri`, when using a separate coordinator and worker, the default `discovery_uri` value of `http://trino-k8s:8080` will only work if the trino coordinator deployment is named `trino-k8s`. If using another alias please update the worker and coordinator charm configurations accordingly.
 
 ## Trino configuration
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,9 @@ juju deploy ./trino-k8s_ubuntu-22.04-amd64.charm --resource trino-image=trinodb/
 # Check deployment was successful:
 kubectl get pods -n trino-k8s
 ```
+
+Note: due to the requirements of the `discovery_uri`, when using a separate coordinator and worker, the trino coordinator deployment must be named `trino-k8s` and cannot use any other alias.
+
 ## Trino configuration
 ```
 # Enable DEBUG logging

--- a/config.yaml
+++ b/config.yaml
@@ -66,3 +66,9 @@ options:
       `all` will result in a single node deployment, not recommended for production.
     default: coordinator
     type: string
+  discovery-uri:
+    description: |
+        When using a coordinator and worker this is the host and port of the 
+        coordinator service that the workers announce themselves to.
+    type: string
+    default: http://trino-k8s:8080

--- a/config.yaml
+++ b/config.yaml
@@ -62,6 +62,7 @@ options:
     type: string
   charm-function:
     description: |
-      One of coordinator or worker, to determine function of the application
+      One of `coordinator`, `worker` or `all` to determine the function of the application.
+      `all` will result in a single node deployment, not recommended for production.
     default: coordinator
     type: string

--- a/config.yaml
+++ b/config.yaml
@@ -60,3 +60,8 @@ options:
         Password to be used for default trino user created on startup.
     default: ubuntu123
     type: string
+  charm-function:
+    description: |
+      One of coordinator or worker, to determine function of the application
+    default: coordinator
+    type: string

--- a/src/charm.py
+++ b/src/charm.py
@@ -347,6 +347,7 @@ class TrinoK8SCharm(CharmBase):
             "SSL_PWD": self._state.truststore_password,
             "SSL_PATH": f"{CONF_PATH}/truststore.jks",
             "CHARM_FUNCTION": self.config["charm-function"],
+            "DISCOVERY_URI": self.config["discovery-uri"],
         }
         return env
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -304,9 +304,11 @@ class TrinoK8SCharm(CharmBase):
             self._state.truststore_password = truststore_password
 
     def _open_service_port(self):
-        """Open port 8080 for trino worker."""
+        """Open port 8080 on Trino coordinator."""
         if self.config["charm-function"] == "coordinator":
             self.model.unit.open_port(port=8080, protocol="tcp")
+        else:
+            self.model.unit.close_port(port=8080, protocol="tcp")
 
     def _validate_config_params(self):
         """Validate that configuration is valid.

--- a/src/charm.py
+++ b/src/charm.py
@@ -10,7 +10,6 @@ develop a new k8s charm using the Operator Framework:
 https://discourse.charmhub.io/t/4208
 """
 
-import functools
 import logging
 
 from charms.nginx_ingress_integrator.v0.nginx_route import require_nginx_route
@@ -306,7 +305,8 @@ class TrinoK8SCharm(CharmBase):
 
     def _open_service_port(self):
         """Open port 8080 for trino worker."""
-        self.model.unit.open_port(port=8080, protocol="tcp")
+        if self.config["charm-function"] == "coordinator":
+            self.model.unit.open_port(port=8080, protocol="tcp")
 
     def _validate_config_params(self):
         """Validate that configuration is valid.

--- a/templates/config.jinja
+++ b/templates/config.jinja
@@ -1,14 +1,16 @@
 {% if CHARM_FUNCTION == "coordinator" %}
 coordinator=true
+discovery.uri=http://trino-k8s:8080
 node-scheduler.include-coordinator=false
 {% elif CHARM_FUNCTION == "worker" %}
 coordinator=false
+discovery.uri=http://trino-k8s:8080
 {% elif CHARM_FUNCTION == "all" %}
 coordinator=true
 node-scheduler.include-coordinator=true
+discovery.uri=http://localhost:8080
 {% endif %}
 
-discovery.uri=http://trino-k8s:8080
 http-server.http.port=8080
 node.internal-address-source=FQDN
 internal-communication.shared-secret={{ INT_COMMS_SECRET | default("changeme")}}

--- a/templates/config.jinja
+++ b/templates/config.jinja
@@ -1,8 +1,16 @@
+{% if CHARM_FUNCTION == "coordinator" %}
 coordinator=true
-discovery.uri=http://localhost:8080
+node-scheduler.include-coordinator=false
+{% elif CHARM_FUNCTION == "worker" %}
+coordinator=false
+{% elif CHARM_FUNCTION == "all" %}
+coordinator=true
+node-scheduler.include-coordinator=true
+{% endif %}
+
+discovery.uri=http://trino-k8s:8080
 http-server.http.port=8080
 node.internal-address-source=FQDN
-node-scheduler.include-coordinator=true
 internal-communication.shared-secret={{ INT_COMMS_SECRET | default("changeme")}}
 
 http-server.process-forwarded=true

--- a/templates/config.jinja
+++ b/templates/config.jinja
@@ -1,10 +1,10 @@
 {% if CHARM_FUNCTION == "coordinator" %}
 coordinator=true
-discovery.uri=http://trino-k8s:8080
+discovery.uri={{ DISCOVERY_URI }}
 node-scheduler.include-coordinator=false
 {% elif CHARM_FUNCTION == "worker" %}
 coordinator=false
-discovery.uri=http://trino-k8s:8080
+discovery.uri={{ DISCOVERY_URI }}
 {% elif CHARM_FUNCTION == "all" %}
 coordinator=true
 node-scheduler.include-coordinator=true

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -7,7 +7,7 @@ import logging
 
 import pytest
 import pytest_asyncio
-from helpers import APP_NAME, METADATA, NGINX_NAME
+from helpers import APP_NAME, METADATA, NGINX_NAME, WORKER_NAME
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
@@ -29,11 +29,20 @@ async def deploy(ops_test: OpsTest):
         application_name=APP_NAME,
         num_units=1,
     )
+    worker_config = {"charm-function": "worker"}
+    await ops_test.model.deploy(
+        charm,
+        resources=resources,
+        application_name=WORKER_NAME,
+        config=worker_config,
+        num_units=1,
+    )
+
     await ops_test.model.deploy(NGINX_NAME, trust=True)
 
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(
-            apps=[NGINX_NAME, APP_NAME],
+            apps=[NGINX_NAME, APP_NAME, WORKER_NAME],
             status="active",
             raise_on_blocked=False,
             timeout=600,

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 CONN_NAME = "connection-test"
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
+WORKER_NAME = f"{APP_NAME}-worker"
 NGINX_NAME = "nginx-ingress-integrator"
 CONN_CONFIG = """connector.name=postgresql
 connection-url=jdbc:postgresql://example.host.com:5432/test

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -96,6 +96,7 @@ class TestCharm(TestCase):
                         "WEB_PROXY": None,
                         "SSL_PATH": "/etc/trino/conf/truststore.jks",
                         "SSL_PWD": "truststore123",
+                        "CHARM_FUNCTION": "coordinator",
                     },
                 }
             },
@@ -173,6 +174,7 @@ class TestCharm(TestCase):
                 "google-client-id": "test-client-id",
                 "google-client-secret": "test-client-secret",
                 "web-proxy": "proxy:port",
+                "charm-function": "worker",
             }
         )
 
@@ -192,6 +194,7 @@ class TestCharm(TestCase):
                         "WEB_PROXY": "proxy:port",
                         "SSL_PATH": "/etc/trino/conf/truststore.jks",
                         "SSL_PWD": "truststore123",
+                        "CHARM_FUNCTION": "worker",
                     },
                 }
             },

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -97,6 +97,7 @@ class TestCharm(TestCase):
                         "SSL_PATH": "/etc/trino/conf/truststore.jks",
                         "SSL_PWD": "truststore123",
                         "CHARM_FUNCTION": "coordinator",
+                        "DISCOVERY_URI": "http://trino-k8s:8080",
                     },
                 }
             },
@@ -195,6 +196,7 @@ class TestCharm(TestCase):
                         "SSL_PATH": "/etc/trino/conf/truststore.jks",
                         "SSL_PWD": "truststore123",
                         "CHARM_FUNCTION": "worker",
+                        "DISCOVERY_URI": "http://trino-k8s:8080",
                     },
                 }
             },


### PR DESCRIPTION
Adds the worker function to the trino charm. 

Includes:

- Update to the `config.properties` to allow for different configuration if the `charm-function` is set to `worker` vs `coordinator` vs `all`. All to be used for single node testing.
- Opening of the service port 8080 such that the workers can announce their presence to the discovery_uri 