### PR TITLE
Add trino default acls for fallback policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ In order to connect clustered database systems to Trino please connect the read-
 salesforce #read-write endpoint
 salesforce_ro #read-only endpoint
 ```
-## Relations
+## Policy
 ### Ranger
 Ranger acts as a fine-grained authorization manager for the Trino charm. It is an optional relation in order to provide access control on the data connected to Trino.
 
@@ -103,6 +103,7 @@ juju relate ranger-k8s postgresql-k8s
 # relate trino-k8s ranger-k8s
 juju relate trino-k8s ranger-k8s
 ```
+By default Trino has an allow all access control policy. If you're using an alternative to Trino's built-in ACLs (ie Ranger) then you can configure the default Trino policy to default to `none`. This will deny all access in the case that Ranger is unavailable.
 
 ### Observability
 

--- a/config.yaml
+++ b/config.yaml
@@ -70,3 +70,23 @@ options:
       Optional regex pattern with capture group to determine the username from oauth email.
       ie. (.*)@.*
     type: string
+  acl-mode-default:
+    description: |
+      The default ACLs for all Trino catalogs, one of `all` or `none`.
+      `all`: Allow all users access to all catalogs.
+      `none`: Deny all users access to all catalogs.
+      A Ranger relation will supersede this default.
+    type: string
+    default: all
+  acl-user-pattern:
+    description: |
+      The pattern to match users, for which the policy should be applied.
+      The default value `.*` applies to all users.
+    type: string
+    default: .*
+  acl-catalog-pattern:
+    description: |
+      The pattern to match catalog names, for which the policy should be applied.
+      The default value `.*` applies to all catalogs.
+    type: string
+    default: .*

--- a/src/literals.py
+++ b/src/literals.py
@@ -25,6 +25,8 @@ CONFIG_FILES = {
     "config.jinja": "config.properties",
     "logging.jinja": "log.properties",
     "password-authenticator.jinja": "password-authenticator.properties",
+    "access-control.jinja": "access-control.properties",
+    "rules.jinja": "rules.json",
 }
 
 CONF_DIR = "conf"
@@ -39,7 +41,6 @@ PASSWORD_DB = "password.db"  # nosec
 RANGER_PLUGIN_VERSION = "2.4.0"
 RANGER_PLUGIN_HOME = "/usr/lib/ranger"
 RANGER_PLUGIN_FILES = {
-    "access-control.properties": "access-control.properties",
     "ranger-plugin.jinja": "install.properties",
 }
 

--- a/src/relations/policy.py
+++ b/src/relations/policy.py
@@ -202,10 +202,7 @@ class PolicyRelationHandler(framework.Object):
         }
         for template, file in RANGER_PLUGIN_FILES.items():
             content = render(template, policy_context)
-            if file == "access-control.properties":
-                path = self.charm.trino_abs_path.joinpath(file)
-            else:
-                path = self.ranger_abs_path.joinpath(file)
+            path = self.ranger_abs_path.joinpath(file)
             container.push(path, content, make_dirs=True, permissions=0o744)
 
     @handle_exec_error
@@ -227,8 +224,3 @@ class PolicyRelationHandler(framework.Object):
             working_dir=str(self.ranger_abs_path),
             environment=JAVA_ENV,
         ).wait()
-
-        container.remove_path(
-            self.charm.trino_abs_path.joinpath("access-control.properties"),
-            recursive=True,
-        )

--- a/templates/access-control.jinja
+++ b/templates/access-control.jinja
@@ -1,0 +1,9 @@
+{% if RANGER_RELATION == true %}
+access-control.name=ranger
+ranger.use_ugi=true
+
+{% else %}
+access-control.name=file
+security.config-file={{ TRINO_HOME }}/rules.json
+
+{% endif %}

--- a/templates/access-control.properties
+++ b/templates/access-control.properties
@@ -1,2 +1,0 @@
-access-control.name=ranger
-ranger.use_ugi=true

--- a/templates/rules.jinja
+++ b/templates/rules.jinja
@@ -1,0 +1,9 @@
+{
+    "catalogs": [
+        {
+            "user": "{{ ACL_USER_PATTERN }}",
+            "catalog": "{{ ACL_CATALOG_PATTERN }}",
+            "allow": "{{ ACL_ACCESS_MODE }}"
+        }
+    ]
+}

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -73,3 +73,15 @@ class TestDeployment:
 
         catalogs = await get_catalogs(ops_test, TRINO_USER, APP_NAME)
         assert TEMP_CATALOG_NAME in str(catalogs)
+
+    async def test_trino_default_policy(self, ops_test: OpsTest):
+        """Update the config and verify no catalog access."""
+        await ops_test.model.applications[APP_NAME].set_config(
+            {"access-control-default": "none"}
+        )
+
+        async with ops_test.fast_forward():
+            await ops_test.model.wait_for_idle(status="active", timeout=600)
+        catalogs = await get_catalogs(ops_test, TRINO_USER, APP_NAME)
+        logging.info(f"Found catalogs: {catalogs}")
+        assert not catalogs

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -139,6 +139,10 @@ class TestCharm(TestCase):
                         "JMX_PORT": 9081,
                         "METRICS_PORT": 9090,
                         "OAUTH_USER_MAPPING": None,
+                        "RANGER_RELATION": False,
+                        "ACL_ACCESS_MODE": "all",
+                        "ACL_CATALOG_PATTERN": ".*",
+                        "ACL_USER_PATTERN": ".*",
                     },
                 }
             },
@@ -244,6 +248,10 @@ class TestCharm(TestCase):
                         "JMX_PORT": 9081,
                         "METRICS_PORT": 9090,
                         "OAUTH_USER_MAPPING": None,
+                        "RANGER_RELATION": False,
+                        "ACL_ACCESS_MODE": "all",
+                        "ACL_CATALOG_PATTERN": ".*",
+                        "ACL_USER_PATTERN": ".*",
                     },
                 }
             },
@@ -311,17 +319,7 @@ class TestCharm(TestCase):
         rel_id = harness.add_relation("policy", "trino-k8s")
         harness.add_relation_unit(rel_id, "trino-k8s/0")
 
-        # Create handlers for Container.exec() commands
-        for command in [
-            "bash",
-            "tar",
-            "useradd",
-            "groupadd",
-            "usermod",
-            "deluser",
-        ]:
-            harness.handle_exec("trino", [command], result=0)
-        harness.handle_exec("trino", ["getent"], handler=group_handler)
+        harness.handle_exec("trino", ["bash"], result=0)
 
         # Create and emit the policy `_on_relation_changed` event.
         data = {


### PR DESCRIPTION
In the case that the Ranger plugin is disabled, Trino can use a flat file for determining access. This PR introduces the most basic functionality in this case. It provides a config parameter which can be set to `all` to allow all access, or `none` to deny all access.

It also allows this to be customized for specific users and catalogs in a limited way. Please note I have not added regex validation as I intend to follow this PR up with one implementing a structured config in which I will also add this validation.