### PR TITLE
CSS-7960 Trino rock and refactor

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -2,6 +2,7 @@ header:
   license:
     spdx-id: Apache-2.0
     copyright-owner: Canonical Ltd.
+    copyright-year: 2023
     content: |
       Copyright [year] [owner]
       See LICENSE file for licensing details.

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -16,6 +16,7 @@ header:
     - '**/*.j2'
     - '**/*.json'
     - '**/*.md'
+    - '**/*.properties'
     - '**/*.rule'
     - '**/*.tmpl'
     - '**/*.txt'

--- a/lib/charms/nginx_ingress_integrator/v0/nginx_route.py
+++ b/lib/charms/nginx_ingress_integrator/v0/nginx_route.py
@@ -86,7 +86,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 __all__ = ["require_nginx_route", "provide_nginx_route"]
 
@@ -181,6 +181,7 @@ def require_nginx_route(  # pylint: disable=too-many-locals,too-many-branches,to
     service_port: int,
     additional_hostnames: typing.Optional[str] = None,
     backend_protocol: typing.Optional[str] = None,
+    enable_access_log: typing.Optional[bool] = None,
     limit_rps: typing.Optional[int] = None,
     limit_whitelist: typing.Optional[str] = None,
     max_body_size: typing.Optional[int] = None,
@@ -211,6 +212,8 @@ def require_nginx_route(  # pylint: disable=too-many-locals,too-many-branches,to
             additional-hostnames option via relation, optional.
         backend_protocol: configure Nginx ingress integrator
             backend-protocol option via relation, optional.
+        enable_access_log: configure Nginx ingress
+            nginx.ingress.kubernetes.io/enable-access-log option.
         limit_rps: configure Nginx ingress integrator limit-rps
             option via relation, optional.
         limit_whitelist: configure Nginx ingress integrator
@@ -251,6 +254,8 @@ def require_nginx_route(  # pylint: disable=too-many-locals,too-many-branches,to
         config["additional-hostnames"] = additional_hostnames
     if backend_protocol is not None:
         config["backend-protocol"] = backend_protocol
+    if enable_access_log is not None:
+        config["enable-access-log"] = "true" if enable_access_log else "false"
     if limit_rps is not None:
         config["limit-rps"] = limit_rps
     if limit_whitelist is not None:

--- a/lib/charms/nginx_ingress_integrator/v0/nginx_route.py
+++ b/lib/charms/nginx_ingress_integrator/v0/nginx_route.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # Licensed under the Apache2.0. See LICENSE file in charm source for details.
 """Library for the nginx-route relation.
 
@@ -86,7 +86,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 __all__ = ["require_nginx_route", "provide_nginx_route"]
 
@@ -404,7 +404,8 @@ def provide_nginx_route(
         RuntimeError: If provide_nginx_route was invoked twice with
             the same nginx-route relation name
     """
-    if __provider_references.get(charm, {}).get(nginx_route_relation_name) is not None:
+    ref_dict: typing.Dict[str, typing.Any] = __provider_references.get(charm, {})
+    if ref_dict.get(nginx_route_relation_name) is not None:
         raise RuntimeError(
             "provide_nginx_route was invoked twice with the same nginx-route relation name"
         )

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -28,7 +28,7 @@ resources:
   trino-image:
     type: oci-image
     description: OCI image for trino
-    upstream-source: ghcr.io/canonical/charmed-trino-rock:418-22.04-edge
+    upstream-source: ghcr.io/canonical/charmed-trino-rock:4
 
 requires:
   nginx-route:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -28,7 +28,7 @@ resources:
   trino-image:
     type: oci-image
     description: OCI image for trino
-    upstream-source: ghcr.io/canonical/charmed-trino-rock:4
+    upstream-source: ghcr.io/canonical/charmed-trino-rock:418-22.04-edge
 
 requires:
   nginx-route:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -28,7 +28,7 @@ resources:
   trino-image:
     type: oci-image
     description: OCI image for trino
-    upstream-source: ghcr.io/canonical/trino:418
+    upstream-source: ghcr.io/canonical/charmed-trino-rock:418-22.04-edge
 
 requires:
   nginx-route:

--- a/src/charm.py
+++ b/src/charm.py
@@ -11,6 +11,7 @@ https://discourse.charmhub.io/t/4208
 """
 
 import logging
+from pathlib import Path
 
 from charms.nginx_ingress_integrator.v0.nginx_route import require_nginx_route
 from ops.charm import CharmBase, ConfigChangedEvent, PebbleReadyEvent
@@ -49,12 +50,30 @@ class TrinoK8SCharm(CharmBase):
     Attrs:
         state: used to store data that is persisted across invocations.
         external_hostname: DNS listing used for external connections.
+        trino_abs_path: The absolute path for Trino home directory.
+        catalog_abs_path: The absolute path for the catalog directory.
+        conf_abs_path: the absolute path for the conf directory.
     """
 
     @property
     def external_hostname(self):
         """Return the DNS listing used for external connections."""
         return self.config["external-hostname"] or self.app.name
+
+    @property
+    def trino_abs_path(self):
+        """Return the catalog absolute path."""
+        return Path(TRINO_HOME)
+
+    @property
+    def catalog_abs_path(self):
+        """Return the catalog absolute path."""
+        return self.trino_abs_path.joinpath(CATALOG_DIR)
+
+    @property
+    def conf_abs_path(self):
+        """Return the catalog absolute path."""
+        return self.trino_abs_path.joinpath(CONF_DIR)
 
     def __init__(self, *args):
         """Construct.
@@ -207,17 +226,18 @@ class TrinoK8SCharm(CharmBase):
         Returns:
             properties: A dictionary of existing connector configurations
         """
-        catalog_path = f"{TRINO_HOME}/{CATALOG_DIR}"
-        if not container.exists(catalog_path):
+        if not container.exists(self.catalog_abs_path):
             return {}
 
-        files = container.list_files(catalog_path, pattern="*.properties")
+        files = container.list_files(
+            self.catalog_abs_path, pattern="*.properties"
+        )
         file_names = [f.name for f in files]
         property_names = [file_name.split(".")[0] for file_name in file_names]
 
         properties = {}
         for item in property_names:
-            path = f"{catalog_path}/{item}.properties"
+            path = self.catalog_abs_path.joinpath(f"{item}.properties")
             config = container.pull(path).read()
             properties[item] = config
 
@@ -231,15 +251,16 @@ class TrinoK8SCharm(CharmBase):
             target: intended connectors from _state
             container: Trino container
         """
-        catalog_path = f"{TRINO_HOME}/{CATALOG_DIR}"
         for key, config in target.items():
             if key not in current:
-                path = f"{catalog_path}/{key}.properties"
+                file = f"{key}.properties"
+                path = self.catalog_abs_path.joinpath(file)
                 container.push(path, config, make_dirs=True)
 
         for key in current.keys():
             if key not in target.keys() and key not in SYSTEM_CONNECTORS:
-                path = f"{catalog_path}/{key}.properties"
+                file = f"{key}.properties"
+                path = self.catalog_abs_path.joinpath(file)
                 container.remove_path(path)
 
         self._restart_trino(container)
@@ -278,7 +299,7 @@ class TrinoK8SCharm(CharmBase):
             container: The application container
         """
         password = bcrypt_pwd(self.config["trino-password"])
-        path = f"{TRINO_HOME}/{PASSWORD_DB}"
+        path = self.trino_abs_path.joinpath(PASSWORD_DB)
         db_content = f"trino:{password}"
 
         container.push(path, db_content, make_dirs=True, permissions=0o644)
@@ -317,6 +338,8 @@ class TrinoK8SCharm(CharmBase):
         Returns:
             env: a dictionary of trino environment variables
         """
+        truststore_path = self.conf_abs_path.joinpath("truststore.jks")
+        db_path = self.trino_abs_path.joinpath(PASSWORD_DB)
         env = {
             "LOG_LEVEL": self.config["log-level"],
             "DEFAULT_PASSWORD": self.config["trino-password"],
@@ -324,12 +347,12 @@ class TrinoK8SCharm(CharmBase):
             "OAUTH_CLIENT_SECRET": self.config.get("google-client-secret"),
             "WEB_PROXY": self.config.get("web-proxy"),
             "SSL_PWD": self.state.truststore_password,
-            "SSL_PATH": f"{TRINO_HOME}/{CONF_DIR}/truststore.jks",
+            "SSL_PATH": str(truststore_path),
             "CHARM_FUNCTION": self.config["charm-function"],
             "DISCOVERY_URI": self.config["discovery-uri"],
             "APPLICATION_NAME": self.app.name,
-            "PASSWORD_DB_PATH": f"{TRINO_HOME}/{PASSWORD_DB}",
-            "TRINO_HOME": TRINO_HOME,
+            "PASSWORD_DB_PATH": str(db_path),
+            "TRINO_HOME": str(self.trino_abs_path),
         }
         return env
 
@@ -361,7 +384,7 @@ class TrinoK8SCharm(CharmBase):
 
         env = self._create_environment()
         for template, file in CONFIG_FILES.items():
-            path = f"{TRINO_HOME}/{file}"
+            path = self.trino_abs_path.joinpath(file)
             content = render(template, env)
             container.push(path, content, make_dirs=True, permissions=0o644)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -417,6 +417,8 @@ class TrinoK8SCharm(CharmBase):
             )
 
             self.model.unit.open_port(port=8080, protocol="tcp")
+        else:
+            self.model.unit.close_port(port=8080, protocol="tcp")
 
         container.add_layer(self.name, pebble_layer, combine=True)
         container.replan()

--- a/src/connector.py
+++ b/src/connector.py
@@ -10,7 +10,7 @@ from ops.charm import ActionEvent
 from ops.framework import Object
 from ops.pebble import ExecError
 
-from literals import CATALOG_DIR, CONF_DIR, CONNECTOR_FIELDS, TRINO_HOME
+from literals import CONNECTOR_FIELDS
 from log import log_event_handler
 from utils import string_to_dict, validate_jdbc_pattern, validate_membership
 
@@ -53,7 +53,7 @@ class TrinoConnector(Object):
         conn_input = string_to_dict(conn_string)
 
         if container.exists(
-            f"{TRINO_HOME}/{CATALOG_DIR}/{conn_name}.properties"
+            self.charm.catalog_abs_path.joinpath(f"{conn_name}.properties")
         ):
             event.fail(f"Failed to add {conn_name}, connector already exists")
             return
@@ -71,7 +71,7 @@ class TrinoConnector(Object):
 
         if conn_cert:
             container.push(
-                f"{TRINO_HOME}/{CONF_DIR}/{conn_name}.crt",
+                self.charm.conf_abs_path.joinpath(f"{conn_name}.crt"),
                 conn_cert,
                 make_dirs=True,
             )
@@ -83,7 +83,7 @@ class TrinoConnector(Object):
                 )
                 return
 
-        path = f"{TRINO_HOME}/{CATALOG_DIR}/{conn_name}.properties"
+        path = self.charm.catalog_abs_path.joinpath(f"{conn_name}.properties")
         container.push(path, conn_string, make_dirs=True)
         self._add_connector_to_state(conn_string, conn_name)
         self.charm._restart_trino(container)
@@ -115,7 +115,7 @@ class TrinoConnector(Object):
         ]
         try:
             container.exec(
-                command, working_dir=f"{TRINO_HOME}/{CONF_DIR}"
+                command, working_dir=self.charm.conf_abs_path
             ).wait()
         except ExecError as e:
             expected_error_string = f"alias <{conn_name}> already exists"
@@ -125,7 +125,9 @@ class TrinoConnector(Object):
             logger.error(e.stdout)
             raise
 
-        container.remove_path(f"{TRINO_HOME}/{CONF_DIR}/{conn_name}.crt")
+        container.remove_path(
+            self.charm.conf_abs_path.joinpath(f"{conn_name}.crt")
+        )
 
     def _is_valid_connection(self, conn_input, conn_type):
         """Validate configuration for connector.
@@ -190,7 +192,7 @@ class TrinoConnector(Object):
         ]
         try:
             container.exec(
-                command, working_dir=f"{TRINO_HOME}/{CONF_DIR}"
+                command, working_dir=self.charm.conf_abs_path
             ).wait()
         except ExecError as e:
             expected_error_string = f"Alias <{conn_name}> does not exist"
@@ -214,7 +216,7 @@ class TrinoConnector(Object):
 
         conn_name = event.params["conn-name"]
 
-        path = f"{TRINO_HOME}/{CATALOG_DIR}/{conn_name}.properties"
+        path = self.charm.catalog_abs_path.joinpath(f"{conn_name}.properties")
         if not container.exists(path):
             event.fail(
                 f"Failed to remove {conn_name}, connector does not exist"
@@ -227,7 +229,9 @@ class TrinoConnector(Object):
             )
             return
 
-        if container.exists(f"{TRINO_HOME}/{CONF_DIR}.truststore.jks"):
+        if container.exists(
+            self.charm.conf_abs_path.joinpath("truststore.jks")
+        ):
             try:
                 self._delete_cert_from_truststore(container, conn_name)
             except ExecError:

--- a/src/connector.py
+++ b/src/connector.py
@@ -10,7 +10,7 @@ from ops.charm import ActionEvent
 from ops.framework import Object
 from ops.pebble import ExecError
 
-from literals import CATALOG_PATH, CONF_PATH, CONNECTOR_FIELDS
+from literals import CATALOG_DIR, CONF_DIR, CONNECTOR_FIELDS, TRINO_HOME
 from log import log_event_handler
 from utils import string_to_dict, validate_jdbc_pattern, validate_membership
 
@@ -52,7 +52,9 @@ class TrinoConnector(Object):
         conn_cert = event.params.get("conn-cert")
         conn_input = string_to_dict(conn_string)
 
-        if container.exists(f"{CATALOG_PATH}/{conn_name}.properties"):
+        if container.exists(
+            f"{TRINO_HOME}/{CATALOG_DIR}/{conn_name}.properties"
+        ):
             event.fail(f"Failed to add {conn_name}, connector already exists")
             return
 
@@ -69,7 +71,9 @@ class TrinoConnector(Object):
 
         if conn_cert:
             container.push(
-                f"{CONF_PATH}/{conn_name}.crt", conn_cert, make_dirs=True
+                f"{TRINO_HOME}/{CONF_DIR}/{conn_name}.crt",
+                conn_cert,
+                make_dirs=True,
             )
             try:
                 self._add_cert_to_truststore(container, conn_name)
@@ -79,7 +83,7 @@ class TrinoConnector(Object):
                 )
                 return
 
-        path = f"{CATALOG_PATH}/{conn_name}.properties"
+        path = f"{TRINO_HOME}/{CATALOG_DIR}/{conn_name}.properties"
         container.push(path, conn_string, make_dirs=True)
         self._add_connector_to_state(conn_string, conn_name)
         self.charm._restart_trino(container)
@@ -110,7 +114,9 @@ class TrinoConnector(Object):
             "-noprompt",
         ]
         try:
-            container.exec(command, working_dir=CONF_PATH).wait()
+            container.exec(
+                command, working_dir=f"{TRINO_HOME}/{CONF_DIR}"
+            ).wait()
         except ExecError as e:
             expected_error_string = f"alias <{conn_name}> already exists"
             if expected_error_string in str(e.stdout):
@@ -119,7 +125,7 @@ class TrinoConnector(Object):
             logger.error(e.stdout)
             raise
 
-        container.remove_path(f"{CONF_PATH}/{conn_name}.crt")
+        container.remove_path(f"{TRINO_HOME}/{CONF_DIR}/{conn_name}.crt")
 
     def _is_valid_connection(self, conn_input, conn_type):
         """Validate configuration for connector.
@@ -183,7 +189,9 @@ class TrinoConnector(Object):
             "-noprompt",
         ]
         try:
-            container.exec(command, working_dir=CONF_PATH).wait()
+            container.exec(
+                command, working_dir=f"{TRINO_HOME}/{CONF_DIR}"
+            ).wait()
         except ExecError as e:
             expected_error_string = f"Alias <{conn_name}> does not exist"
             if expected_error_string in str(e.stdout):
@@ -206,7 +214,7 @@ class TrinoConnector(Object):
 
         conn_name = event.params["conn-name"]
 
-        path = f"{CATALOG_PATH}/{conn_name}.properties"
+        path = f"{TRINO_HOME}/{CATALOG_DIR}/{conn_name}.properties"
         if not container.exists(path):
             event.fail(
                 f"Failed to remove {conn_name}, connector does not exist"
@@ -219,7 +227,7 @@ class TrinoConnector(Object):
             )
             return
 
-        if container.exists(f"{CONF_PATH}.truststore.jks"):
+        if container.exists(f"{TRINO_HOME}/{CONF_DIR}.truststore.jks"):
             try:
                 self._delete_cert_from_truststore(container, conn_name)
             except ExecError:

--- a/src/connector.py
+++ b/src/connector.py
@@ -115,7 +115,7 @@ class TrinoConnector(Object):
         ]
         try:
             container.exec(
-                command, working_dir=self.charm.conf_abs_path
+                command, working_dir=str(self.charm.conf_abs_path)
             ).wait()
         except ExecError as e:
             expected_error_string = f"alias <{conn_name}> already exists"
@@ -192,7 +192,7 @@ class TrinoConnector(Object):
         ]
         try:
             container.exec(
-                command, working_dir=self.charm.conf_abs_path
+                command, working_dir=str(self.charm.conf_abs_path)
             ).wait()
         except ExecError as e:
             expected_error_string = f"Alias <{conn_name}> does not exist"

--- a/src/literals.py
+++ b/src/literals.py
@@ -11,7 +11,7 @@ TRINO_PORTS = {
 }
 
 # Configuration literals
-TRINO_HOME = "/trino/etc"
+TRINO_HOME = "/usr/lib/trino/etc"
 CONFIG_FILES = {
     "config.jinja": "config.properties",
     "logging.jinja": "log.properties",
@@ -27,13 +27,13 @@ PASSWORD_DB = "password.db"  # nosec
 
 # Ranger plugin literals
 RANGER_PLUGIN_VERSION = "2.4.0"
-RANGER_PLUGIN_HOME = "/trino/etc/ranger"
+RANGER_PLUGIN_HOME = "/usr/lib/ranger"
 RANGER_PLUGIN_FILES = {
     "access-control.properties": "access-control.properties",
     "ranger-plugin.jinja": "install.properties",
 }
 
-JAVA_ENV = {"JAVA_HOME": "/opt/java/openjdk"}
+JAVA_ENV = {"JAVA_HOME": "/usr/lib/jvm/java-21-openjdk-amd64"}
 
 
 # UNIX literals

--- a/src/literals.py
+++ b/src/literals.py
@@ -45,45 +45,6 @@ UNIX_TYPE_MAPPING = {
 
 # Connector literal
 CONNECTOR_FIELDS = {
-    "accumlo": {
-        "required": [
-            "connector.name",
-            "accumlo.instance",
-            "accumlo.zookeepers",
-            "accumlo.username",
-            "accumlo.password",
-        ],
-        "optional": [],
-    },
-    "bigquery": {
-        "required": ["connector.name", "bigquery.project-id"],
-        "optional": [],
-    },
-    "cassandra": {
-        "required": [
-            "connector.name",
-            "cassandra.contact-points",
-            "cassandra.load-policy.dc-aware.local-dc",
-        ],
-        "optional": [],
-    },
-    "clickhouse": {
-        "required": [
-            "connector.name",
-            "connection-url",
-            "connection-user",
-            "connection-password",
-        ],
-        "optional": [],
-    },
-    "delta_lake": {
-        "required": ["connector.name", "hive.metastore.uri"],
-        "optional": [],
-    },
-    "druid": {
-        "required": ["connector.name", "connection-url"],
-        "optional": [],
-    },
     "elasticsearch": {
         "required": [
             "connector.name",
@@ -91,53 +52,6 @@ CONNECTOR_FIELDS = {
             "elasticsearch.port",
             "elasticsearch.default-schema-name",
         ],
-        "optional": [],
-    },
-    "hive": {
-        "required": ["connector.name", "hive.metastore.uri"],
-        "optional": [],
-    },
-    "hudi": {
-        "required": ["connector.name", "hive.metastore.uri"],
-        "optional": [],
-    },
-    "ignite": {
-        "required": [
-            "connector.name",
-            "connection-url",
-            "connection-user",
-            "connection-password",
-        ],
-        "optional": [],
-    },
-    "jmx": {
-        "required": [
-            "connector.name",
-            "jmx.dump-tables",
-            "jmx.dump-period",
-            "jmx.max-entries",
-        ],
-        "optional": [],
-    },
-    "kinesis": {
-        "required": [
-            "connector.name",
-            "kinesis.access-key",
-            "kinesis.secret-key",
-        ],
-        "optional": [],
-    },
-    "mariadb": {
-        "required": [
-            "connector.name",
-            "connection-url",
-            "connection-user",
-            "connection-password",
-        ],
-        "optional": [],
-    },
-    "mongodb": {
-        "required": ["connector.name", "mongodb.connection-url"],
         "optional": [],
     },
     "mysql": {
@@ -157,19 +71,6 @@ CONNECTOR_FIELDS = {
             "dynamic-filtering.enabled",
             "dynamic-filtering.wait-timeout",
         ],
-    },
-    "oracle": {
-        "required": [
-            "connector.name",
-            "connection-url",
-            "connection-user",
-            "connection-password",
-        ],
-        "optional": [],
-    },
-    "pinot": {
-        "required": ["connector.name", "pinot.controller-urls"],
-        "optional": [],
     },
     "postgresql": {
         "required": [
@@ -191,37 +92,6 @@ CONNECTOR_FIELDS = {
     },
     "redis": {
         "required": ["connector.name", "redis.table-names", "redis.nodes"],
-        "optional": [],
-    },
-    "redshift": {
-        "required": [
-            "connector.name",
-            "connection-url",
-            "connection-user",
-            "connection-password",
-        ],
-        "optional": [],
-    },
-    "singlestore": {
-        "required": [
-            "connector.name",
-            "connection-url",
-            "connection-user",
-            "connection-password",
-        ],
-        "optional": [],
-    },
-    "sqlserver": {
-        "required": [
-            "connector.name",
-            "connection-url",
-            "connection-user",
-            "connection-password",
-        ],
-        "optional": [],
-    },
-    "trino_thrift": {
-        "required": ["connector.name", "trino.thrift.client.addresses"],
         "optional": [],
     },
 }

--- a/src/literals.py
+++ b/src/literals.py
@@ -11,36 +11,30 @@ TRINO_PORTS = {
 }
 
 # Configuration literals
-CONF_PATH = "/etc/trino/conf"
-CATALOG_PATH = "/etc/trino/catalog"
-CONFIG_JINJA = "config.jinja"
-CONFIG_PATH = "/etc/trino/config.properties"
-LOG_PATH = "/etc/trino/log.properties"
-LOG_JINJA = "logging.jinja"
-RUN_TRINO_COMMAND = "/usr/lib/trino/bin/run-trino"
+TRINO_HOME = "/trino/etc"
+CONFIG_FILES = {
+    "config.jinja": "config.properties",
+    "logging.jinja": "log.properties",
+    "password-authenticator.jinja": "password-authenticator.properties",
+}
+
+CONF_DIR = "conf"
+CATALOG_DIR = "catalog"
+RUN_TRINO_COMMAND = "./entrypoint.sh"
 
 # Authentication literals
-PASSWORD_DB_PATH = "/etc/trino/password.db"  # nosec
-AUTHENTICATOR_PATH = "/etc/trino/password-authenticator.properties"
-AUTHENTICATOR_PROPERTIES = """password-authenticator.name=file
-file.password-file=/etc/trino/password.db
-file.refresh-period=1m
-file.auth-token-cache.max-size=1000"""
+PASSWORD_DB = "password.db"  # nosec
 
 # Ranger plugin literals
-RANGER_PLUGIN_FILE = "plugin-install.jinja"
-RANGER_PLUGIN_VERSION = {
-    "tar": "2.4.0",
-    "path": "3.0.0-SNAPSHOT",
+RANGER_PLUGIN_VERSION = "2.4.0"
+RANGER_PLUGIN_HOME = "/trino/etc/ranger"
+RANGER_PLUGIN_FILES = {
+    "access-control.properties": "access-control.properties",
+    "ranger-plugin.jinja": "install.properties",
 }
 
 JAVA_ENV = {"JAVA_HOME": "/opt/java/openjdk"}
-RANGER_POLICY_PATH = "/etc/ranger"
-RANGER_ACCESS_CONTROL = """\
-access-control.name=ranger
-ranger.use_ugi=true
-"""
-RANGER_ACCESS_CONTROL_PATH = "/etc/trino/access-control.properties"
+
 
 # UNIX literals
 UNIX_TYPE_MAPPING = {

--- a/src/relations/policy.py
+++ b/src/relations/policy.py
@@ -185,7 +185,7 @@ class PolicyRelationHandler(framework.Object):
         ]
         container.exec(
             command,
-            working_dir=self.ranger_abs_path,
+            working_dir=str(self.ranger_abs_path),
             environment=JAVA_ENV,
         ).wait()
 
@@ -374,7 +374,7 @@ class PolicyRelationHandler(framework.Object):
         ]
         container.exec(
             command,
-            working_dir=RANGER_PLUGIN_HOME,
+            working_dir=str(self.ranger_abs_path),
             environment=JAVA_ENV,
         ).wait()
 

--- a/src/relations/policy.py
+++ b/src/relations/policy.py
@@ -4,6 +4,7 @@
 """Defines policy relation event handling methods."""
 
 import logging
+from pathlib import Path
 
 import yaml
 from ops import framework
@@ -13,7 +14,6 @@ from literals import (
     JAVA_ENV,
     RANGER_PLUGIN_FILES,
     RANGER_PLUGIN_HOME,
-    TRINO_HOME,
     TRINO_PORTS,
     UNIX_TYPE_MAPPING,
 )
@@ -24,7 +24,16 @@ logger = logging.getLogger(__name__)
 
 
 class PolicyRelationHandler(framework.Object):
-    """Client for trino policy relations."""
+    """Client for trino policy relations.
+
+    Attrs:
+        ranger_abs_path: The absolute path for Ranger plugin home directory.
+    """
+
+    @property
+    def ranger_abs_path(self):
+        """Return the Ranger plugin absolute path."""
+        return Path(RANGER_PLUGIN_HOME)
 
     def __init__(self, charm, relation_name="policy"):
         """Construct.
