### PR TITLE
CSS-10284 Make Trino jvm options configurable

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -89,3 +89,49 @@ options:
     description: |
       The Juju secret id for the Trino user credentials.
     type: string
+  xmx-size:
+    description: |
+      Maximum heap size for the JVM.
+    type: string
+    default: '2G'
+  initial-ram-percentage:
+    description: |
+      Percentage of total RAM to be allocated as initial heap size.
+    type: int
+    default: 80
+  max-ram-percentage:
+    description: |
+      Maximum percentage of total RAM to be used by the JVM.
+    type: int
+    default: 80
+  heap-region-size:
+    description: |
+      Size of each heap region for the JVM's garbage collector.
+    type: string
+    default: '32M'
+  reserved-cache-size:
+    description: |
+      Amount of memory reserved for the JVM's code cache.
+    type: string
+    default: '512M'
+  retry-allocation-count:
+    description: |
+      Number of times to retry memory allocation during GC.
+    type: int
+    default: 32
+  additional-jvm-options:
+    description: |
+      Space separated string of JVM options to be added to the config file.
+      If no value if provided then the following are included by default:
+        -XX:+ExplicitGCInvokesConcurrent
+        -XX:+ExitOnOutOfMemoryError
+        -XX:+HeapDumpOnOutOfMemoryError
+        -XX:-OmitStackTraceInFastThrow
+        -XX:PerMethodRecompilationCutoff=10000
+        -XX:PerBytecodeRecompilationCutoff=10000
+        -Djdk.attach.allowAttachSelf=true
+        -Djdk.nio.maxCachedBufferSize=2000000
+        -Dfile.encoding=UTF-8
+        -XX:+UnlockDiagnosticVMOptions
+        -XX:+EnableDynamicAgentLoading
+    type: string

--- a/config.yaml
+++ b/config.yaml
@@ -89,48 +89,16 @@ options:
     description: |
       The Juju secret id for the Trino user credentials.
     type: string
-  xmx-size:
-    description: |
-      Maximum heap size for the JVM.
-    type: string
-    default: '2G'
-  initial-ram-percentage:
-    description: |
-      Percentage of total RAM to be allocated as initial heap size.
-    type: int
-    default: 80
-  max-ram-percentage:
-    description: |
-      Maximum percentage of total RAM to be used by the JVM.
-    type: int
-    default: 80
-  heap-region-size:
-    description: |
-      Size of each heap region for the JVM's garbage collector.
-    type: string
-    default: '32M'
-  reserved-cache-size:
-    description: |
-      Amount of memory reserved for the JVM's code cache.
-    type: string
-    default: '512M'
-  retry-allocation-count:
-    description: |
-      Number of times to retry memory allocation during GC.
-    type: int
-    default: 32
   additional-jvm-options:
     description: |
-      Space separated string of JVM options to be added to the config file.
-      If no value if provided then the following are included by default:
-        -XX:+ExplicitGCInvokesConcurrent
-        -XX:+ExitOnOutOfMemoryError
-        -XX:+HeapDumpOnOutOfMemoryError
-        -XX:-OmitStackTraceInFastThrow
-        -XX:PerMethodRecompilationCutoff=10000
-        -XX:PerBytecodeRecompilationCutoff=10000
-        -Djdk.attach.allowAttachSelf=true
-        -Djdk.nio.maxCachedBufferSize=2000000
-        -Dfile.encoding=UTF-8
-        -XX:+EnableDynamicAgentLoading
+      Space-separated string of JVM options to be added to the config file.
+      By default the following options are included. 
+      The value of the option can be overwritten by providing the option 
+      with the updated value via this config parameter.
+        "-Xmx2G"
+        "-XX:InitialRAMPercentage=80"
+        "-XX:+ExplicitGCInvokesConcurrent"
+        "-XX:-OmitStackTraceInFastThrow"
+        "-Djdk.attach.allowAttachSelf=true"
+        "-Dfile.encoding=UTF-8"
     type: string

--- a/config.yaml
+++ b/config.yaml
@@ -132,6 +132,5 @@ options:
         -Djdk.attach.allowAttachSelf=true
         -Djdk.nio.maxCachedBufferSize=2000000
         -Dfile.encoding=UTF-8
-        -XX:+UnlockDiagnosticVMOptions
         -XX:+EnableDynamicAgentLoading
     type: string

