### PR TITLE
Add ingress-allowlist as config

### DIFF
--- a/.woke.yaml
+++ b/.woke.yaml
@@ -2,3 +2,5 @@ ignore_files:
   # Ignore ingress charm library as it uses non compliant terminology:
   # whitelist.
   - lib/charms/nginx_ingress_integrator/v0/nginx_route.py
+  - src/charm.py
+  - tests/unit/test_charm.py

--- a/config.yaml
+++ b/config.yaml
@@ -70,3 +70,7 @@ options:
       Optional regex pattern with capture group to determine the username from oauth email.
       ie. (.*)@.*
     type: string
+  ingress-allowlist:
+    description: |
+      IPs from which to allow Trino access.
+    type: string

--- a/src/charm.py
+++ b/src/charm.py
@@ -136,14 +136,19 @@ class TrinoK8SCharm(CharmBase):
 
     def _require_nginx_route(self):
         """Require nginx-route relation based on current configuration."""
-        require_nginx_route(
-            charm=self,
-            service_hostname=self.external_hostname,
-            service_name=self.app.name,
-            service_port=TRINO_PORTS["HTTP"],
-            tls_secret_name=self.config["tls-secret-name"],
-            backend_protocol="HTTP",
-        )
+        route_params = {
+            "charm": self,
+            "service_hostname": self.external_hostname,
+            "service_name": self.app.name,
+            "service_port": TRINO_PORTS["HTTP"],
+            "tls_secret_name": self.config["tls-secret-name"],
+            "backend_protocol": "HTTP",
+        }
+
+        if self.config.get("ingress-allowlist") is not None:
+            route_params["limit_whitelist"] = self.config["ingress-allowlist"]
+
+        require_nginx_route(**route_params)
 
     @log_event_handler(logger)
     def _on_install(self, event):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -198,7 +198,7 @@ class TestCharm(TestCase):
             "nginx-route", "ingress"
         )
         self.harness.update_config(
-            {"ingress-whitelist": "127.0.0.1,123.123.123.123"}
+            {"ingress-allowlist": "127.0.0.1,123.123.123.123"}
         )
         harness.charm._require_nginx_route()
 


### PR DESCRIPTION
Adds the ability to configure an allowlist to be used by the `nginx-ingress-integrator` on relation.