### PR TITLE
CSS-5987 integration testing for policy relation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ops >= 2.2.0
+ops>=2.2.0
 Jinja2==3.1.1
 cryptography==39.0.1
 jsonschema==4.17.3

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -9,8 +9,6 @@ import time
 from pathlib import Path
 
 import yaml
-from pytest_operator.plugin import OpsTest
-from trino_client.show_catalogs import show_catalogs
 from apache_ranger.client.ranger_client import RangerClient
 from apache_ranger.model.ranger_policy import (
     RangerPolicy,
@@ -56,6 +54,7 @@ USER_WITH_ACCESS = "user1"
 USER_WITHOUT_ACCESS = "user2"
 GROUP_WITH_ACCESS = "commercial-systems"
 POLICY_NAME = "tpch - catalog, schema, table, column"
+
 
 async def get_unit_url(
     ops_test: OpsTest, application, unit, port, protocol="http"
@@ -124,7 +123,9 @@ async def run_connector_action(ops_test, action, params, user):
 
 async def create_group_policy(ops_test, ranger_url):
     """Create a Ranger group policy.
+
     Allow members of `commercial-systems` to access `tpch` catalog.
+
     Args:
         ops_test: PyTest object
         ranger_url: the polciy manager url

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -11,20 +11,51 @@ from pathlib import Path
 import yaml
 from pytest_operator.plugin import OpsTest
 from trino_client.show_catalogs import show_catalogs
+from apache_ranger.client.ranger_client import RangerClient
+from apache_ranger.model.ranger_policy import (
+    RangerPolicy,
+    RangerPolicyItem,
+    RangerPolicyItemAccess,
+    RangerPolicyResource,
+)
+from pytest_operator.plugin import OpsTest
+from trino_client.show_catalogs import show_catalogs
 
 logger = logging.getLogger(__name__)
 
+RANGER_AUTH = ("admin", "rangerR0cks!")
 CONN_NAME = "connection-test"
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
 WORKER_NAME = f"{APP_NAME}-worker"
+POSTGRES_NAME = "postgresql-k8s"
 NGINX_NAME = "nginx-ingress-integrator"
 CONN_CONFIG = """connector.name=postgresql
 connection-url=jdbc:postgresql://example.host.com:5432/test
 connection-user=trino
 connection-password=trino
 """
-
+RANGER_NAME = "ranger-k8s"
+GROUP_MANAGEMENT = """\
+    trino-service:
+        users:
+          - name: user1
+            firstname: One
+            lastname: User
+            email: user1@canonical.com
+        memberships:
+          - groupname: commercial-systems
+            users: [user1]
+        groups:
+          - name: commercial-systems
+            description: commercial systems team
+"""
+TRINO_USER = "trino"
+TRINO_SERVICE = "trino-service"
+USER_WITH_ACCESS = "user1"
+USER_WITHOUT_ACCESS = "user2"
+GROUP_WITH_ACCESS = "commercial-systems"
+POLICY_NAME = "tpch - catalog, schema, table, column"
 
 async def get_unit_url(
     ops_test: OpsTest, application, unit, port, protocol="http"
@@ -48,11 +79,12 @@ async def get_unit_url(
     return f"{protocol}://{address}:{port}"
 
 
-async def get_catalogs(ops_test: OpsTest):
+async def get_catalogs(ops_test: OpsTest, user):
     """Return a list of catalogs from Trino charm.
 
     Args:
         ops_test: PyTest object
+        user: the user to access Trino with
 
     Returns:
         catalogs: list of catalogs connected to trino
@@ -62,17 +94,18 @@ async def get_catalogs(ops_test: OpsTest):
         "address"
     ]
     logger.info("executing query on app address: %s", address)
-    catalogs = await show_catalogs(address)
+    catalogs = await show_catalogs(address, user)
     return catalogs
 
 
-async def run_connector_action(ops_test, action, params):
+async def run_connector_action(ops_test, action, params, user):
     """Run connection action.
 
     Args:
-        ops_test: PyTest
+        ops_test: PyTest object
         action: either add-connection or remove-connection action
         params: action parameters
+        user: the user to access Trino with
 
     Returns:
         catalogs: list of trino catalogs after action
@@ -84,6 +117,31 @@ async def run_connector_action(ops_test, action, params):
     )
     await action.wait()
     time.sleep(30)
-    catalogs = await get_catalogs(ops_test)
+    catalogs = await get_catalogs(ops_test, user)
     logging.info(f"action {action} run, catalogs: {catalogs}")
     return catalogs
+
+
+async def create_group_policy(ops_test, ranger_url):
+    """Create a Ranger group policy.
+    Allow members of `commercial-systems` to access `tpch` catalog.
+    Args:
+        ops_test: PyTest object
+        ranger_url: the polciy manager url
+    """
+    ranger = RangerClient(ranger_url, RANGER_AUTH)
+    policy = RangerPolicy()
+    policy.service = TRINO_SERVICE
+    policy.name = POLICY_NAME
+    policy.resources = {
+        "schema": RangerPolicyResource({"values": ["*"]}),
+        "catalog": RangerPolicyResource({"values": ["tpch"]}),
+        "table": RangerPolicyResource({"values": ["*"]}),
+        "column": RangerPolicyResource({"values": ["*"]}),
+    }
+
+    allow_items = RangerPolicyItem()
+    allow_items.groups = [GROUP_WITH_ACCESS]
+    allow_items.accesses = [RangerPolicyItemAccess({"type": "select"})]
+    policy.policyItems = [allow_items]
+    ranger.create_policy(policy)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -79,18 +79,19 @@ async def get_unit_url(
     return f"{protocol}://{address}:{port}"
 
 
-async def get_catalogs(ops_test: OpsTest, user):
+async def get_catalogs(ops_test: OpsTest, user, app_name):
     """Return a list of catalogs from Trino charm.
 
     Args:
         ops_test: PyTest object
         user: the user to access Trino with
+        app_name: name of the application
 
     Returns:
         catalogs: list of catalogs connected to trino
     """
     status = await ops_test.model.get_status()  # noqa: F821
-    address = status["applications"][APP_NAME]["units"][f"{APP_NAME}/{0}"][
+    address = status["applications"][app_name]["units"][f"{app_name}/{0}"][
         "address"
     ]
     logger.info("executing query on app address: %s", address)
@@ -117,7 +118,7 @@ async def run_connector_action(ops_test, action, params, user):
     )
     await action.wait()
     time.sleep(30)
-    catalogs = await get_catalogs(ops_test, user)
+    catalogs = await get_catalogs(ops_test, user, APP_NAME)
     logging.info(f"action {action} run, catalogs: {catalogs}")
     return catalogs
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -54,6 +54,7 @@ USER_WITH_ACCESS = "user1"
 USER_WITHOUT_ACCESS = "user2"
 GROUP_WITH_ACCESS = "commercial-systems"
 POLICY_NAME = "tpch - catalog, schema, table, column"
+TRINO_POLICY = "trino-k8s-policy"
 
 
 async def get_unit_url(

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -54,7 +54,7 @@ USER_WITH_ACCESS = "user1"
 USER_WITHOUT_ACCESS = "user2"
 GROUP_WITH_ACCESS = "commercial-systems"
 POLICY_NAME = "tpch - catalog, schema, table, column"
-TRINO_POLICY = "trino-k8s-policy"
+TRINO_POLICY_NAME = "trino-k8s-policy"
 
 
 async def get_unit_url(

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -13,6 +13,7 @@ from helpers import (
     APP_NAME,
     CONN_CONFIG,
     CONN_NAME,
+    TRINO_USER,
     get_catalogs,
     get_unit_url,
     run_connector_action,
@@ -39,7 +40,7 @@ class TestDeployment:
 
     async def test_basic_client(self, ops_test: OpsTest):
         """Connects a client and executes a basic SQL query."""
-        catalogs = await get_catalogs(ops_test)
+        catalogs = await get_catalogs(ops_test, TRINO_USER)
         logging.info(f"trino catalogs: {catalogs}")
         assert catalogs
 
@@ -50,7 +51,10 @@ class TestDeployment:
             "conn-config": CONN_CONFIG,
         }
         catalogs = await run_connector_action(
-            ops_test, "add-connector", params
+            ops_test,
+            "add-connector",
+            params,
+            TRINO_USER,
         )
         assert [CONN_NAME] in catalogs
 
@@ -60,6 +64,9 @@ class TestDeployment:
             "conn-name": CONN_NAME,
         }
         catalogs = await run_connector_action(
-            ops_test, "remove-connector", params
+            ops_test,
+            "remove-connector",
+            params,
+            TRINO_USER,
         )
         assert [CONN_NAME] not in catalogs

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -40,7 +40,7 @@ class TestDeployment:
 
     async def test_basic_client(self, ops_test: OpsTest):
         """Connects a client and executes a basic SQL query."""
-        catalogs = await get_catalogs(ops_test, TRINO_USER)
+        catalogs = await get_catalogs(ops_test, TRINO_USER, APP_NAME)
         logging.info(f"trino catalogs: {catalogs}")
         assert catalogs
 

--- a/tests/integration/test_policy.py
+++ b/tests/integration/test_policy.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Trino policy integration tests."""
+
+import logging
+import time
+
+import pytest
+import pytest_asyncio
+from conftest import deploy  # noqa: F401, pylint: disable=W0611
+from helpers import (
+    APP_NAME,
+    GROUP_MANAGEMENT,
+    METADATA,
+    POSTGRES_NAME,
+    RANGER_NAME,
+    USER_WITH_ACCESS,
+    USER_WITHOUT_ACCESS,
+    create_group_policy,
+    get_catalogs,
+    get_unit_url,
+)
+from pytest_operator.plugin import OpsTest
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.skip_if_deployed
+@pytest_asyncio.fixture(name="deploy", scope="module")
+async def deploy_ranger(ops_test: OpsTest):
+    """Add Ranger relation and apply group configuration."""
+    charm = await ops_test.build_charm(".")
+    resources = {
+        "trino-image": METADATA["resources"]["trino-image"]["upstream-source"]
+    }
+    trino_config = {
+        "charm-function": "all",
+        "ranger-service-name": "trino-service",
+    }
+    await ops_test.model.deploy(
+        charm,
+        resources=resources,
+        application_name=APP_NAME,
+        num_units=1,
+        config=trino_config,
+    )
+
+    await ops_test.model.deploy(POSTGRES_NAME, channel="14", trust=True)
+    await ops_test.model.wait_for_idle(
+        apps=[POSTGRES_NAME, APP_NAME],
+        status="active",
+        raise_on_blocked=False,
+        timeout=1200,
+    )
+
+    ranger_config = {"user-group-configuration": GROUP_MANAGEMENT}
+    await ops_test.model.deploy(
+        RANGER_NAME, channel="edge", config=ranger_config
+    )
+
+    await ops_test.model.wait_for_idle(
+        apps=[RANGER_NAME],
+        status="blocked",
+        raise_on_blocked=False,
+        timeout=1200,
+    )
+    await ops_test.model.integrate(RANGER_NAME, POSTGRES_NAME)
+
+    await ops_test.model.set_config({"update-status-hook-interval": "1m"})
+    await ops_test.model.wait_for_idle(
+        apps=[POSTGRES_NAME, RANGER_NAME],
+        status="active",
+        raise_on_blocked=False,
+        timeout=1200,
+    )
+    logging.info("integrating trino and ranger")
+    await ops_test.model.integrate(RANGER_NAME, APP_NAME)
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME, RANGER_NAME],
+        status="active",
+        raise_on_blocked=False,
+        timeout=1200,
+    )
+
+
+@pytest.mark.abort_on_fail
+@pytest.mark.usefixtures("deploy")
+class TestPolicy:
+    """Integration test for policy relation."""
+
+    async def test_group_policy(self, ops_test: OpsTest):
+        """Connects a client and executes a basic SQL query."""
+        url = await get_unit_url(
+            ops_test, application=RANGER_NAME, unit=0, port=6080
+        )
+        logging.info(f"creating test policies for {url}")
+        await create_group_policy(ops_test, url)
+
+        # wait 3 minutes for the policy to be synced.
+        time.sleep(180)
+
+        catalogs = await get_catalogs(ops_test, USER_WITH_ACCESS)
+        assert catalogs == [["tpch"]]
+        catalogs = await get_catalogs(ops_test, USER_WITHOUT_ACCESS)
+        assert catalogs == []

