### PR TITLE
Improve Trino Secret handing

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -272,12 +272,11 @@ class TrinoK8SCharm(CharmBase):
         """
         try:
             self._update_password_db(event)
+            self._restart_trino()
         except Exception:
             self.unit.status = BlockedStatus(
                 "Secret cannot be found or is incorrectly formatted."
             )
-            return
-        self._restart_trino()
 
     def _restart_trino(self):
         """Restart Trino."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -367,7 +367,7 @@ class TrinoK8SCharm(CharmBase):
             event.defer()
             return
 
-        secret_id = self.config.get("user-secret-id")
+        secret_id = self.state.user_secret_id
         db_path = str(self.trino_abs_path.joinpath(PASSWORD_DB))
 
         if secret_id:
@@ -572,6 +572,7 @@ class TrinoK8SCharm(CharmBase):
         if self.config["charm-function"] in ["coordinator", "all"]:
             self.state.discovery_uri = self.config.get("discovery-uri", "")
             self.state.catalog_config = self.config.get("catalog-config", "")
+            self.state.user_secret_id = self.config.get("user-secret-id", "")
 
         self._configure_catalogs(container)
 

--- a/src/relations/trino_coordinator.py
+++ b/src/relations/trino_coordinator.py
@@ -79,8 +79,10 @@ class TrinoCoordinator(Object):
 
         coordinator_relations = self.model.relations["trino-coordinator"]
 
-        relation_data = {"discovery-uri": self.charm.config["discovery-uri"],
-        "user-secret-id": self.charm.config.get("user-secret-id", "")}
+        relation_data = {
+            "discovery-uri": self.charm.config["discovery-uri"],
+            "user-secret-id": self.charm.config.get("user-secret-id", ""),
+        }
 
         for relation in coordinator_relations:
             if self.charm.config.get("catalog-config"):

--- a/src/relations/trino_coordinator.py
+++ b/src/relations/trino_coordinator.py
@@ -79,7 +79,8 @@ class TrinoCoordinator(Object):
 
         coordinator_relations = self.model.relations["trino-coordinator"]
 
-        relation_data = {"discovery-uri": self.charm.config["discovery-uri"]}
+        relation_data = {"discovery-uri": self.charm.config["discovery-uri"],
+        "user-secret-id": self.charm.config.get("user-secret-id", "")}
 
         for relation in coordinator_relations:
             if self.charm.config.get("catalog-config"):

--- a/src/relations/trino_worker.py
+++ b/src/relations/trino_worker.py
@@ -70,6 +70,7 @@ class TrinoWorker(Object):
 
         event_data = event.relation.data[event.app]
         self.charm.state.discovery_uri = event_data.get("discovery-uri")
+        self.charm.state.user_secret_id = event_data.get("user-secret-id")
 
         secret_id = event_data.get("catalog-secret-id")
         if not secret_id:


### PR DESCRIPTION
This PR:
- Passes the juju secret id from coordinator to worker so that users are consistent between the two applications without needing to set the config once for each. 
- Adds a blocked status if there is an error getting the secret content.
- Moves the update of the db to the `_update` method as this is then called on relation changed events between coordinator and worker,