### PR TITLE
CSS-8485 Restore ranger plugin if relation exists

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -178,7 +178,7 @@ configure the following scrape-related settings, which behave as described by th
 - `scrape_timeout`
 - `proxy_url`
 - `relabel_configs`
-- `metrics_relabel_configs`
+- `metric_relabel_configs`
 - `sample_limit`
 - `label_limit`
 - `label_name_length_limit`
@@ -362,7 +362,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 45
+LIBPATCH = 47
 
 PYDEPS = ["cosl"]
 
@@ -377,7 +377,7 @@ ALLOWED_KEYS = {
     "scrape_timeout",
     "proxy_url",
     "relabel_configs",
-    "metrics_relabel_configs",
+    "metric_relabel_configs",
     "sample_limit",
     "label_limit",
     "label_name_length_limit",
@@ -521,8 +521,8 @@ class PrometheusConfig:
                         # for such a target. Therefore labeling with Juju topology, excluding the
                         # unit name.
                         non_wildcard_static_config["labels"] = {
-                            **non_wildcard_static_config.get("labels", {}),
                             **topology.label_matcher_dict,
+                            **non_wildcard_static_config.get("labels", {}),
                         }
 
                     non_wildcard_static_configs.append(non_wildcard_static_config)
@@ -547,9 +547,9 @@ class PrometheusConfig:
                         if topology:
                             # Add topology labels
                             modified_static_config["labels"] = {
-                                **modified_static_config.get("labels", {}),
                                 **topology.label_matcher_dict,
                                 **{"juju_unit": unit_name},
+                                **modified_static_config.get("labels", {}),
                             }
 
                             # Instance relabeling for topology should be last in order.

--- a/src/charm.py
+++ b/src/charm.py
@@ -241,6 +241,7 @@ class TrinoK8SCharm(CharmBase):
 
         self.unit.status = MaintenanceStatus("restarting trino")
         self._restart_trino(container)
+        self._configure_catalogs(container)
         self._enable_password_auth(container)
 
         event.set_results({"result": "trino successfully restarted"})

--- a/src/charm.py
+++ b/src/charm.py
@@ -225,6 +225,8 @@ class TrinoK8SCharm(CharmBase):
             container: Trino container
         """
         self.unit.status = MaintenanceStatus("restarting trino")
+        self._configure_catalogs(container)
+        self._enable_password_auth(container)
         container.restart(self.name)
 
     @log_event_handler(logger)
@@ -241,8 +243,6 @@ class TrinoK8SCharm(CharmBase):
 
         self.unit.status = MaintenanceStatus("restarting trino")
         self._restart_trino(container)
-        self._configure_catalogs(container)
-        self._enable_password_auth(container)
 
         event.set_results({"result": "trino successfully restarted"})
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -315,7 +315,6 @@ class TrinoK8SCharm(CharmBase):
         """
         # Get dictionary of certs and catalogs.
         catalog_config = self.config.get("catalog-config")
-        certs, catalogs = create_cert_and_catalog_dicts(catalog_config)
         truststore_pwd = generate_password()
 
         # Remove existing catalogs and certs.
@@ -324,8 +323,9 @@ class TrinoK8SCharm(CharmBase):
                 container.remove_path(path, recursive=True)
 
         # Add catalogs from config
-        if not catalogs:
+        if not catalog_config:
             return
+        certs, catalogs = create_cert_and_catalog_dicts(catalog_config)
         self._add_catalogs(container, catalogs, truststore_pwd)
 
         # Add certs from config

--- a/src/literals.py
+++ b/src/literals.py
@@ -30,6 +30,7 @@ CONFIG_FILES = {
 CONF_DIR = "conf"
 CATALOG_DIR = "catalog"
 RUN_TRINO_COMMAND = "./entrypoint.sh"
+TRINO_PLUGIN_DIR = "/usr/lib/trino/plugin"
 
 # Authentication literals
 PASSWORD_DB = "password.db"  # nosec

--- a/src/relations/policy.py
+++ b/src/relations/policy.py
@@ -14,6 +14,7 @@ from literals import (
     JAVA_ENV,
     RANGER_PLUGIN_FILES,
     RANGER_PLUGIN_HOME,
+    TRINO_PLUGIN_DIR,
     TRINO_PORTS,
     UNIX_TYPE_MAPPING,
 )
@@ -81,9 +82,6 @@ class PolicyRelationHandler(framework.Object):
 
         Args:
             event: Relation changed event.
-
-        Raises:
-            ExecError: When failure to enable Ranger plugin.
         """
         if not self.charm.unit.is_leader():
             return
@@ -93,22 +91,14 @@ class PolicyRelationHandler(framework.Object):
             event.defer()
             return
 
-        policy_manager_url = event.relation.data[event.app].get(
-            "policy_manager_url"
-        )
-        if not policy_manager_url:
+        self.charm.state.policy_manager_url = event.relation.data[
+            event.app
+        ].get("policy_manager_url")
+        if not self.charm.state.policy_manager_url:
             return
 
-        policy_relation = f"relation_{event.relation.id}"
-
-        try:
-            self._configure_plugin_properties(
-                container, policy_manager_url, policy_relation
-            )
-            self._enable_plugin(container)
-            logger.info("Ranger plugin is enabled.")
-        except ExecError as err:
-            raise ExecError(f"Unable to enable Ranger plugin: {err}") from err
+        self.charm.state.policy_relation = f"relation_{event.relation.id}"
+        self._configure_ranger_plugin(container)
 
         users_and_groups = event.relation.data[event.app].get(
             "user-group-configuration"
@@ -166,6 +156,7 @@ class PolicyRelationHandler(framework.Object):
 
         try:
             self._disable_ranger_plugin(container)
+            self.charm.state.ranger_enabled = False
             logger.info("Ranger plugin disabled successfully")
         except ExecError as err:
             raise ExecError(f"Unable to disable Ranger plugin: {err}") from err
@@ -173,7 +164,23 @@ class PolicyRelationHandler(framework.Object):
         self.charm._restart_trino(container)
 
     @handle_exec_error
-    def _enable_plugin(self, container):
+    def _configure_ranger_plugin(self, container):
+        """Enable the ranger plugin for Trino.
+
+        Args:
+            container: The application container.
+        """
+        self._push_plugin_files(
+            container,
+            self.charm.state.policy_manager_url,
+            self.charm.state.policy_relation,
+        )
+        self._run_plugin_entrypoint(container)
+        self.charm.state.ranger_enabled = True
+        logger.info("Ranger plugin is enabled.")
+
+    @handle_exec_error
+    def _run_plugin_entrypoint(self, container):
         """Enable ranger plugin.
 
         Args:
@@ -189,7 +196,7 @@ class PolicyRelationHandler(framework.Object):
             environment=JAVA_ENV,
         ).wait()
 
-    def _configure_plugin_properties(
+    def _push_plugin_files(
         self, container, policy_manager_url, policy_relation
     ):
         """Configure the Ranger plugin install.properties file.
@@ -368,17 +375,20 @@ class PolicyRelationHandler(framework.Object):
         Args:
             container: application container
         """
-        command = [
-            "bash",
-            "disable-trino-plugin.sh",
-        ]
-        container.exec(
-            command,
-            working_dir=str(self.ranger_abs_path),
-            environment=JAVA_ENV,
-        ).wait()
+        if container.exists(f"{TRINO_PLUGIN_DIR}/ranger"):
+            command = [
+                "bash",
+                "disable-trino-plugin.sh",
+            ]
+            container.exec(
+                command,
+                working_dir=str(self.ranger_abs_path),
+                environment=JAVA_ENV,
+            ).wait()
 
-        container.remove_path(
-            self.charm.trino_abs_path.joinpath("access-control.properties"),
-            recursive=True,
-        )
+            container.remove_path(
+                self.charm.trino_abs_path.joinpath(
+                    "access-control.properties"
+                ),
+                recursive=True,
+            )

--- a/src/relations/policy.py
+++ b/src/relations/policy.py
@@ -375,20 +375,20 @@ class PolicyRelationHandler(framework.Object):
         Args:
             container: application container
         """
-        if container.exists(f"{TRINO_PLUGIN_DIR}/ranger"):
-            command = [
-                "bash",
-                "disable-trino-plugin.sh",
-            ]
-            container.exec(
-                command,
-                working_dir=str(self.ranger_abs_path),
-                environment=JAVA_ENV,
-            ).wait()
+        if not container.exists(f"{TRINO_PLUGIN_DIR}/ranger"):
+            return
 
-            container.remove_path(
-                self.charm.trino_abs_path.joinpath(
-                    "access-control.properties"
-                ),
-                recursive=True,
-            )
+        command = [
+            "bash",
+            "disable-trino-plugin.sh",
+        ]
+        container.exec(
+            command,
+            working_dir=str(self.ranger_abs_path),
+            environment=JAVA_ENV,
+        ).wait()
+
+        container.remove_path(
+            self.charm.trino_abs_path.joinpath("access-control.properties"),
+            recursive=True,
+        )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -56,6 +56,7 @@ GROUP_MANAGEMENT = """\
             description: commercial systems team
 """
 mock_incomplete_pebble_plan = {"services": {"trino": {"override": "replace"}}}
+RANGER_LIB = "/usr/lib/ranger"
 
 logger = logging.getLogger(__name__)
 
@@ -351,6 +352,15 @@ class TestCharm(TestCase):
         self.assertFalse(
             event.relation.data["ranger-k8s"].get("user-group-configuration")
         )
+
+    def test_restore_ranger_plugin(self):
+        """Restore plugin if lost."""
+        harness = self.harness
+        self.test_policy_relation_changed()
+        container = harness.model.unit.get_container("trino")
+        container.remove_path(RANGER_LIB, recursive=True)
+        harness.charm.on.trino_pebble_ready.emit(container)
+        assert container.exists(RANGER_LIB)
 
     def test_update_status_up(self):
         """The charm updates the unit status to active based on UP status."""


### PR DESCRIPTION
Fixes this bug: https://warthogs.atlassian.net/browse/CSS-8485

When the pod is evicted the container is terminated and a new container created. In this instance the files created on relation with ranger (to facilitate ranger authorization) are lost. This PR:
- Makes a distinct plugin configuration method that can be called outside of the ranger relation handlers. And renames some of the methods it calls.
- Stores in `state` relevant values relating to the Ranger relation and if it should be enabled.
- Checks when executing `update` if the plugin should be enabled but the required directory is missing. If so calls the configuration method to enable the plugin.

It also:
- Adds a check for the required plugin directory before disabling Ranger plugin. As if this is not present the plugin is already disabled.
- Adds a unit test (which validates a directory created with the ranger relation, is restored if dropped)
- Updates nginx and prometheus libs

If anyone knows how to simulate a pod termination (but not charm destory-application) please let me know -it would be good to follow up this PR with introducing an integration test.