--- a/tests/integration/test_policy.py
+++ b/tests/integration/test_policy.py
@@ -57,7 +57,7 @@ async def deploy_ranger(ops_test: OpsTest):
 
     ranger_config = {"user-group-configuration": GROUP_MANAGEMENT}
     await ops_test.model.deploy(
-        RANGER_NAME, channel="edge", config=ranger_config
+        RANGER_NAME, channel="beta", config=ranger_config
     )
 
     await ops_test.model.wait_for_idle(

--- a/tests/integration/test_policy.py
+++ b/tests/integration/test_policy.py
@@ -101,7 +101,9 @@ class TestPolicy:
         # wait 3 minutes for the policy to be synced.
         time.sleep(180)
 
-        catalogs = await get_catalogs(ops_test, USER_WITH_ACCESS)
+        catalogs = await get_catalogs(ops_test, USER_WITH_ACCESS, TRINO_POLICY)
         assert catalogs == [["tpch"]]
-        catalogs = await get_catalogs(ops_test, USER_WITHOUT_ACCESS)
+        catalogs = await get_catalogs(
+            ops_test, USER_WITHOUT_ACCESS, TRINO_POLICY
+        )
         assert catalogs == []

--- a/tests/integration/test_policy.py
+++ b/tests/integration/test_policy.py
@@ -11,11 +11,11 @@ import pytest
 import pytest_asyncio
 from conftest import deploy  # noqa: F401, pylint: disable=W0611
 from helpers import (
-    APP_NAME,
     GROUP_MANAGEMENT,
     METADATA,
     POSTGRES_NAME,
     RANGER_NAME,
+    TRINO_POLICY,
     USER_WITH_ACCESS,
     USER_WITHOUT_ACCESS,
     create_group_policy,
@@ -42,14 +42,14 @@ async def deploy_ranger(ops_test: OpsTest):
     await ops_test.model.deploy(
         charm,
         resources=resources,
-        application_name=APP_NAME,
+        application_name=TRINO_POLICY,
         num_units=1,
         config=trino_config,
     )
 
     await ops_test.model.deploy(POSTGRES_NAME, channel="14", trust=True)
     await ops_test.model.wait_for_idle(
-        apps=[POSTGRES_NAME, APP_NAME],
+        apps=[POSTGRES_NAME, TRINO_POLICY],
         status="active",
         raise_on_blocked=False,
         timeout=1200,
@@ -76,9 +76,9 @@ async def deploy_ranger(ops_test: OpsTest):
         timeout=1200,
     )
     logging.info("integrating trino and ranger")
-    await ops_test.model.integrate(RANGER_NAME, APP_NAME)
+    await ops_test.model.integrate(RANGER_NAME, TRINO_POLICY)
     await ops_test.model.wait_for_idle(
-        apps=[APP_NAME, RANGER_NAME],
+        apps=[TRINO_POLICY, RANGER_NAME],
         status="active",
         raise_on_blocked=False,
         timeout=1200,

--- a/tests/integration/test_policy.py
+++ b/tests/integration/test_policy.py
@@ -68,7 +68,6 @@ async def deploy_ranger(ops_test: OpsTest):
     )
     await ops_test.model.integrate(RANGER_NAME, POSTGRES_NAME)
 
-    await ops_test.model.set_config({"update-status-hook-interval": "1m"})
     await ops_test.model.wait_for_idle(
         apps=[POSTGRES_NAME, RANGER_NAME],
         status="active",

--- a/tests/integration/trino_client/show_catalogs.py
+++ b/tests/integration/trino_client/show_catalogs.py
@@ -7,7 +7,7 @@
 from trino.dbapi import connect
 
 
-async def show_catalogs(host) -> str:
+async def show_catalogs(host, user) -> str:
     """Trino catalogs.
 
     Args:
@@ -19,7 +19,7 @@ async def show_catalogs(host) -> str:
     conn = connect(
         host=host,
         port=8080,
-        user="trino",
+        user=user,
         http_scheme="http",
         verify=False,
     )

--- a/tests/integration/trino_client/show_catalogs.py
+++ b/tests/integration/trino_client/show_catalogs.py
@@ -12,6 +12,7 @@ async def show_catalogs(host, user) -> str:
 
     Args:
         host: trino server address.
+        user: the user to access Trino with
 
     Returns:
         result: list of Trino catalogs

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,7 @@ deps =
     pytest==7.1.3
     pytest-operator==0.22.0
     trino==0.326.0
+    apache-ranger==0.0.11
     -r{toxinidir}/requirements.txt
 commands =
    pytest {[vars]tst_path}integration -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}


### PR DESCRIPTION
Add integration tests for the policy relation. The test:
- Deploys Ranger and PostgreSQL charms
- Relates Trino and Ranger
- Creates policies in Ranger
- Verifies these policies are applied to users accessing Trino