--- a/src/charm.py
+++ b/src/charm.py
@@ -60,6 +60,7 @@ from utils import (
     create_cert_and_catalog_dicts,
     generate_password,
     render,
+    update_opts,
 )
 
 # Log messages can be retrieved using juju debug-log
@@ -523,7 +524,13 @@ class TrinoK8SCharm(CharmBase):
             env: a dictionary of trino environment variables.
         """
         db_path = self.trino_abs_path.joinpath(PASSWORD_DB)
-        default_jvm_options = " ".join(DEFAULT_JVM_OPTIONS)
+        default_opts = " ".join(DEFAULT_JVM_OPTIONS)
+        user_opts = self.config.get("additional-jvm-options")
+
+        jvm_opts = (
+            update_opts(default_opts, user_opts) if user_opts else default_opts
+        )
+
         env = {
             "LOG_LEVEL": self.config["log-level"],
             "OAUTH_CLIENT_ID": self.config.get("google-client-id"),
@@ -546,18 +553,7 @@ class TrinoK8SCharm(CharmBase):
             "ACL_CATALOG_PATTERN": self.config["acl-catalog-pattern"],
             "JAVA_TRUSTSTORE_PWD": self.state.java_truststore_pwd,
             "USER_SECRET_ID": self.config.get("user-secret-id"),
-            "XMX_SIZE": self.config.get("xmx-size"),
-            "INITIAL_RAM_PERCENTAGE": self.config.get(
-                "initial-ram-percentage"
-            ),
-            "MAX_RAM_PERCENTAGE": self.config.get("max-ram-percentage"),
-            "HEAP_REGION_SIZE": self.config.get("heap-region-size"),
-            "RESERVED_CACHE_SIZE": self.config.get("reserved-cache-size"),
-            "RETRY_ALLOCATION_COUNT": self.config.get(
-                "retry-allocation-count"
-            ),
-            "ADDITIONAL_JVM_OPTIONS": self.config.get("additional-jvm-options")
-            or default_jvm_options,
+            "JVM_OPTIONS": jvm_opts,
         }
         return env
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -36,6 +36,7 @@ from literals import (
     CONF_DIR,
     CONFIG_FILES,
     DEFAULT_CREDENTIALS,
+    DEFAULT_JVM_OPTIONS,
     INDEX_NAME,
     JAVA_HOME,
     JMX_PORT,
@@ -522,6 +523,7 @@ class TrinoK8SCharm(CharmBase):
             env: a dictionary of trino environment variables.
         """
         db_path = self.trino_abs_path.joinpath(PASSWORD_DB)
+        default_jvm_options = " ".join(DEFAULT_JVM_OPTIONS)
         env = {
             "LOG_LEVEL": self.config["log-level"],
             "OAUTH_CLIENT_ID": self.config.get("google-client-id"),
@@ -544,6 +546,18 @@ class TrinoK8SCharm(CharmBase):
             "ACL_CATALOG_PATTERN": self.config["acl-catalog-pattern"],
             "JAVA_TRUSTSTORE_PWD": self.state.java_truststore_pwd,
             "USER_SECRET_ID": self.config.get("user-secret-id"),
+            "XMX_SIZE": self.config.get("xmx-size"),
+            "INITIAL_RAM_PERCENTAGE": self.config.get(
+                "initial-ram-percentage"
+            ),
+            "MAX_RAM_PERCENTAGE": self.config.get("max-ram-percentage"),
+            "HEAP_REGION_SIZE": self.config.get("heap-region-size"),
+            "RESERVED_CACHE_SIZE": self.config.get("reserved-cache-size"),
+            "RETRY_ALLOCATION_COUNT": self.config.get(
+                "retry-allocation-count"
+            ),
+            "ADDITIONAL_JVM_OPTIONS": self.config.get("additional-jvm-options")
+            or default_jvm_options,
         }
         return env
 

--- a/src/literals.py
+++ b/src/literals.py
@@ -112,3 +112,17 @@ INDEX_NAME = "ranger_audits"
 CERTIFICATE_NAME = "opensearch-ca"
 
 DEFAULT_CREDENTIALS = {"trino": "trinoR0cks!"}
+
+DEFAULT_JVM_OPTIONS = [
+    "-XX:+ExplicitGCInvokesConcurrent",
+    "-XX:+ExitOnOutOfMemoryError",
+    "-XX:+HeapDumpOnOutOfMemoryError",
+    "-XX:-OmitStackTraceInFastThrow",
+    "-XX:PerMethodRecompilationCutoff=10000",
+    "-XX:PerBytecodeRecompilationCutoff=10000",
+    "-Djdk.attach.allowAttachSelf=true",
+    "-Djdk.nio.maxCachedBufferSize=2000000",
+    "-Dfile.encoding=UTF-8",
+    "-XX:+UnlockDiagnosticVMOptions",
+    "-XX:+EnableDynamicAgentLoading",
+]