@@ -176,7 +185,7 @@ class PolicyRelationHandler(framework.Object):
         ]
         container.exec(
             command,
-            working_dir=RANGER_PLUGIN_HOME,
+            working_dir=self.ranger_abs_path,
             environment=JAVA_ENV,
         ).wait()
 
@@ -198,9 +207,9 @@ class PolicyRelationHandler(framework.Object):
         for template, file in RANGER_PLUGIN_FILES.items():
             content = render(template, policy_context)
             if file == "access-control.properties":
-                path = f"{TRINO_HOME}/{file}"
+                path = self.charm.trino_abs_path.joinpath(file)
             else:
-                path = f"{RANGER_PLUGIN_HOME}/{file}"
+                path = self.ranger_abs_path.joinpath(file)
             container.push(path, content, make_dirs=True, permissions=0o744)
 
     @handle_exec_error
@@ -370,5 +379,6 @@ class PolicyRelationHandler(framework.Object):
         ).wait()
 
         container.remove_path(
-            f"{TRINO_HOME}/access-control.properties", recursive=True
+            self.charm.trino_abs_path.joinpath("access-control.properties"),
+            recursive=True,
         )

--- a/src/utils.py
+++ b/src/utils.py
@@ -12,7 +12,6 @@ import string
 
 import bcrypt
 from jinja2 import Environment, FileSystemLoader
