### PR TITLE
CSS-8769 Make oauth user mapping an optional config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -65,3 +65,8 @@ options:
     description: |
       Catalogs for which Trino should be connected.
     type: string
+  oauth-user-mapping:
+    description: |
+      Optional regex pattern with capture group to determine the username from oauth email.
+      ie. (.*)@.*
+    type: string 

--- a/config.yaml
+++ b/config.yaml
@@ -69,4 +69,4 @@ options:
     description: |
       Optional regex pattern with capture group to determine the username from oauth email.
       ie. (.*)@.*
-    type: string 
+    type: string

--- a/src/charm.py
+++ b/src/charm.py
@@ -377,6 +377,7 @@ class TrinoK8SCharm(CharmBase):
             "DEFAULT_PASSWORD": self.config["trino-password"],
             "OAUTH_CLIENT_ID": self.config.get("google-client-id"),
             "OAUTH_CLIENT_SECRET": self.config.get("google-client-secret"),
+            "OAUTH_USER_MAPPING": self.config.get("oauth-user-mapping"),
             "WEB_PROXY": self.config.get("web-proxy"),
             "CHARM_FUNCTION": self.config["charm-function"],
             "DISCOVERY_URI": self.config["discovery-uri"],

--- a/templates/config.jinja
+++ b/templates/config.jinja
@@ -21,7 +21,9 @@ http-server.authentication.allow-insecure-over-http=true
 {% if OAUTH_CLIENT_ID is not none and OAUTH_CLIENT_SECRET is not none %}
 http-server.authentication.type=oauth2,PASSWORD
 web-ui.authentication.type=oauth2
-http-server.authentication.oauth2.user-mapping.pattern=(.*)@.*
+    {% if OAUTH_USER_MAPPING is not none %}
+http-server.authentication.oauth2.user-mapping.pattern={{ OAUTH_USER_MAPPING }}
+    {% endif %}
 http-server.authentication.oauth2.issuer=https://accounts.google.com
 http-server.authentication.oauth2.principal-field=email
 http-server.authentication.oauth2.scopes=https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/userinfo.profile,openid

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -138,6 +138,7 @@ class TestCharm(TestCase):
                         "TRINO_HOME": "/usr/lib/trino/etc",
                         "JMX_PORT": 9081,
                         "METRICS_PORT": 9090,
+                        "OAUTH_USER_MAPPING": None,
                     },
                 }
             },
@@ -242,6 +243,7 @@ class TestCharm(TestCase):
                         "TRINO_HOME": "/usr/lib/trino/etc",
                         "JMX_PORT": 9081,
                         "METRICS_PORT": 9090,
+                        "OAUTH_USER_MAPPING": None,
                     },
                 }
             },


### PR DESCRIPTION
As our ldap synchronization will use email as the key we do not need any user mapping. While it's not needed for our use case it could still be useful for others who have a different source of users. Therefore instead of removing this value entirely this PR makes it an optional config.