### PR TITLE
Use trino rock and refactor file management

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -2,6 +2,7 @@ header:
   license:
     spdx-id: Apache-2.0
     copyright-owner: Canonical Ltd.
+    copyright-year: 2023
     content: |
       Copyright [year] [owner]
       See LICENSE file for licensing details.

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -16,6 +16,7 @@ header:
     - '**/*.j2'
     - '**/*.json'
     - '**/*.md'
+    - '**/*.properties'
     - '**/*.rule'
     - '**/*.tmpl'
     - '**/*.txt'

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -28,7 +28,7 @@ resources:
   trino-image:
     type: oci-image
     description: OCI image for trino
-    upstream-source: ghcr.io/canonical/charmed-trino-rock:418-22.04-edge
+    upstream-source: ghcr.io/canonical/charmed-trino-rock:4
 
 requires:
   nginx-route:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -28,7 +28,7 @@ resources:
   trino-image:
     type: oci-image
     description: OCI image for trino
-    upstream-source: ghcr.io/canonical/trino:418
+    upstream-source: ghcr.io/canonical/charmed-trino-rock:418-22.04-edge
 
 requires:
   nginx-route:

--- a/src/connector.py
+++ b/src/connector.py
@@ -10,7 +10,7 @@ from ops.charm import ActionEvent
 from ops.framework import Object
 from ops.pebble import ExecError
 
-from literals import CATALOG_PATH, CONF_PATH, CONNECTOR_FIELDS
+from literals import CATALOG_DIR, CONF_DIR, CONNECTOR_FIELDS, TRINO_HOME
 from log import log_event_handler
 from utils import string_to_dict, validate_jdbc_pattern, validate_membership
 
@@ -52,7 +52,9 @@ class TrinoConnector(Object):
         conn_cert = event.params.get("conn-cert")
         conn_input = string_to_dict(conn_string)
 
-        if container.exists(f"{CATALOG_PATH}/{conn_name}.properties"):
+        if container.exists(
+            f"{TRINO_HOME}/{CATALOG_DIR}/{conn_name}.properties"
+        ):
             event.fail(f"Failed to add {conn_name}, connector already exists")
             return
 
@@ -69,7 +71,9 @@ class TrinoConnector(Object):
 
         if conn_cert:
             container.push(
-                f"{CONF_PATH}/{conn_name}.crt", conn_cert, make_dirs=True
+                f"{TRINO_HOME}/{CONF_DIR}/{conn_name}.crt",
+                conn_cert,
+                make_dirs=True,
             )
             try:
                 self._add_cert_to_truststore(container, conn_name)
@@ -79,7 +83,7 @@ class TrinoConnector(Object):
                 )
                 return
 
-        path = f"{CATALOG_PATH}/{conn_name}.properties"
+        path = f"{TRINO_HOME}/{CATALOG_DIR}/{conn_name}.properties"
         container.push(path, conn_string, make_dirs=True)
         self._add_connector_to_state(conn_string, conn_name)
         self.charm._restart_trino(container)
@@ -110,7 +114,9 @@ class TrinoConnector(Object):
             "-noprompt",
         ]
         try:
-            container.exec(command, working_dir=CONF_PATH).wait()
+            container.exec(
+                command, working_dir=f"{TRINO_HOME}/{CONF_DIR}"
+            ).wait()
         except ExecError as e:
             expected_error_string = f"alias <{conn_name}> already exists"
             if expected_error_string in str(e.stdout):
@@ -119,7 +125,7 @@ class TrinoConnector(Object):
             logger.error(e.stdout)
             raise
 
