### PR TITLE
CSS-10079 Add dns override for ranger policy manager

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -33,6 +33,12 @@ options:
     description: |
       The service name for Trino in Apache Ranger when related. Defaults to relation id.
     type: string
+  ranger-dns-override:
+    description: |
+      The DNS of Ranger admin to be used to override the address sent by the relation.
+      Required for cross-controller relations for disaster recovery.
+      eg. "https://ranger-admin.com"
+    type: string
   external-hostname:
     description: |
         The DNS listing used for external connections. 

--- a/src/relations/policy.py
+++ b/src/relations/policy.py
@@ -203,7 +203,8 @@ class PolicyRelationHandler(framework.Object):
         ):
             self.charm.opensearch_relation_handler.update_certificates()
         policy_context = {
-            "POLICY_MGR_URL": policy_manager_url,
+            "POLICY_MGR_URL": self.charm.config.get("ranger-dns-override")
+            or policy_manager_url,
             "REPOSITORY_NAME": self.charm.config.get("ranger-service-name")
             or policy_relation,
             "RANGER_RELATION": True,


### PR DESCRIPTION
The policy-manager-url relation value passed from Ranger is a k8s address for applications deployed on the same cluster. To support a disaster recovery architecture where trino should be deployed to another K8s cluster then the ranger policy manager dns should be provided as an overriding value. 

I decided not to pass the DNS as the default as the ranger plugin requires that this DNS have a valid certificate authority - meaning it adds additional complexity for integration testing and development if the DNS is provided directly in the relation.