--- a/src/literals.py
+++ b/src/literals.py
@@ -123,6 +123,5 @@ DEFAULT_JVM_OPTIONS = [
     "-Djdk.attach.allowAttachSelf=true",
     "-Djdk.nio.maxCachedBufferSize=2000000",
     "-Dfile.encoding=UTF-8",
-    "-XX:+UnlockDiagnosticVMOptions",
     "-XX:+EnableDynamicAgentLoading",
 ]

--- a/src/literals.py
+++ b/src/literals.py
@@ -114,14 +114,10 @@ CERTIFICATE_NAME = "opensearch-ca"
 DEFAULT_CREDENTIALS = {"trino": "trinoR0cks!"}
 
 DEFAULT_JVM_OPTIONS = [
+    "-Xmx2G",
+    "-XX:InitialRAMPercentage=80",
     "-XX:+ExplicitGCInvokesConcurrent",
-    "-XX:+ExitOnOutOfMemoryError",
-    "-XX:+HeapDumpOnOutOfMemoryError",
     "-XX:-OmitStackTraceInFastThrow",
-    "-XX:PerMethodRecompilationCutoff=10000",
-    "-XX:PerBytecodeRecompilationCutoff=10000",
     "-Djdk.attach.allowAttachSelf=true",
-    "-Djdk.nio.maxCachedBufferSize=2000000",
     "-Dfile.encoding=UTF-8",
-    "-XX:+EnableDynamicAgentLoading",
 ]

--- a/src/utils.py
+++ b/src/utils.py
@@ -250,28 +250,6 @@ def add_users_to_password_db(container, credentials, db_path):
             raise
 
 
-def get_opt_name(opt: str):
-    """Extract the name or key from a given option string.
-
-    Args:
-        opt: The option string from which to extract the key or name.
-
-    Returns:
-        opt: The extracted key or name if a match is found, otherwise the
-        original option string.
-    """
-    patterns_index = [
-        (r"^-X[a-z]+", 0),
-        (r"^-XX:[+-](\w+)", 1),
-        (r"^(.*?)=", 1),
-    ]
-    for pi in patterns_index:
-        match = re.match(pi[0], opt)
-        if match:
-            return match.group(pi[1])
-    return opt
-
-
 def update_opts(default_opts, user_opts):
     """Update the default options with user-provided options.
 
@@ -282,6 +260,28 @@ def update_opts(default_opts, user_opts):
     Returns:
         Combined options, with user options overriding any matching default options.
     """
+
+    def get_opt_name(opt: str):
+        """Extract the name or key from a given option string.
+
+        Args:
+            opt: The option string from which to extract the key or name.
+
+        Returns:
+            opt: The extracted key or name if a match is found, otherwise the
+            original option string.
+        """
+        patterns_index = [
+            (r"^-X[a-z]+", 0),
+            (r"^-XX:[+-](\w+)", 1),
+            (r"^(.*?)=", 1),
+        ]
+        for pi in patterns_index:
+            match = re.match(pi[0], opt)
+            if match:
+                return match.group(pi[1])
+        return opt
+
     def_dict = {get_opt_name(opt): opt for opt in default_opts.split()}
     user_dict = {get_opt_name(opt): opt for opt in user_opts.split()}
     def_dict.update(user_dict)

--- a/src/utils.py
+++ b/src/utils.py
@@ -248,3 +248,41 @@ def add_users_to_password_db(container, credentials, db_path):
         except (subprocess.CalledProcessError, ExecError) as e:
             logger.error(f"unable to add user credentials {e.stderr}")
             raise
