### PR TITLE
CSS-9167 Update uri to be full k8s service address

### DIFF
--- a/src/relations/policy.py
+++ b/src/relations/policy.py
@@ -111,7 +111,8 @@ class PolicyRelationHandler(framework.Object):
         """
         host = self.charm.app.name
         port = TRINO_PORTS["HTTP"]
-        uri = f"{host}:{port}"
+        namespace = self.model.name
+        uri = f"{host}.{namespace}.svc.cluster.local:{port}"
 
         service_name = (
             self.charm.config.get("ranger-service-name")

--- a/tests/unit/test_policy.py
+++ b/tests/unit/test_policy.py
@@ -60,7 +60,7 @@ class TestPolicy(TestCase):
             "name": f"relation_{rel_id}",
             "type": "trino",
             "jdbc.driverClassName": "io.trino.jdbc.TrinoDriver",
-            "jdbc.url": "jdbc:trino://trino-k8s:8080",
+            "jdbc.url": "jdbc:trino://trino-k8s.trino-model.svc.cluster.local:8080",
         }
 
     def test_policy_relation_changed(self):


### PR DESCRIPTION
As Ranger and Trino may not be deployed to the same model (as in our case) we need to provide the full address of the service.