### PR TITLE
Configure catalogs when Trino is restarted

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -178,7 +178,7 @@ configure the following scrape-related settings, which behave as described by th
 - `scrape_timeout`
 - `proxy_url`
 - `relabel_configs`
-- `metrics_relabel_configs`
+- `metric_relabel_configs`
 - `sample_limit`
 - `label_limit`
 - `label_name_length_limit`
@@ -362,7 +362,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 45
+LIBPATCH = 47
 
 PYDEPS = ["cosl"]
 
@@ -377,7 +377,7 @@ ALLOWED_KEYS = {
     "scrape_timeout",
     "proxy_url",
     "relabel_configs",
-    "metrics_relabel_configs",
+    "metric_relabel_configs",
     "sample_limit",
     "label_limit",
     "label_name_length_limit",
@@ -521,8 +521,8 @@ class PrometheusConfig:
                         # for such a target. Therefore labeling with Juju topology, excluding the
                         # unit name.
                         non_wildcard_static_config["labels"] = {
-                            **non_wildcard_static_config.get("labels", {}),
                             **topology.label_matcher_dict,
+                            **non_wildcard_static_config.get("labels", {}),
                         }
 
                     non_wildcard_static_configs.append(non_wildcard_static_config)
@@ -547,9 +547,9 @@ class PrometheusConfig:
                         if topology:
                             # Add topology labels
                             modified_static_config["labels"] = {
-                                **modified_static_config.get("labels", {}),
                                 **topology.label_matcher_dict,
                                 **{"juju_unit": unit_name},
+                                **modified_static_config.get("labels", {}),
                             }
 
                             # Instance relabeling for topology should be last in order.

--- a/src/charm.py
+++ b/src/charm.py
@@ -241,6 +241,7 @@ class TrinoK8SCharm(CharmBase):
 
         self.unit.status = MaintenanceStatus("restarting trino")
         self._restart_trino(container)
+        self._configure_catalogs(container)
         self._enable_password_auth(container)
 
         event.set_results({"result": "trino successfully restarted"})

--- a/src/charm.py
+++ b/src/charm.py
@@ -225,6 +225,8 @@ class TrinoK8SCharm(CharmBase):
             container: Trino container
         """
         self.unit.status = MaintenanceStatus("restarting trino")
+        self._configure_catalogs(container)
+        self._enable_password_auth(container)
         container.restart(self.name)
 
     @log_event_handler(logger)
@@ -241,8 +243,6 @@ class TrinoK8SCharm(CharmBase):
 
         self.unit.status = MaintenanceStatus("restarting trino")
         self._restart_trino(container)
-        self._configure_catalogs(container)
-        self._enable_password_auth(container)
 
         event.set_results({"result": "trino successfully restarted"})
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -315,7 +315,6 @@ class TrinoK8SCharm(CharmBase):
         """
         # Get dictionary of certs and catalogs.
         catalog_config = self.config.get("catalog-config")
-        certs, catalogs = create_cert_and_catalog_dicts(catalog_config)
         truststore_pwd = generate_password()
 
         # Remove existing catalogs and certs.
@@ -324,8 +323,9 @@ class TrinoK8SCharm(CharmBase):
                 container.remove_path(path, recursive=True)
 
         # Add catalogs from config
-        if not catalogs:
+        if not catalog_config:
             return
+        certs, catalogs = create_cert_and_catalog_dicts(catalog_config)
         self._add_catalogs(container, catalogs, truststore_pwd)
 
         # Add certs from config


### PR DESCRIPTION
There is a `juju action` that restarts trino and trino is restarted after relation with ranger. The logic for configuring catalogs should therefore be present here (as an `_update` is not triggered). I've also moved the `enable_password_auth` here as well as this was previously only triggered on the action not the relation with Ranger.

The prometheus and nginx libs have also been updated. 