+
+
+def get_opt_name(opt: str):
+    """Extract the name or key from a given option string.
+
+    Args:
+        opt: The option string from which to extract the key or name.
+
+    Returns:
+        opt: The extracted key or name if a match is found, otherwise the
+        original option string.
+    """
+    patterns_index = [
+        (r"^-X[a-z]+", 0),
+        (r"^-XX:[+-](\w+)", 1),
+        (r"^(.*?)=", 1),
+    ]
+    for pi in patterns_index:
+        match = re.match(pi[0], opt)
+        if match:
+            return match.group(pi[1])
+    return opt
+
+
+def update_opts(default_opts, user_opts):
+    """Update the default options with user-provided options.
+
+    Args:
+        default_opts: The jvm default options.
+        user_opts: The user options that may override the defaults.
+
+    Returns:
+        Combined options, with user options overriding any matching default options.
+    """
+    def_dict = {get_opt_name(opt): opt for opt in default_opts.split()}
+    user_dict = {get_opt_name(opt): opt for opt in user_opts.split()}
+    def_dict.update(user_dict)
+    return " ".join(def_dict.values())

--- a/templates/jvm.jinja
+++ b/templates/jvm.jinja
@@ -1,4 +1,5 @@
 -server
+-XX:+UnlockDiagnosticVMOptions
 -Xmx{{ XMX_SIZE }}
 -XX:InitialRAMPercentage={{ INITIAL_RAM_PERCENTAGE }}
 -XX:MaxRAMPercentage={{ MAX_RAM_PERCENTAGE }}

--- a/templates/jvm.jinja
+++ b/templates/jvm.jinja
@@ -1,14 +1,8 @@
 -server
 -XX:+UnlockDiagnosticVMOptions
--Xmx{{ XMX_SIZE }}
--XX:InitialRAMPercentage={{ INITIAL_RAM_PERCENTAGE }}
--XX:MaxRAMPercentage={{ MAX_RAM_PERCENTAGE }}
--XX:G1HeapRegionSize={{ HEAP_REGION_SIZE }}
--XX:ReservedCodeCacheSize={{ RESERVED_CACHE_SIZE }}
--XX:GCLockerRetryAllocationCount={{ RETRY_ALLOCATION_COUNT }}
-# Additional JVM options
-{%- if ADDITIONAL_JVM_OPTIONS -%}
-{% set jvm_options = ADDITIONAL_JVM_OPTIONS.split(" ") %}
+# JVM options
+{%- if JVM_OPTIONS -%}
+{% set jvm_options = JVM_OPTIONS.split(" ") %}
 {% for option in jvm_options -%}
 {{ option }}
 {% endfor -%}

--- a/templates/jvm.jinja
+++ b/templates/jvm.jinja
@@ -1,23 +1,17 @@
 -server
--Xmx16G
--XX:InitialRAMPercentage=80
--XX:MaxRAMPercentage=80
--XX:G1HeapRegionSize=32M
--XX:+ExplicitGCInvokesConcurrent
--XX:+ExitOnOutOfMemoryError
--XX:+HeapDumpOnOutOfMemoryError
--XX:-OmitStackTraceInFastThrow
--XX:ReservedCodeCacheSize=512M
--XX:PerMethodRecompilationCutoff=10000
--XX:PerBytecodeRecompilationCutoff=10000
--Djdk.attach.allowAttachSelf=true
--Djdk.nio.maxCachedBufferSize=2000000
--Dfile.encoding=UTF-8
-# Reduce starvation of threads by GClocker, recommend to set about the number of cpu cores (JDK-8192647)
--XX:+UnlockDiagnosticVMOptions
--XX:GCLockerRetryAllocationCount=32
-# Allow loading dynamic agent used by JOL
--XX:+EnableDynamicAgentLoading
+-Xmx{{ XMX_SIZE }}
+-XX:InitialRAMPercentage={{ INITIAL_RAM_PERCENTAGE }}
+-XX:MaxRAMPercentage={{ MAX_RAM_PERCENTAGE }}
+-XX:G1HeapRegionSize={{ HEAP_REGION_SIZE }}
+-XX:ReservedCodeCacheSize={{ RESERVED_CACHE_SIZE }}
+-XX:GCLockerRetryAllocationCount={{ RETRY_ALLOCATION_COUNT }}
+# Additional JVM options
+{%- if ADDITIONAL_JVM_OPTIONS -%}
+{% set jvm_options = ADDITIONAL_JVM_OPTIONS.split(" ") %}
+{% for option in jvm_options -%}
+{{ option }}
+{% endfor -%}
+{% endif %}
 # Default Java truststore
 -Djavax.net.ssl.trustStorePassword={{ JAVA_TRUSTSTORE_PWD }}
 # jmx

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -45,21 +45,26 @@ TEST_USERS = """\
     another_user: ubuntu345
 """
 
