### PR TITLE
update secret structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Additionally user/password authentication can be enabled via a Juju secret.
 
 ```
 # Create the secret and grant access to Trino.
-juju add-secret trino-user-management --file /path/to/user-secrets.yaml
+juju add-secret trino-user-management users#file=/path/to/user-secrets.yaml
 juju grant-secret trino-user-management trino-k8s
 juju grant-secret trino-user-management trino-k8s-worker
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -363,11 +363,17 @@ class TrinoK8SCharm(CharmBase):
         secret_id = self.config.get("user-secret-id")
         db_path = str(self.trino_abs_path.joinpath(PASSWORD_DB))
 
-        credentials = (
-            self._get_secret_content(secret_id)
-            if secret_id
-            else DEFAULT_CREDENTIALS
-        )
+        if secret_id:
+            try:
+                credentials = yaml.safe_load(
+                    self._get_secret_content(secret_id)["users"]
+                )
+            except yaml.ScannerError as e:
+                raise yaml.ScannerError(
+                    f"Incorrectly formatted user secret: {e}"
+                )
+        else:
+            credentials = DEFAULT_CREDENTIALS
 
         add_users_to_password_db(container, credentials, db_path)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -354,6 +354,9 @@ class TrinoK8SCharm(CharmBase):
 
         Args:
             event: The pebble ready or config changed event.
+
+        Raises:
+            ScannerError: In case the secret is incorrectly formatted.
         """
         container = self.unit.get_container(self.name)
         if not container.can_connect():

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -40,3 +40,7 @@ POLICY_MGR_URL = "http://ranger-k8s:6080"
 RANGER_LIB = "/usr/lib/ranger"
 
 JAVA_HOME = "/usr/lib/jvm/java-21-openjdk-amd64"
+TEST_USERS = """\
+    example_user: ubuntu123
+    another_user: ubuntu345
+"""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -25,6 +25,7 @@ from unit.helpers import (
     SERVER_PORT,
     TEST_CATALOG_CONFIG,
     TEST_CATALOG_PATH,
+    TEST_USERS,
     UPDATED_CATALOG_CONFIG,
     UPDATED_CATALOG_PATH,
 )
@@ -484,7 +485,7 @@ def simulate_lifecycle_coordinator(harness):
     rel_id = harness.add_relation("trino-coordinator", "trino-k8s-worker")
     secret_id = harness.add_model_secret(
         "trino-k8s",
-        {"trino": "ubuntu123"},
+        {"users": TEST_USERS},
     )
 
     harness.update_config({"user-secret-id": secret_id})


### PR DESCRIPTION
Update the secret structure to store all usernames and passwords under 1 key. This is due to juju secret keys not being allowed to include `_` this provides the flexibility to have the usernames contain this character.