-        container.remove_path(f"{CONF_PATH}/{conn_name}.crt")
+        container.remove_path(f"{TRINO_HOME}/{CONF_DIR}/{conn_name}.crt")
 
     def _is_valid_connection(self, conn_input, conn_type):
         """Validate configuration for connector.
@@ -183,7 +189,9 @@ class TrinoConnector(Object):
             "-noprompt",
         ]
         try:
-            container.exec(command, working_dir=CONF_PATH).wait()
+            container.exec(
+                command, working_dir=f"{TRINO_HOME}/{CONF_DIR}"
+            ).wait()
         except ExecError as e:
             expected_error_string = f"Alias <{conn_name}> does not exist"
             if expected_error_string in str(e.stdout):
@@ -206,7 +214,7 @@ class TrinoConnector(Object):
 
         conn_name = event.params["conn-name"]
 
-        path = f"{CATALOG_PATH}/{conn_name}.properties"
+        path = f"{TRINO_HOME}/{CATALOG_DIR}/{conn_name}.properties"
         if not container.exists(path):
             event.fail(
                 f"Failed to remove {conn_name}, connector does not exist"
@@ -219,7 +227,7 @@ class TrinoConnector(Object):
             )
             return
 
-        if container.exists(f"{CONF_PATH}.truststore.jks"):
+        if container.exists(f"{TRINO_HOME}/{CONF_DIR}.truststore.jks"):
             try:
                 self._delete_cert_from_truststore(container, conn_name)
             except ExecError:

--- a/src/literals.py
+++ b/src/literals.py
@@ -11,7 +11,7 @@ TRINO_PORTS = {
 }
 
 # Configuration literals
-TRINO_HOME = "/trino/etc"
+TRINO_HOME = "/usr/lib/trino/etc"
 CONFIG_FILES = {
     "config.jinja": "config.properties",
     "logging.jinja": "log.properties",
@@ -27,13 +27,13 @@ PASSWORD_DB = "password.db"  # nosec
 
 # Ranger plugin literals
 RANGER_PLUGIN_VERSION = "2.4.0"
-RANGER_PLUGIN_HOME = "/trino/etc/ranger"
+RANGER_PLUGIN_HOME = "/usr/lib/ranger"
 RANGER_PLUGIN_FILES = {
     "access-control.properties": "access-control.properties",
     "ranger-plugin.jinja": "install.properties",
 }
 
-JAVA_ENV = {"JAVA_HOME": "/opt/java/openjdk"}
+JAVA_ENV = {"JAVA_HOME": "/usr/lib/jvm/java-21-openjdk-amd64"}
 
 
 # UNIX literals

--- a/src/literals.py
+++ b/src/literals.py
@@ -11,36 +11,30 @@ TRINO_PORTS = {
 }
 
 # Configuration literals
-CONF_PATH = "/etc/trino/conf"
-CATALOG_PATH = "/etc/trino/catalog"
-CONFIG_JINJA = "config.jinja"
-CONFIG_PATH = "/etc/trino/config.properties"
-LOG_PATH = "/etc/trino/log.properties"
-LOG_JINJA = "logging.jinja"
-RUN_TRINO_COMMAND = "/usr/lib/trino/bin/run-trino"
+TRINO_HOME = "/trino/etc"
+CONFIG_FILES = {
+    "config.jinja": "config.properties",
+    "logging.jinja": "log.properties",
+    "password-authenticator.jinja": "password-authenticator.properties",
+}
+
+CONF_DIR = "conf"
+CATALOG_DIR = "catalog"
+RUN_TRINO_COMMAND = "./entrypoint.sh"
 
 # Authentication literals
-PASSWORD_DB_PATH = "/etc/trino/password.db"  # nosec
-AUTHENTICATOR_PATH = "/etc/trino/password-authenticator.properties"
-AUTHENTICATOR_PROPERTIES = """password-authenticator.name=file
-file.password-file=/etc/trino/password.db
-file.refresh-period=1m
-file.auth-token-cache.max-size=1000"""
+PASSWORD_DB = "password.db"  # nosec
 
 # Ranger plugin literals
-RANGER_PLUGIN_FILE = "plugin-install.jinja"
-RANGER_PLUGIN_VERSION = {
-    "tar": "2.4.0",
-    "path": "3.0.0-SNAPSHOT",
+RANGER_PLUGIN_VERSION = "2.4.0"
+RANGER_PLUGIN_HOME = "/trino/etc/ranger"
+RANGER_PLUGIN_FILES = {
+    "access-control.properties": "access-control.properties",
+    "ranger-plugin.jinja": "install.properties",
 }
 
 JAVA_ENV = {"JAVA_HOME": "/opt/java/openjdk"}
-RANGER_POLICY_PATH = "/etc/ranger"
-RANGER_ACCESS_CONTROL = """\
-access-control.name=ranger
-ranger.use_ugi=true
-"""
-RANGER_ACCESS_CONTROL_PATH = "/etc/trino/access-control.properties"
+
 
 # UNIX literals
 UNIX_TYPE_MAPPING = {

--- a/src/utils.py
+++ b/src/utils.py
@@ -12,7 +12,6 @@ import string
 
 import bcrypt
 from jinja2 import Environment, FileSystemLoader
-from ops.model import Container
 from ops.pebble import ExecError
 
 logger = logging.getLogger(__name__)
@@ -36,8 +35,11 @@ def render(template_name, env=None):
     """Pushes configuration files to application.
 
     Args:
