### PR TITLE
Add a blocked state if secret not found

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -356,7 +356,7 @@ class TrinoK8SCharm(CharmBase):
             event: The pebble ready or config changed event.
 
         Raises:
-            In case the secret is incorrectly formatted.
+            Exception: In case the secret is incorrectly formatted.
         """
         container = self.unit.get_container(self.name)
         if not container.can_connect():
@@ -374,7 +374,9 @@ class TrinoK8SCharm(CharmBase):
                 logger.error(
                     f"secret {secret_id!r} not found, check permissions."
                 )
-                self.unit.status = BlockedStatus(str(err))
+                self.unit.status = BlockedStatus("Secret not found, check permissions.")
+                event.defer()
+                return
             except Exception as e:
                 logger.error(f"Incorrectly formatted user secret: {e}")
                 raise

--- a/src/charm.py
+++ b/src/charm.py
@@ -356,7 +356,7 @@ class TrinoK8SCharm(CharmBase):
             event: The pebble ready or config changed event.
 
         Raises:
-            ScannerError: In case the secret is incorrectly formatted.
+            In case the secret is incorrectly formatted.
         """
         container = self.unit.get_container(self.name)
         if not container.can_connect():
@@ -368,13 +368,16 @@ class TrinoK8SCharm(CharmBase):
 
         if secret_id:
             try:
-                credentials = yaml.safe_load(
-                    self._get_secret_content(secret_id)["users"]
+                secret = self._get_secret_content(secret_id)
+                credentials = yaml.safe_load(secret["users"])
+            except SecretNotFoundError as err:
+                logger.error(
+                    f"secret {secret_id!r} not found, check permissions."
                 )
-            except yaml.ScannerError as e:
-                raise yaml.ScannerError(
-                    f"Incorrectly formatted user secret: {e}"
-                )
+                self.unit.status = BlockedStatus(str(err))
+            except Exception as e:
+                logger.error(f"Incorrectly formatted user secret: {e}")
+                raise
         else:
             credentials = DEFAULT_CREDENTIALS
 


### PR DESCRIPTION
If the application has not been granted permission to the secret  on deployment this will result directly in an error, it's a better user experience to put this in a blocked state until permission is granted.