### PR TITLE
CSS-10040 adds storage for ranger policy cache

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -23,12 +23,20 @@ issues: https://github.com/canonical/trino-k8s-operator/issues
 containers:
   trino:
     resource: trino-image
+    mounts:
+      - storage: policy
+        location: /etc/ranger
 
 resources:
   trino-image:
     type: oci-image
     description: OCI image for trino
     upstream-source: ghcr.io/canonical/charmed-trino-rock:418-22.04-edge
+
+storage:
+  policy:
+    type: filesystem
+    location: /etc/ranger
 
 requires:
   nginx-route:


### PR DESCRIPTION
In the event that Ranger becomes unavailable, Trino will still be able to determine access controls based on its `policycache` - this PR mounts that as a volume so as to persist it. 

Please note: the upgrade in place does not work when the storage has been changed between upgrades. Therefore the safe-upgrade integration test is expected to fail, as this change is breaking. This test will still be relevant and expect to pass for future upgrades where no change has been made to the storage.