-        template_name: template_file
+        template_name: template_file.
         env: (Optional) The subset of config values for the file.
+
+    Returns:
+        content: template content.
     """
     # get the absolute path of templates directory.
     charm_dir = os.path.abspath(

--- a/templates/access-control.properties
+++ b/templates/access-control.properties
@@ -1,0 +1,2 @@
+access-control.name=ranger
+ranger.use_ugi=true

--- a/templates/access-control.properties
+++ b/templates/access-control.properties
@@ -1,5 +1,2 @@
-# Copyright 2023 Canonical Ltd.
-# See LICENSE file for licensing details.
-
 access-control.name=ranger
 ranger.use_ugi=true

--- a/templates/access-control.properties
+++ b/templates/access-control.properties
@@ -1,2 +1,5 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 access-control.name=ranger
 ranger.use_ugi=true

--- a/templates/password-authenticator.jinja
+++ b/templates/password-authenticator.jinja
@@ -1,0 +1,4 @@
+password-authenticator.name=file
+file.password-file= {{ PASSWORD_DB_PATH }}
+file.refresh-period=1m
+file.auth-token-cache.max-size=1000

--- a/templates/ranger-plugin.jinja
+++ b/templates/ranger-plugin.jinja
@@ -20,7 +20,7 @@ INSTALL_ENV=docker
 # This location should be relative to the parent of the directory containing
 # the plugin installation files.
 #
-COMPONENT_INSTALL_DIR_NAME=/etc/trino
+COMPONENT_INSTALL_DIR_NAME=trino/etc/
 
 # Enable audit logs to Solr
 #Example

--- a/templates/ranger-plugin.jinja
+++ b/templates/ranger-plugin.jinja
@@ -20,7 +20,7 @@ INSTALL_ENV=docker
 # This location should be relative to the parent of the directory containing
 # the plugin installation files.
 #
-COMPONENT_INSTALL_DIR_NAME=trino/etc/
+COMPONENT_INSTALL_DIR_NAME={{ TRINO_HOME | default("/usr/lib/trino/etc")}}
 
 # Enable audit logs to Solr
 #Example

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -23,10 +23,12 @@ async def deploy(ops_test: OpsTest):
     }
 
     # Deploy trino and nginx charms
+    trino_config = {"ranger-service-name": "trino-service"}
     await ops_test.model.deploy(
         charm,
         resources=resources,
         application_name=APP_NAME,
+        config=trino_config,
         num_units=1,
     )
     worker_config = {"charm-function": "worker"}
@@ -42,8 +44,14 @@ async def deploy(ops_test: OpsTest):
 
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(
-            apps=[NGINX_NAME, APP_NAME, WORKER_NAME],
+            apps=[APP_NAME, WORKER_NAME],
             status="active",
+            raise_on_blocked=False,
+            timeout=600,
+        )
+        await ops_test.model.wait_for_idle(
+            apps=[NGINX_NAME],
+            status="waiting",
             raise_on_blocked=False,
             timeout=600,
         )

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -34,27 +34,13 @@ connection-user=trino
 connection-password=trino
 """
 RANGER_NAME = "ranger-k8s"
-GROUP_MANAGEMENT = """\
-    trino-service:
-        users:
-          - name: user1
-            firstname: One
-            lastname: User
-            email: user1@canonical.com
-        memberships:
-          - groupname: commercial-systems
-            users: [user1]
-        groups:
-          - name: commercial-systems
-            description: commercial systems team
-"""
 TRINO_USER = "trino"
 TRINO_SERVICE = "trino-service"