-DEFAULT_JVM_OPTIONS = [
-    "-XX:+ExplicitGCInvokesConcurrent",
-    "-XX:+ExitOnOutOfMemoryError",
-    "-XX:+HeapDumpOnOutOfMemoryError",
-    "-XX:-OmitStackTraceInFastThrow",
-    "-XX:PerMethodRecompilationCutoff=10000",
-    "-XX:PerBytecodeRecompilationCutoff=10000",
-    "-Djdk.attach.allowAttachSelf=true",
-    "-Djdk.nio.maxCachedBufferSize=2000000",
-    "-Dfile.encoding=UTF-8",
-    "-XX:+EnableDynamicAgentLoading",
-]
+DEFAULT_JVM_STRING = " ".join(
+    [
+        "-Xmx2G",
+        "-XX:InitialRAMPercentage=80",
+        "-XX:+ExplicitGCInvokesConcurrent",
+        "-XX:-OmitStackTraceInFastThrow",
+        "-Djdk.attach.allowAttachSelf=true",
+        "-Dfile.encoding=UTF-8",
+    ]
+)
 
-DEFAULT_JVM_STRING = " ".join(DEFAULT_JVM_OPTIONS)
-
-CUSTOMIZED_JVM_STRING = (
-    "-XX:+ExplicitGCInvokesConcurrent -XX:+ExitOnOutOfMemoryError"
+USER_JVM_STRING = "-Xmx4G -XX:InitialRAMPercentage=50 -Xxs10G"
+UPDATED_JVM_OPTIONS = " ".join(
+    [
+        "-Xmx4G",
+        "-XX:InitialRAMPercentage=50",
+        "-XX:+ExplicitGCInvokesConcurrent",
+        "-XX:-OmitStackTraceInFastThrow",
+        "-Djdk.attach.allowAttachSelf=true",
+        "-Dfile.encoding=UTF-8",
+        "-Xxs10G",
+    ]
 )

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -44,3 +44,23 @@ TEST_USERS = """\
     example_user: ubuntu123
     another_user: ubuntu345
 """
+
+DEFAULT_JVM_OPTIONS = [
+    "-XX:+ExplicitGCInvokesConcurrent",
+    "-XX:+ExitOnOutOfMemoryError",
+    "-XX:+HeapDumpOnOutOfMemoryError",
+    "-XX:-OmitStackTraceInFastThrow",
+    "-XX:PerMethodRecompilationCutoff=10000",
+    "-XX:PerBytecodeRecompilationCutoff=10000",
+    "-Djdk.attach.allowAttachSelf=true",
+    "-Djdk.nio.maxCachedBufferSize=2000000",
+    "-Dfile.encoding=UTF-8",
+    "-XX:+UnlockDiagnosticVMOptions",
+    "-XX:+EnableDynamicAgentLoading",
+]
+
+DEFAULT_JVM_STRING = " ".join(DEFAULT_JVM_OPTIONS)
+
+CUSTOMIZED_JVM_STRING = (
+    "-XX:+ExplicitGCInvokesConcurrent -XX:+ExitOnOutOfMemoryError"
+)

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -55,7 +55,6 @@ DEFAULT_JVM_OPTIONS = [
     "-Djdk.attach.allowAttachSelf=true",
     "-Djdk.nio.maxCachedBufferSize=2000000",
     "-Dfile.encoding=UTF-8",
-    "-XX:+UnlockDiagnosticVMOptions",
     "-XX:+EnableDynamicAgentLoading",
 ]
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -21,7 +21,6 @@ from ops.model import (
 from ops.pebble import CheckStatus
 from ops.testing import Harness
 from unit.helpers import (
-    CUSTOMIZED_JVM_STRING,
     DEFAULT_JVM_STRING,
     JAVA_HOME,
     SERVER_PORT,
@@ -30,6 +29,8 @@ from unit.helpers import (
     TEST_USERS,
     UPDATED_CATALOG_CONFIG,
     UPDATED_CATALOG_PATH,
+    UPDATED_JVM_OPTIONS,
+    USER_JVM_STRING,
 )
 
 from charm import TrinoK8SCharm
@@ -124,13 +125,7 @@ class TestCharm(TestCase):
                         "ACL_USER_PATTERN": ".*",
                         "JAVA_TRUSTSTORE_PWD": "truststore_pwd",
                         "USER_SECRET_ID": "secret:secret-id",
-                        "XMX_SIZE": "2G",
-                        "INITIAL_RAM_PERCENTAGE": 80,
-                        "MAX_RAM_PERCENTAGE": 80,
-                        "HEAP_REGION_SIZE": "32M",
-                        "RESERVED_CACHE_SIZE": "512M",
-                        "RETRY_ALLOCATION_COUNT": 32,
-                        "ADDITIONAL_JVM_OPTIONS": DEFAULT_JVM_STRING,
+                        "JVM_OPTIONS": DEFAULT_JVM_STRING,
                     },
                 }
             },
