### PR TITLE
Fix for when password contains `{` and lib update

### DIFF
--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -480,7 +480,9 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 28
+LIBPATCH = 29
+
+PYDEPS = ["cosl"]
 
 logger = logging.getLogger(__name__)
 

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -362,7 +362,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 44
+LIBPATCH = 45
 
 PYDEPS = ["cosl"]
 
@@ -1537,12 +1537,11 @@ class MetricsEndpointProvider(Object):
             relation.data[self._charm.app]["scrape_metadata"] = json.dumps(self._scrape_metadata)
             relation.data[self._charm.app]["scrape_jobs"] = json.dumps(self._scrape_jobs)
 
-            if alert_rules_as_dict:
-                # Update relation data with the string representation of the rule file.
-                # Juju topology is already included in the "scrape_metadata" field above.
-                # The consumer side of the relation uses this information to name the rules file
-                # that is written to the filesystem.
-                relation.data[self._charm.app]["alert_rules"] = json.dumps(alert_rules_as_dict)
+            # Update relation data with the string representation of the rule file.
+            # Juju topology is already included in the "scrape_metadata" field above.
+            # The consumer side of the relation uses this information to name the rules file
+            # that is written to the filesystem.
+            relation.data[self._charm.app]["alert_rules"] = json.dumps(alert_rules_as_dict)
 
     def _set_unit_ip(self, _=None):
         """Set unit host address.

--- a/src/charm.py
+++ b/src/charm.py
@@ -13,7 +13,6 @@ https://discourse.charmhub.io/t/4208
 import logging
 from pathlib import Path
 
-
 import yaml
 from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
 from charms.loki_k8s.v0.loki_push_api import LogProxyConsumer
@@ -268,10 +267,10 @@ class TrinoK8SCharm(CharmBase):
         """
         for name, config in catalogs.items():
             # Inject truststore path and password.
-            config = config.format(
-                SSL_PATH=str(self.truststore_abs_path),
-                SSL_PWD=truststore_pwd,
-            )
+            config = config.replace(
+                "{SSL_PATH}", str(self.truststore_abs_path)
+            ).replace("{SSL_PWD}", truststore_pwd)
+
             # Add catalog.
             container.push(
                 self.catalog_abs_path.joinpath(f"{name}.properties"),

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -32,7 +32,7 @@ catalogs:
         connector.name=postgresql
         connection-url=jdbc:postgresql://host.com:5432/database?ssl=true&sslmode=require&sslrootcert={SSL_PATH}&sslrootcertpassword={SSL_PWD}
         connection-user=testing
-        connection-password=test
+        connection-password=pd3h@!}93*hdu
 certs:
     example-cert: |
         -----BEGIN CERTIFICATE-----


### PR DESCRIPTION
This is a fix for an error introduced when the catalog config contains the special character `{` as this causes `.format()` to error. Using `replace` instead ensures that the replacement is not broken by special characters. I've also added these characters in the password of the unit test.