-USER_WITH_ACCESS = "user1"
-USER_WITHOUT_ACCESS = "user2"
-GROUP_WITH_ACCESS = "commercial-systems"
-POLICY_NAME = "tpch - catalog, schema, table, column"
-TRINO_POLICY_NAME = "trino-k8s-policy"
+USER_WITH_ACCESS = "dev"
+USER_WITHOUT_ACCESS = "user"
+POLICY_NAME = "system - catalog, schema, table, column"
+LDAP_NAME = "comsys-openldap-k8s"
+USERSYNC_NAME = "ranger-usersync-k8s"
 
 
 async def get_unit_url(
@@ -123,10 +109,10 @@ async def run_connector_action(ops_test, action, params, user):
     return catalogs
 
 
-async def create_group_policy(ops_test, ranger_url):
-    """Create a Ranger group policy.
+async def create_policy(ops_test, ranger_url):
+    """Create a Ranger user policy.
 
-    Allow members of `commercial-systems` to access `tpch` catalog.
+    Allow user `user1` to access `system` catalog.
 
     Args:
         ops_test: PyTest object
@@ -138,13 +124,13 @@ async def create_group_policy(ops_test, ranger_url):
     policy.name = POLICY_NAME
     policy.resources = {
         "schema": RangerPolicyResource({"values": ["*"]}),
-        "catalog": RangerPolicyResource({"values": ["tpch"]}),
+        "catalog": RangerPolicyResource({"values": ["system"]}),
         "table": RangerPolicyResource({"values": ["*"]}),
         "column": RangerPolicyResource({"values": ["*"]}),
     }
 
     allow_items = RangerPolicyItem()
-    allow_items.groups = [GROUP_WITH_ACCESS]
+    allow_items.users = [USER_WITH_ACCESS]
     allow_items.accesses = [RangerPolicyItemAccess({"type": "select"})]
     policy.policyItems = [allow_items]
     ranger.create_policy(policy)

--- a/tests/integration/test_policy.py
+++ b/tests/integration/test_policy.py
@@ -8,16 +8,15 @@ import logging
 import time
 
 import pytest
-import pytest_asyncio
 from helpers import (
-    GROUP_MANAGEMENT,
-    METADATA,
+    APP_NAME,
+    LDAP_NAME,
     POSTGRES_NAME,
     RANGER_NAME,
-    TRINO_POLICY_NAME,
     USER_WITH_ACCESS,
     USER_WITHOUT_ACCESS,
-    create_group_policy,
+    USERSYNC_NAME,
+    create_policy,
     get_catalogs,
     get_unit_url,
 )
@@ -26,84 +25,83 @@ from pytest_operator.plugin import OpsTest
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.skip_if_deployed
-@pytest_asyncio.fixture(name="deploy", scope="module")
-async def deploy_ranger(ops_test: OpsTest):
-    """Add Ranger relation and apply group configuration."""
-    charm = await ops_test.build_charm(".")
-    resources = {
-        "trino-image": METADATA["resources"]["trino-image"]["upstream-source"]
-    }
-    trino_config = {
-        "charm-function": "all",
-        "ranger-service-name": "trino-service",
-    }
-    await ops_test.model.deploy(
-        charm,
-        resources=resources,
-        application_name=TRINO_POLICY_NAME,
-        num_units=1,
-        config=trino_config,
-    )
-
-    await ops_test.model.deploy(POSTGRES_NAME, channel="14", trust=True)
-    await ops_test.model.wait_for_idle(
-        apps=[POSTGRES_NAME, TRINO_POLICY_NAME],
-        status="active",
-        raise_on_blocked=False,
-        timeout=1200,
-    )
-
-    ranger_config = {"user-group-configuration": GROUP_MANAGEMENT}
-    await ops_test.model.deploy(
-        RANGER_NAME, channel="beta", config=ranger_config
-    )
-
-    await ops_test.model.wait_for_idle(
-        apps=[RANGER_NAME],
-        status="blocked",
-        raise_on_blocked=False,
-        timeout=1200,
-    )
-    await ops_test.model.integrate(RANGER_NAME, POSTGRES_NAME)
-
-    await ops_test.model.wait_for_idle(
-        apps=[POSTGRES_NAME, RANGER_NAME],
-        status="active",
-        raise_on_blocked=False,
-        timeout=1200,
-    )
-    logging.info("integrating trino and ranger")
-    await ops_test.model.integrate(RANGER_NAME, TRINO_POLICY_NAME)
-    await ops_test.model.wait_for_idle(
-        apps=[TRINO_POLICY_NAME, RANGER_NAME],
-        status="active",
-        raise_on_blocked=False,
-        timeout=1200,
-    )
-
-
 @pytest.mark.abort_on_fail
 @pytest.mark.usefixtures("deploy")
-class TestPolicy:
-    """Integration test for policy relation."""
+class TestPolicyManager:
+    """Integration test for Ranger policy enforcement."""
 
-    async def test_group_policy(self, ops_test: OpsTest):
-        """Connects a client and executes a basic SQL query."""
+    async def test_policy_enforcement(self, ops_test: OpsTest):
+        """Add Ranger relation and apply group configuration."""
+        # Deploy and prepare Ranger admin.
+        await ops_test.model.deploy(POSTGRES_NAME, channel="14", trust=True)
+        await ops_test.model.deploy(RANGER_NAME, channel="edge")
+
+        await ops_test.model.wait_for_idle(
+            apps=[POSTGRES_NAME],
+            status="active",
+            raise_on_blocked=False,
+            timeout=1200,
+        )
+        await ops_test.model.integrate(RANGER_NAME, POSTGRES_NAME)
+
+        await ops_test.model.wait_for_idle(
+            apps=[POSTGRES_NAME, RANGER_NAME],
+            status="active",
+            raise_on_blocked=False,
+            timeout=1200,
+        )
+
+        # Deploy and prepare Ranger usersync.
+        await ops_test.model.deploy(LDAP_NAME, channel="edge")
+        await ops_test.model.wait_for_idle(
+            apps=[LDAP_NAME],
+            status="active",
+            raise_on_blocked=False,
+            timeout=1500,
+        )
+        action = (
+            await ops_test.model.applications[LDAP_NAME]
+            .units[0]
+            .run_action("load-test-users")
+        )
+        await action.wait()
+
+        usersync_config = {"charm-function": "usersync"}
+        await ops_test.model.deploy(
+            RANGER_NAME,
+            channel="edge",
+            config=usersync_config,
+            application_name=USERSYNC_NAME,
+        )
+        await ops_test.model.integrate(USERSYNC_NAME, LDAP_NAME)
+        time.sleep(100)  # Provide time for user synchronization to occur.
+        await ops_test.model.wait_for_idle(
+            apps=[USERSYNC_NAME, LDAP_NAME],
+            status="active",
+            raise_on_blocked=False,
+            timeout=1500,
+        )
+
+        # Integrate Trino and Ranger.
+        logging.info("integrating trino and ranger")
+        await ops_test.model.integrate(RANGER_NAME, APP_NAME)
+        await ops_test.model.wait_for_idle(
+            apps=[APP_NAME, RANGER_NAME],
+            status="active",
+            raise_on_blocked=False,
+            timeout=1200,
+        )
+        # Test policy implementation.
         url = await get_unit_url(
             ops_test, application=RANGER_NAME, unit=0, port=6080
         )
         logging.info(f"creating test policies for {url}")
-        await create_group_policy(ops_test, url)
+        await create_policy(ops_test, url)
 
         # wait 3 minutes for the policy to be synced.
         time.sleep(180)
 
-        catalogs = await get_catalogs(
-            ops_test, USER_WITH_ACCESS, TRINO_POLICY_NAME
-        )
-        assert catalogs == [["tpch"]]
-        catalogs = await get_catalogs(
-            ops_test, USER_WITHOUT_ACCESS, TRINO_POLICY_NAME
-        )
+        catalogs = await get_catalogs(ops_test, USER_WITH_ACCESS, APP_NAME)
+        assert catalogs == [["system"]]
+        catalogs = await get_catalogs(ops_test, USER_WITHOUT_ACCESS, APP_NAME)
         assert catalogs == []

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -25,10 +25,8 @@ connection-url=jdbc:postgresql://host.com:5432/database
 connection-user=testing
 connection-password=test
 """
-DB_PATH = "/etc/trino/catalog/example-db.properties"
-RANGER_PROPERTIES_PATH = (
-    "/root/ranger-3.0.0-SNAPSHOT-trino-plugin/install.properties"
-)
+DB_PATH = "/trino/etc/catalog/example-db.properties"
+RANGER_PROPERTIES_PATH = "/trino/etc/ranger/install.properties"
 POLICY_MGR_URL = "http://ranger-k8s:6080"
 GROUP_MANAGEMENT = """\
         users:
@@ -104,15 +102,16 @@ class TestCharm(TestCase):
                 "trino": {
                     "override": "replace",
                     "summary": "trino server",
-                    "command": "/usr/lib/trino/bin/run-trino",
+                    "command": "./entrypoint.sh",
                     "startup": "enabled",
                     "environment": {
                         "DEFAULT_PASSWORD": "ubuntu123",
+                        "PASSWORD_DB_PATH": "/trino/etc/password.db",
                         "LOG_LEVEL": "info",
                         "OAUTH_CLIENT_ID": None,
                         "OAUTH_CLIENT_SECRET": None,
                         "WEB_PROXY": None,
-                        "SSL_PATH": "/etc/trino/conf/truststore.jks",
+                        "SSL_PATH": "/trino/etc/conf/truststore.jks",
                         "SSL_PWD": "truststore123",
                         "CHARM_FUNCTION": "coordinator",
                         "DISCOVERY_URI": "http://trino-k8s:8080",
@@ -204,15 +203,16 @@ class TestCharm(TestCase):
                 "trino": {
                     "override": "replace",
                     "summary": "trino server",
-                    "command": "/usr/lib/trino/bin/run-trino",
+                    "command": "./entrypoint.sh",
                     "startup": "enabled",
                     "environment": {
                         "DEFAULT_PASSWORD": "ubuntu123",
+                        "PASSWORD_DB_PATH": "/trino/etc/password.db",
                         "LOG_LEVEL": "info",
                         "OAUTH_CLIENT_ID": "test-client-id",
                         "OAUTH_CLIENT_SECRET": "test-client-secret",
                         "WEB_PROXY": "proxy:port",
-                        "SSL_PATH": "/etc/trino/conf/truststore.jks",
+                        "SSL_PATH": "/trino/etc/conf/truststore.jks",
                         "SSL_PWD": "truststore123",
                         "CHARM_FUNCTION": "worker",
                         "DISCOVERY_URI": "http://trino-k8s:8080",

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,7 @@ deps =
     juju==3.1.0.1
     pytest==7.1.3
     pytest-operator==0.22.0
+    pytest-asyncio==0.21
     trino==0.326.0
     apache-ranger==0.0.11
     -r{toxinidir}/requirements.txt
@@ -41,8 +42,9 @@ description = Run integration tests
 deps =
     ipdb==0.13.9
     juju==3.1.0.1
-    pytest==7.4.0
-    pytest-operator==0.29.0
+    pytest==7.1.3
+    pytest-operator==0.22.0
+    pytest-asyncio==0.21
     trino==0.326.0
     apache-ranger==0.0.11
     -r{toxinidir}/requirements.txt
@@ -54,8 +56,9 @@ description = Run integration tests
 deps =
     ipdb==0.13.9
     juju==3.1.0.1
-    pytest==7.4.0
-    pytest-operator==0.29.0
+    pytest==7.1.3
+    pytest-operator==0.22.0
+    pytest-asyncio==0.21
     trino==0.326.0
     apache-ranger==0.0.11
     -r{toxinidir}/requirements.txt


### PR DESCRIPTION
This PR updates the charm to use the trino rock. This required:
- Some updates to ranger and trino home pathways
- Removal of unpacking the tar from the charm as this is now handled by the rock
- Update to the entrypoint
- Update to environment variables to include the required paths for the install.properties
- Update to tests given the above.

Due to changes in Ranger the following was updates:
- Ranger no longer synchronizes via a file and relation to Trino. The way we handle this moving forward has not been determined so I have left in this option, however I have updated the integration test to validate policies which apply to the user not the group until we have a clear pathway forward.

Some general refactors:
- Adding password authenticator as a jinja file as opposed to literal string. 
- Update to literals to use `RANGER_HOME` and `TRINO_HOME` to avoid changes in multiple places when the location is updated
- Consolidated the mechanism for pushing a file into the container as there were multiple functions handling this.
- Added up check and status_update handler.