-from ops.model import Container
 from ops.pebble import ExecError
 
 logger = logging.getLogger(__name__)
@@ -36,8 +35,11 @@ def render(template_name, env=None):
     """Pushes configuration files to application.
 
     Args:
-        template_name: template_file
+        template_name: template_file.
         env: (Optional) The subset of config values for the file.
+
+    Returns:
+        content: template content.
     """
     # get the absolute path of templates directory.
     charm_dir = os.path.abspath(

--- a/templates/access-control.properties
+++ b/templates/access-control.properties
@@ -1,0 +1,2 @@
+access-control.name=ranger
+ranger.use_ugi=true

--- a/templates/access-control.properties
+++ b/templates/access-control.properties
@@ -1,5 +1,2 @@
-# Copyright 2023 Canonical Ltd.
-# See LICENSE file for licensing details.
-
 access-control.name=ranger
 ranger.use_ugi=true

--- a/templates/access-control.properties
+++ b/templates/access-control.properties
@@ -1,2 +1,5 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 access-control.name=ranger
 ranger.use_ugi=true

--- a/templates/password-authenticator.jinja
+++ b/templates/password-authenticator.jinja
@@ -1,0 +1,4 @@
+password-authenticator.name=file
+file.password-file= {{ PASSWORD_DB_PATH }}
+file.refresh-period=1m
+file.auth-token-cache.max-size=1000

--- a/templates/ranger-plugin.jinja
+++ b/templates/ranger-plugin.jinja
@@ -20,7 +20,7 @@ INSTALL_ENV=docker
 # This location should be relative to the parent of the directory containing
 # the plugin installation files.
 #
-COMPONENT_INSTALL_DIR_NAME=/etc/trino
+COMPONENT_INSTALL_DIR_NAME=trino/etc/
 
 # Enable audit logs to Solr
 #Example

--- a/templates/ranger-plugin.jinja
+++ b/templates/ranger-plugin.jinja
@@ -20,7 +20,7 @@ INSTALL_ENV=docker
 # This location should be relative to the parent of the directory containing
 # the plugin installation files.
 #
-COMPONENT_INSTALL_DIR_NAME=trino/etc/
+COMPONENT_INSTALL_DIR_NAME={{ TRINO_HOME | default("/usr/lib/trino/etc")}}
 
 # Enable audit logs to Solr
 #Example

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -23,10 +23,12 @@ async def deploy(ops_test: OpsTest):
     }
 
     # Deploy trino and nginx charms