@@ -226,7 +221,7 @@ class TestCharm(TestCase):
                 "google-client-secret": "test-client-secret",
                 "web-proxy": "proxy:port",
                 "charm-function": "all",
-                "additional-jvm-options": CUSTOMIZED_JVM_STRING,
+                "additional-jvm-options": USER_JVM_STRING,
             }
         )
 
@@ -259,13 +254,7 @@ class TestCharm(TestCase):
                         "ACL_USER_PATTERN": ".*",
                         "JAVA_TRUSTSTORE_PWD": "truststore_pwd",
                         "USER_SECRET_ID": "secret:secret-id",
-                        "XMX_SIZE": "2G",
-                        "INITIAL_RAM_PERCENTAGE": 80,
-                        "MAX_RAM_PERCENTAGE": 80,
-                        "HEAP_REGION_SIZE": "32M",
-                        "RESERVED_CACHE_SIZE": "512M",
-                        "RETRY_ALLOCATION_COUNT": 32,
-                        "ADDITIONAL_JVM_OPTIONS": CUSTOMIZED_JVM_STRING,
+                        "JVM_OPTIONS": UPDATED_JVM_OPTIONS,
                     },
                 }
             },

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -21,6 +21,8 @@ from ops.model import (
 from ops.pebble import CheckStatus
 from ops.testing import Harness
 from unit.helpers import (
+    CUSTOMIZED_JVM_STRING,
+    DEFAULT_JVM_STRING,
     JAVA_HOME,
     SERVER_PORT,
     TEST_CATALOG_CONFIG,
@@ -122,6 +124,13 @@ class TestCharm(TestCase):
                         "ACL_USER_PATTERN": ".*",
                         "JAVA_TRUSTSTORE_PWD": "truststore_pwd",
                         "USER_SECRET_ID": "secret:secret-id",
+                        "XMX_SIZE": "2G",
+                        "INITIAL_RAM_PERCENTAGE": 80,
+                        "MAX_RAM_PERCENTAGE": 80,
+                        "HEAP_REGION_SIZE": "32M",
+                        "RESERVED_CACHE_SIZE": "512M",
+                        "RETRY_ALLOCATION_COUNT": 32,
+                        "ADDITIONAL_JVM_OPTIONS": DEFAULT_JVM_STRING,
                     },
                 }
             },
@@ -217,6 +226,7 @@ class TestCharm(TestCase):
                 "google-client-secret": "test-client-secret",
                 "web-proxy": "proxy:port",
                 "charm-function": "all",
+                "additional-jvm-options": CUSTOMIZED_JVM_STRING,
             }
         )
 
@@ -249,6 +259,13 @@ class TestCharm(TestCase):
                         "ACL_USER_PATTERN": ".*",
                         "JAVA_TRUSTSTORE_PWD": "truststore_pwd",
                         "USER_SECRET_ID": "secret:secret-id",
+                        "XMX_SIZE": "2G",
+                        "INITIAL_RAM_PERCENTAGE": 80,
+                        "MAX_RAM_PERCENTAGE": 80,
+                        "HEAP_REGION_SIZE": "32M",
+                        "RESERVED_CACHE_SIZE": "512M",
+                        "RETRY_ALLOCATION_COUNT": 32,
+                        "ADDITIONAL_JVM_OPTIONS": CUSTOMIZED_JVM_STRING,
                     },
                 }
             },


### PR DESCRIPTION
This PR makes the Trino JVM options configurable for the purpose of optimization. This should be a temporary update to give us more control over the jvm properties in order to optemise trino, with the long term plan of eventually providing configurable profiles (`production`, `staging`, `development`) with the jvm values pre-selected for these environments.

This introduces a number of addition configuration values:
- Individual values for those properties which have a high optimisation potential (meaning we may want to tweak frequently in testing). For these I believe we would always want to include the option the only change would be to the value - please let me know if you see a scenario for one of these where we would want to remove it entirely and I can adjust for this.
- `additional-jvm-options` value for covering all over values and providing flexibility to add and remove any options we require in testing. 