+    trino_config = {"ranger-service-name": "trino-service"}
     await ops_test.model.deploy(
         charm,
         resources=resources,
         application_name=APP_NAME,
+        config=trino_config,
         num_units=1,
     )
     worker_config = {"charm-function": "worker"}
@@ -42,8 +44,14 @@ async def deploy(ops_test: OpsTest):
 
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(
-            apps=[NGINX_NAME, APP_NAME, WORKER_NAME],
+            apps=[APP_NAME, WORKER_NAME],
             status="active",
+            raise_on_blocked=False,
+            timeout=600,
+        )
+        await ops_test.model.wait_for_idle(
+            apps=[NGINX_NAME],
+            status="waiting",
             raise_on_blocked=False,
             timeout=600,
         )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -2,7 +2,6 @@
 # See LICENSE file for licensing details.
 
 """Trino charm integration test config."""
-
 import logging
 
 import pytest
@@ -42,29 +41,28 @@ async def deploy(ops_test: OpsTest):
 
     await ops_test.model.deploy(NGINX_NAME, trust=True)
 
-    async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(
-            apps=[APP_NAME, WORKER_NAME],
-            status="active",
-            raise_on_blocked=False,
-            timeout=600,
-        )
-        await ops_test.model.wait_for_idle(
-            apps=[NGINX_NAME],
-            status="waiting",
-            raise_on_blocked=False,
-            timeout=600,
-        )
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME, WORKER_NAME],
+        status="active",
+        raise_on_blocked=False,
+        timeout=600,
+    )
+    await ops_test.model.wait_for_idle(
+        apps=[NGINX_NAME],
+        status="waiting",
+        raise_on_blocked=False,
+        timeout=600,
+    )
 
-        await ops_test.model.integrate(APP_NAME, NGINX_NAME)
+    await ops_test.model.integrate(APP_NAME, NGINX_NAME)
 
-        await ops_test.model.wait_for_idle(
-            apps=[APP_NAME],
-            status="active",
-            raise_on_blocked=False,
-            timeout=300,
-        )
-        assert (
-            ops_test.model.applications[APP_NAME].units[0].workload_status
-            == "active"
-        )
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME],
+        status="active",
+        raise_on_blocked=False,
+        timeout=300,
+    )
+    assert (
+        ops_test.model.applications[APP_NAME].units[0].workload_status
+        == "active"
+    )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -6,36 +6,32 @@ import logging
 
 import pytest
 import pytest_asyncio
-from helpers import APP_NAME, METADATA, NGINX_NAME, WORKER_NAME
+from helpers import APP_NAME, BASE_DIR, NGINX_NAME, TRINO_IMAGE, WORKER_NAME
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
+
+WORKER_CONFIG = {"charm-function": "worker"}
 
 
 @pytest.mark.skip_if_deployed
 @pytest_asyncio.fixture(name="deploy", scope="module")
 async def deploy(ops_test: OpsTest):
     """Deploy the app."""
-    charm = await ops_test.build_charm(".")
-    resources = {
-        "trino-image": METADATA["resources"]["trino-image"]["upstream-source"]
-    }
+    charm = await ops_test.build_charm(BASE_DIR)
 
     # Deploy trino and nginx charms
-    trino_config = {"ranger-service-name": "trino-service"}
     await ops_test.model.deploy(
         charm,
-        resources=resources,
+        resources=TRINO_IMAGE,
         application_name=APP_NAME,
-        config=trino_config,
         num_units=1,
     )
-    worker_config = {"charm-function": "worker"}
     await ops_test.model.deploy(
         charm,
-        resources=resources,
+        resources=TRINO_IMAGE,
         application_name=WORKER_NAME,
-        config=worker_config,
+        config=WORKER_CONFIG,
         num_units=1,
     )
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -141,7 +141,7 @@ async def create_user(ops_test, ranger_url):
 
     Args:
         ops_test: PyTest object
-        ranger_url: the polciy manager url
+        ranger_url: the policy manager url
     """
     url = f"{ranger_url}/service/xusers/users"
     response = requests.post(

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -41,6 +41,20 @@ USER_WITHOUT_ACCESS = "user"
 POLICY_NAME = "system - catalog, schema, table, column"
 LDAP_NAME = "comsys-openldap-k8s"
 USERSYNC_NAME = "ranger-usersync-k8s"
+HEADERS = {
+    "Accept": "application/json",
+    "Content-Type": "application/json",
+}
+DEV_USER = {
+    "user": {
+        "name": USER_WITH_ACCESS,
+        "password": "devpassword",
+        "firstName": USER_WITH_ACCESS,
+        "lastName": "user",
+        "emailAddress": "dev@example.com",
+        "status": 1,
+    }
+}
 
 
 async def get_unit_url(

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -34,27 +34,13 @@ connection-user=trino
 connection-password=trino
 """
 RANGER_NAME = "ranger-k8s"
-GROUP_MANAGEMENT = """\
-    trino-service:
-        users:
-          - name: user1
-            firstname: One
-            lastname: User
-            email: user1@canonical.com
-        memberships:
-          - groupname: commercial-systems
-            users: [user1]
-        groups:
-          - name: commercial-systems
-            description: commercial systems team
-"""
 TRINO_USER = "trino"
 TRINO_SERVICE = "trino-service"
-USER_WITH_ACCESS = "user1"
-USER_WITHOUT_ACCESS = "user2"
-GROUP_WITH_ACCESS = "commercial-systems"
-POLICY_NAME = "tpch - catalog, schema, table, column"
-TRINO_POLICY_NAME = "trino-k8s-policy"
+USER_WITH_ACCESS = "dev"
+USER_WITHOUT_ACCESS = "user"
+POLICY_NAME = "system - catalog, schema, table, column"
+LDAP_NAME = "comsys-openldap-k8s"
+USERSYNC_NAME = "ranger-usersync-k8s"
 
 
 async def get_unit_url(
@@ -123,10 +109,10 @@ async def run_connector_action(ops_test, action, params, user):
     return catalogs
 
 
-async def create_group_policy(ops_test, ranger_url):
-    """Create a Ranger group policy.
+async def create_policy(ops_test, ranger_url):
+    """Create a Ranger user policy.
 
-    Allow members of `commercial-systems` to access `tpch` catalog.
+    Allow user `user1` to access `system` catalog.
 
     Args:
         ops_test: PyTest object
@@ -138,13 +124,13 @@ async def create_group_policy(ops_test, ranger_url):
     policy.name = POLICY_NAME
     policy.resources = {
         "schema": RangerPolicyResource({"values": ["*"]}),
-        "catalog": RangerPolicyResource({"values": ["tpch"]}),
+        "catalog": RangerPolicyResource({"values": ["system"]}),
         "table": RangerPolicyResource({"values": ["*"]}),
         "column": RangerPolicyResource({"values": ["*"]}),
     }
 
     allow_items = RangerPolicyItem()
-    allow_items.groups = [GROUP_WITH_ACCESS]
+    allow_items.users = [USER_WITH_ACCESS]
     allow_items.accesses = [RangerPolicyItemAccess({"type": "select"})]
     policy.policyItems = [allow_items]
     ranger.create_policy(policy)

--- a/tests/integration/test_policy.py
+++ b/tests/integration/test_policy.py
@@ -8,16 +8,15 @@ import logging
 import time
 
 import pytest
-import pytest_asyncio
 from helpers import (
-    GROUP_MANAGEMENT,
-    METADATA,
+    APP_NAME,
+    LDAP_NAME,
     POSTGRES_NAME,
     RANGER_NAME,
-    TRINO_POLICY_NAME,
     USER_WITH_ACCESS,
     USER_WITHOUT_ACCESS,
-    create_group_policy,
+    USERSYNC_NAME,
+    create_policy,
     get_catalogs,
     get_unit_url,
 )
@@ -26,84 +25,83 @@ from pytest_operator.plugin import OpsTest
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.skip_if_deployed
-@pytest_asyncio.fixture(name="deploy", scope="module")
-async def deploy_ranger(ops_test: OpsTest):
-    """Add Ranger relation and apply group configuration."""
-    charm = await ops_test.build_charm(".")
-    resources = {
-        "trino-image": METADATA["resources"]["trino-image"]["upstream-source"]
-    }
-    trino_config = {
-        "charm-function": "all",
-        "ranger-service-name": "trino-service",
-    }
-    await ops_test.model.deploy(
-        charm,
-        resources=resources,
-        application_name=TRINO_POLICY_NAME,
-        num_units=1,
-        config=trino_config,
-    )
-
-    await ops_test.model.deploy(POSTGRES_NAME, channel="14", trust=True)
-    await ops_test.model.wait_for_idle(
-        apps=[POSTGRES_NAME, TRINO_POLICY_NAME],
-        status="active",
-        raise_on_blocked=False,
-        timeout=1200,
-    )
-
-    ranger_config = {"user-group-configuration": GROUP_MANAGEMENT}
-    await ops_test.model.deploy(
-        RANGER_NAME, channel="beta", config=ranger_config
-    )
-
-    await ops_test.model.wait_for_idle(
-        apps=[RANGER_NAME],
-        status="blocked",
-        raise_on_blocked=False,
-        timeout=1200,
-    )
-    await ops_test.model.integrate(RANGER_NAME, POSTGRES_NAME)
-
-    await ops_test.model.wait_for_idle(
-        apps=[POSTGRES_NAME, RANGER_NAME],
-        status="active",
-        raise_on_blocked=False,
-        timeout=1200,
-    )
-    logging.info("integrating trino and ranger")
-    await ops_test.model.integrate(RANGER_NAME, TRINO_POLICY_NAME)
-    await ops_test.model.wait_for_idle(
-        apps=[TRINO_POLICY_NAME, RANGER_NAME],
-        status="active",
-        raise_on_blocked=False,
-        timeout=1200,
-    )
-
-
 @pytest.mark.abort_on_fail
 @pytest.mark.usefixtures("deploy")
-class TestPolicy:
-    """Integration test for policy relation."""
+class TestPolicyManager:
+    """Integration test for Ranger policy enforcement."""
 
-    async def test_group_policy(self, ops_test: OpsTest):
-        """Connects a client and executes a basic SQL query."""
+    async def test_policy_enforcement(self, ops_test: OpsTest):
+        """Add Ranger relation and apply group configuration."""
+        # Deploy and prepare Ranger admin.
+        await ops_test.model.deploy(POSTGRES_NAME, channel="14", trust=True)
+        await ops_test.model.deploy(RANGER_NAME, channel="edge")
+
+        await ops_test.model.wait_for_idle(
+            apps=[POSTGRES_NAME],
+            status="active",
+            raise_on_blocked=False,
+            timeout=1200,
+        )
+        await ops_test.model.integrate(RANGER_NAME, POSTGRES_NAME)
+
+        await ops_test.model.wait_for_idle(
+            apps=[POSTGRES_NAME, RANGER_NAME],
+            status="active",
+            raise_on_blocked=False,
+            timeout=1200,
+        )
+
+        # Deploy and prepare Ranger usersync.
+        await ops_test.model.deploy(LDAP_NAME, channel="edge")
+        await ops_test.model.wait_for_idle(
+            apps=[LDAP_NAME],
+            status="active",
+            raise_on_blocked=False,
+            timeout=1500,
+        )
+        action = (
+            await ops_test.model.applications[LDAP_NAME]
+            .units[0]
+            .run_action("load-test-users")
+        )
+        await action.wait()
+
+        usersync_config = {"charm-function": "usersync"}
+        await ops_test.model.deploy(
+            RANGER_NAME,
+            channel="edge",
+            config=usersync_config,
+            application_name=USERSYNC_NAME,
+        )
+        await ops_test.model.integrate(USERSYNC_NAME, LDAP_NAME)
+        time.sleep(100)  # Provide time for user synchronization to occur.
+        await ops_test.model.wait_for_idle(
+            apps=[USERSYNC_NAME, LDAP_NAME],
+            status="active",
+            raise_on_blocked=False,
+            timeout=1500,
+        )
+
+        # Integrate Trino and Ranger.
+        logging.info("integrating trino and ranger")
+        await ops_test.model.integrate(RANGER_NAME, APP_NAME)
+        await ops_test.model.wait_for_idle(
+            apps=[APP_NAME, RANGER_NAME],
+            status="active",
+            raise_on_blocked=False,
+            timeout=1200,
+        )
+        # Test policy implementation.
         url = await get_unit_url(
             ops_test, application=RANGER_NAME, unit=0, port=6080
         )
         logging.info(f"creating test policies for {url}")
-        await create_group_policy(ops_test, url)
+        await create_policy(ops_test, url)
 
         # wait 3 minutes for the policy to be synced.
         time.sleep(180)
 
-        catalogs = await get_catalogs(
-            ops_test, USER_WITH_ACCESS, TRINO_POLICY_NAME
-        )
-        assert catalogs == [["tpch"]]
-        catalogs = await get_catalogs(
-            ops_test, USER_WITHOUT_ACCESS, TRINO_POLICY_NAME
-        )
+        catalogs = await get_catalogs(ops_test, USER_WITH_ACCESS, APP_NAME)
+        assert catalogs == [["system"]]
+        catalogs = await get_catalogs(ops_test, USER_WITHOUT_ACCESS, APP_NAME)
         assert catalogs == []

--- a/tests/integration/test_policy.py
+++ b/tests/integration/test_policy.py
@@ -8,14 +8,14 @@ import logging
 import time
 
 import pytest
+import pytest_asyncio
 from helpers import (
     APP_NAME,
-    LDAP_NAME,
+    METADATA,
     POSTGRES_NAME,
     RANGER_NAME,
     USER_WITH_ACCESS,
     USER_WITHOUT_ACCESS,
-    USERSYNC_NAME,
     create_policy,
     get_catalogs,
     get_unit_url,
@@ -25,72 +25,69 @@ from pytest_operator.plugin import OpsTest
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.abort_on_fail
-@pytest.mark.usefixtures("deploy")
-class TestPolicyManager:
-    """Integration test for Ranger policy enforcement."""
+@pytest.mark.skip_if_deployed
+@pytest_asyncio.fixture(name="deploy-policy", scope="module")
+async def test_policy_enforcement(ops_test: OpsTest):
+    """Add Ranger relation and apply group configuration."""
+    charm = await ops_test.build_charm(".")
+    resources = {
+        "trino-image": METADATA["resources"]["trino-image"]["upstream-source"]
+    }
+    trino_config = {
+        "ranger-service-name": "trino-service",
+        "charm-function": "all",
+    }
+    await ops_test.model.deploy(
+        charm,
+        resources=resources,
+        application_name=APP_NAME,
+        num_units=1,
+        config=trino_config,
+    )
+    # Deploy and prepare Ranger admin.
+    await ops_test.model.deploy(POSTGRES_NAME, channel="14", trust=True)
+    await ops_test.model.deploy(RANGER_NAME, channel="edge")
 
-    async def test_policy_enforcement(self, ops_test: OpsTest):
-        """Add Ranger relation and apply group configuration."""
-        # Deploy and prepare Ranger admin.
-        await ops_test.model.deploy(POSTGRES_NAME, channel="14", trust=True)
-        await ops_test.model.deploy(RANGER_NAME, channel="edge")
-
+    async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(
             apps=[POSTGRES_NAME],
             status="active",
             raise_on_blocked=False,
-            timeout=1200,
-        )
-        await ops_test.model.integrate(RANGER_NAME, POSTGRES_NAME)
-
-        await ops_test.model.wait_for_idle(
-            apps=[POSTGRES_NAME, RANGER_NAME],
-            status="active",
-            raise_on_blocked=False,
-            timeout=1200,
+            timeout=2000,
         )
 
-        # Deploy and prepare Ranger usersync.
-        await ops_test.model.deploy(LDAP_NAME, channel="edge")
-        await ops_test.model.wait_for_idle(
-            apps=[LDAP_NAME],
-            status="active",
-            raise_on_blocked=False,
-            timeout=1500,
-        )
-        action = (
-            await ops_test.model.applications[LDAP_NAME]
-            .units[0]
-            .run_action("load-test-users")
-        )
-        await action.wait()
+    await ops_test.model.wait_for_idle(
+        apps=[RANGER_NAME],
+        status="blocked",
+        raise_on_blocked=False,
+        timeout=2000,
+    )
+    await ops_test.model.integrate(RANGER_NAME, POSTGRES_NAME)
 
-        usersync_config = {"charm-function": "usersync"}
-        await ops_test.model.deploy(
-            RANGER_NAME,
-            channel="edge",
-            config=usersync_config,
-            application_name=USERSYNC_NAME,
-        )
-        await ops_test.model.integrate(USERSYNC_NAME, LDAP_NAME)
-        time.sleep(100)  # Provide time for user synchronization to occur.
-        await ops_test.model.wait_for_idle(
-            apps=[USERSYNC_NAME, LDAP_NAME],
-            status="active",
-            raise_on_blocked=False,
-            timeout=1500,
-        )
+    await ops_test.model.wait_for_idle(
+        apps=[POSTGRES_NAME, RANGER_NAME, APP_NAME],
+        status="active",
+        raise_on_blocked=False,
+        timeout=2000,
+    )
 
-        # Integrate Trino and Ranger.
-        logging.info("integrating trino and ranger")
-        await ops_test.model.integrate(RANGER_NAME, APP_NAME)
-        await ops_test.model.wait_for_idle(
-            apps=[APP_NAME, RANGER_NAME],
-            status="active",
-            raise_on_blocked=False,
-            timeout=1200,
-        )
+    # Integrate Trino and Ranger.
+    await ops_test.model.integrate(RANGER_NAME, APP_NAME)
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME, RANGER_NAME],
+        status="active",
+        raise_on_blocked=False,
+        timeout=1200,
+    )
+
+
+@pytest.mark.abort_on_fail
+@pytest.mark.usefixtures("deploy-policy")
+class TestPolicyManager:
+    """Integration test for Ranger policy enforcement."""
+
+    async def test_policy_enforcement(self, ops_test):
+        """Test Ranger integration."""
         # Test policy implementation.
         url = await get_unit_url(
             ops_test, application=RANGER_NAME, unit=0, port=6080
@@ -98,10 +95,12 @@ class TestPolicyManager:
         logging.info(f"creating test policies for {url}")
         await create_policy(ops_test, url)
 
-        # wait 3 minutes for the policy to be synced.
-        time.sleep(180)
+        # wait 30 seconds for the policy to be synced.
+        time.sleep(30)
 
         catalogs = await get_catalogs(ops_test, USER_WITH_ACCESS, APP_NAME)
         assert catalogs == [["system"]]
+        logger.info(f"{USER_WITH_ACCESS} can access {catalogs}.")
         catalogs = await get_catalogs(ops_test, USER_WITHOUT_ACCESS, APP_NAME)
+        logger.info(f"{USER_WITHOUT_ACCESS}, can access {catalogs}.")
         assert catalogs == []

--- a/tests/integration/test_policy.py
+++ b/tests/integration/test_policy.py
@@ -11,12 +11,14 @@ import pytest
 import pytest_asyncio
 from helpers import (
     APP_NAME,
-    METADATA,
+    BASE_DIR,
     POSTGRES_NAME,
     RANGER_NAME,
+    TRINO_IMAGE,
     USER_WITH_ACCESS,
     USER_WITHOUT_ACCESS,
     create_policy,
+    create_user,
     get_catalogs,
     get_unit_url,
 )
@@ -24,14 +26,18 @@ from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
 
+TRINO_CONIG = {
+    "ranger-service-name": "trino-service",
+    "charm-function": "all",
+}
+
 
 @pytest.mark.skip_if_deployed
 @pytest_asyncio.fixture(name="deploy-policy", scope="module")
-async def test_policy_enforcement(ops_test: OpsTest):
+async def deploy_policy_engine(ops_test: OpsTest):
     """Add Ranger relation and apply group configuration."""
-    # Deploy and prepare Ranger admin.
     await ops_test.model.deploy(POSTGRES_NAME, channel="14", trust=True)
-    await ops_test.model.deploy(RANGER_NAME, channel="stable")
+    await ops_test.model.deploy(RANGER_NAME, channel="edge", trust=True)
 
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(
@@ -41,51 +47,21 @@ async def test_policy_enforcement(ops_test: OpsTest):
             timeout=2000,
         )
 
-    await ops_test.model.wait_for_idle(
-        apps=[RANGER_NAME],
-        status="blocked",
-        raise_on_blocked=False,
-        timeout=2000,
-    )
-    await ops_test.model.integrate(RANGER_NAME, POSTGRES_NAME)
+        await ops_test.model.wait_for_idle(
+            apps=[RANGER_NAME],
+            status="blocked",
+            raise_on_blocked=False,
+            timeout=2000,
+        )
+        logger.info("Integrating Ranger and PostgreSQL.")
+        await ops_test.model.integrate(RANGER_NAME, POSTGRES_NAME)
 
-    await ops_test.model.wait_for_idle(
-        apps=[POSTGRES_NAME, RANGER_NAME],
-        status="active",
-        raise_on_blocked=False,
-        timeout=2000,
-    )
-    charm = await ops_test.build_charm(".")
-    resources = {
-        "trino-image": METADATA["resources"]["trino-image"]["upstream-source"]
-    }
-    trino_config = {
-        "ranger-service-name": "trino-service",
-        "charm-function": "all",
-    }
-    await ops_test.model.deploy(
-        charm,
-        resources=resources,
-        application_name=APP_NAME,
-        num_units=1,
-        config=trino_config,
-    )
-
-    await ops_test.model.wait_for_idle(
-        apps=[APP_NAME, RANGER_NAME],
-        status="active",
-        raise_on_blocked=False,
-        timeout=2000,
-    )
-
-    # Integrate Trino and Ranger.
-    await ops_test.model.integrate(RANGER_NAME, APP_NAME)
-    await ops_test.model.wait_for_idle(
-        apps=[APP_NAME, RANGER_NAME],
-        status="active",
-        raise_on_blocked=False,
-        timeout=1200,
-    )
+        await ops_test.model.wait_for_idle(
+            apps=[POSTGRES_NAME, RANGER_NAME],
+            status="active",
+            raise_on_blocked=False,
+            timeout=2000,
+        )
 
 
 @pytest.mark.abort_on_fail
@@ -95,19 +71,46 @@ class TestPolicyManager:
 
     async def test_policy_enforcement(self, ops_test):
         """Test Ranger integration."""
-        # Test policy implementation.
+        charm = await ops_test.build_charm(BASE_DIR)
+        await ops_test.model.deploy(
+            charm,
+            resources=TRINO_IMAGE,
+            application_name=APP_NAME,
+            config=TRINO_CONIG,
+        )
+
+        async with ops_test.fast_forward():
+            await ops_test.model.wait_for_idle(
+                apps=[APP_NAME],
+                status="active",
+                raise_on_blocked=False,
+                timeout=2000,
+            )
+
+        logger.info("Creating test user.")
         url = await get_unit_url(
             ops_test, application=RANGER_NAME, unit=0, port=6080
+        )
+        await create_user(ops_test, url)
+
+        # Integrate Trino and Ranger.
+        logger.info("Integrating Trino and Ranger.")
+        await ops_test.model.integrate(RANGER_NAME, APP_NAME)
+        await ops_test.model.wait_for_idle(
+            apps=[APP_NAME, RANGER_NAME],
+            status="active",
+            raise_on_blocked=False,
+            timeout=2000,
         )
         logging.info(f"creating test policies for {url}")
         await create_policy(ops_test, url)
 
-        # wait 30 seconds for the policy to be synced.
-        time.sleep(30)
+        time.sleep(30)  # wait 30 seconds for the policy to be synced.
 
         catalogs = await get_catalogs(ops_test, USER_WITH_ACCESS, APP_NAME)
         assert catalogs == [["system"]]
         logger.info(f"{USER_WITH_ACCESS} can access {catalogs}.")
+
         catalogs = await get_catalogs(ops_test, USER_WITHOUT_ACCESS, APP_NAME)
         logger.info(f"{USER_WITHOUT_ACCESS}, can access {catalogs}.")
         assert catalogs == []

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -25,10 +25,8 @@ connection-url=jdbc:postgresql://host.com:5432/database
 connection-user=testing
 connection-password=test
 """
-DB_PATH = "/etc/trino/catalog/example-db.properties"
-RANGER_PROPERTIES_PATH = (
-    "/root/ranger-3.0.0-SNAPSHOT-trino-plugin/install.properties"
-)
+DB_PATH = "/trino/etc/catalog/example-db.properties"
+RANGER_PROPERTIES_PATH = "/trino/etc/ranger/install.properties"
 POLICY_MGR_URL = "http://ranger-k8s:6080"
 GROUP_MANAGEMENT = """\
         users:
@@ -104,15 +102,16 @@ class TestCharm(TestCase):
                 "trino": {
                     "override": "replace",
                     "summary": "trino server",
-                    "command": "/usr/lib/trino/bin/run-trino",
+                    "command": "./entrypoint.sh",
                     "startup": "enabled",
                     "environment": {
                         "DEFAULT_PASSWORD": "ubuntu123",
+                        "PASSWORD_DB_PATH": "/trino/etc/password.db",
                         "LOG_LEVEL": "info",
                         "OAUTH_CLIENT_ID": None,
                         "OAUTH_CLIENT_SECRET": None,
                         "WEB_PROXY": None,
-                        "SSL_PATH": "/etc/trino/conf/truststore.jks",
+                        "SSL_PATH": "/trino/etc/conf/truststore.jks",
                         "SSL_PWD": "truststore123",
                         "CHARM_FUNCTION": "coordinator",
                         "DISCOVERY_URI": "http://trino-k8s:8080",
@@ -204,15 +203,16 @@ class TestCharm(TestCase):
                 "trino": {
                     "override": "replace",
                     "summary": "trino server",
-                    "command": "/usr/lib/trino/bin/run-trino",
+                    "command": "./entrypoint.sh",
                     "startup": "enabled",
                     "environment": {
                         "DEFAULT_PASSWORD": "ubuntu123",
+                        "PASSWORD_DB_PATH": "/trino/etc/password.db",
                         "LOG_LEVEL": "info",
                         "OAUTH_CLIENT_ID": "test-client-id",
                         "OAUTH_CLIENT_SECRET": "test-client-secret",
                         "WEB_PROXY": "proxy:port",
-                        "SSL_PATH": "/etc/trino/conf/truststore.jks",
+                        "SSL_PATH": "/trino/etc/conf/truststore.jks",
                         "SSL_PWD": "truststore123",
                         "CHARM_FUNCTION": "worker",
                         "DISCOVERY_URI": "http://trino-k8s:8080",

--- a/tox.ini
+++ b/tox.ini
@@ -28,9 +28,9 @@ description = Run integration tests
 deps =
     ipdb==0.13.9
     juju==3.1.0.1
-    pytest==7.1.3
-    pytest-operator==0.22.0
-    pytest-asyncio==0.21
+    pytest==7.4.0
+    pytest-operator==0.29.0
+    pytest-asyncio==0.21.0
     trino==0.326.0
     apache-ranger==0.0.11
     -r{toxinidir}/requirements.txt
@@ -42,9 +42,9 @@ description = Run integration tests
 deps =
     ipdb==0.13.9
     juju==3.1.0.1
-    pytest==7.1.3
-    pytest-operator==0.22.0
-    pytest-asyncio==0.21
+    pytest==7.4.0
+    pytest-operator==0.29.0
+    pytest-asyncio==0.21.0
     trino==0.326.0
     apache-ranger==0.0.11
     -r{toxinidir}/requirements.txt
@@ -56,9 +56,9 @@ description = Run integration tests
 deps =
     ipdb==0.13.9
     juju==3.1.0.1
-    pytest==7.1.3
-    pytest-operator==0.22.0
-    pytest-asyncio==0.21
+    pytest==7.4.0
+    pytest-operator==0.29.0
+    pytest-asyncio==0.21.0
     trino==0.326.0
     apache-ranger==0.0.11
     -r{toxinidir}/requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,7 @@ deps =
     juju==3.1.0.1
     pytest==7.1.3
     pytest-operator==0.22.0
+    pytest-asyncio==0.21
     trino==0.326.0
     apache-ranger==0.0.11
     -r{toxinidir}/requirements.txt
@@ -41,8 +42,9 @@ description = Run integration tests
 deps =
     ipdb==0.13.9
     juju==3.1.0.1
-    pytest==7.4.0
-    pytest-operator==0.29.0
+    pytest==7.1.3
+    pytest-operator==0.22.0
+    pytest-asyncio==0.21
     trino==0.326.0
     apache-ranger==0.0.11
     -r{toxinidir}/requirements.txt
@@ -54,8 +56,9 @@ description = Run integration tests
 deps =
     ipdb==0.13.9
     juju==3.1.0.1
-    pytest==7.4.0
-    pytest-operator==0.29.0
+    pytest==7.1.3
+    pytest-operator==0.22.0
+    pytest-asyncio==0.21
     trino==0.326.0
     apache-ranger==0.0.11
     -r{toxinidir}/requirements.txt


### PR DESCRIPTION
This PR updates the charm to use the trino rock. This required:
- Some updates to ranger and trino home pathways
- Removal of unpacking the tar from the charm as this is now handled by the rock
- Update to the entrypoint
- Update to environment variables to include the required paths for the install.properties
- Update to tests given the above.
- Removal of value restrictions for plugins not included in the ROCK

Due to changes in Ranger the following was updates:
Ranger no longer synchronizes via a file and relation to Trino. The way we handle this moving forward has not been determined so I have left in this option, however I have updated the integration test to validate policies which apply to the user not the group until we have a clear pathway forward.

Some general refactors:
- Adding password authenticator as a jinja file as opposed to literal string.
- Update to literals to use RANGER_HOME and TRINO_HOME to avoid changes in multiple places when the location is updated
- Consolidated the mechanism for pushing a file into the container as there were multiple functions handling this.
- Added up check and status_update handler.