### PR TITLE
CSS-10465 update trino secret format

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -20,9 +20,9 @@ jobs:
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
-          juju-channel: 3.1/stable
+          juju-channel: 3.4/stable
           provider: microk8s
-          microk8s-addons: "ingress storage dns rbac registry"
-          channel: 1.25-strict/stable
+          microk8s-addons: "dns ingress rbac storage metallb:10.15.119.2-10.15.119.4 registry"
+          channel: 1.28-strict/stable
       - name: Run integration tests
         run: tox -e ${{ matrix.tox-environments }}

--- a/.github/workflows/test_and_publish_charm.yaml
+++ b/.github/workflows/test_and_publish_charm.yaml
@@ -11,6 +11,6 @@ jobs:
     secrets: inherit
     with:
       integration-test-provider: microk8s
-      integration-test-provider-channel: 1.25-strict/stable
-      integration-test-juju-channel: 3.1/stable
+      integration-test-provider-channel: 1.28-strict/stable
+      integration-test-juju-channel: 3.4/stable
       integration-test-modules: '["test_charm", "test_policy"]'

--- a/README.md
+++ b/README.md
@@ -62,16 +62,31 @@ The below is an example of the `catalog_config.yaml`, which connects 1 postgresq
 ### The config file
 ```
 catalogs:
-  production_db: |
-    connector.name=postgresql
-    connection-url=jdbc:postgresql://host:port/db?ssl=true&sslmode=require&sslrootcert={SSL_PATH}&sslrootcertpassword={SSL_PWD}
-    connection-user=user
-    connection-password=password
-  staging_db: |
-    connector.name=postgresql
-    connection-url=jdbc:postgresql://host:port/staging_db
-    connection-user=user
-    connection-password=password
+  example: 
+    backend: dwh
+    database: example  
+  another-example:
+    backend: dwh
+    database: another-db
+
+backends:
+  dwh:
+    connector: postgresql
+    url: jdbc:postgresql://host.example.com:5432
+    params: ssl=true&sslmode=require&sslrootcert={SSL_PATH}&sslrootcertpassword={SSL_PWD}
+    replicas:
+      rw: 
+        user: trino
+        password: pwd1
+        suffix: _developer
+      ro:
+        user: trino_ro
+        password: pwd2
+    config: |
+      case-insensitive-name-matching=true
+      decimal-mapping=allow_overflow
+      decimal-rounding-mode=HALF_UP
+
 certs:
   production_cert: |
     -----BEGIN CERTIFICATE-----

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ cryptography==39.0.1
 jsonschema==4.17.3
 bcrypt==4.0.1
 cosl==0.0.10
+cerberus==1.3.5

--- a/src/literals.py
+++ b/src/literals.py
@@ -121,8 +121,7 @@ DEFAULT_JVM_OPTIONS = [
     "-Djdk.attach.allowAttachSelf=true",
     "-Dfile.encoding=UTF-8",
 ]
-USER_SECRET_LABEL = "trino-user-management"
-
+USER_SECRET_LABEL = "trino-user-management"  # nosec
 CATALOG_SCHEMA = {
     "backend": {"type": "string"},
     "database": {"type": "string"},

--- a/src/literals.py
+++ b/src/literals.py
@@ -121,3 +121,45 @@ DEFAULT_JVM_OPTIONS = [
     "-Djdk.attach.allowAttachSelf=true",
     "-Dfile.encoding=UTF-8",
 ]
+USER_SECRET_LABEL = "trino-user-management"
+
+CATALOG_SCHEMA = {
+    "backend": {"type": "string"},
+    "database": {"type": "string"},
+}
+
+POSTGRESQL_BACKEND_SCHEMA = {
+    "connector": {"type": "string"},
+    "url": {"type": "string"},
+    "params": {"type": "string"},
+    "replicas": {
+        "type": "dict",
+        "schema": {
+            "rw": {
+                "type": "dict",
+                "schema": {
+                    "user": {"type": "string"},
+                    "password": {"type": "string"},
+                    "suffix": {"type": "string", "nullable": True},
+                },
+                "required": False,
+            },
+            "ro": {
+                "type": "dict",
+                "schema": {
+                    "user": {"type": "string"},
+                    "password": {"type": "string"},
+                    "suffix": {"type": "string", "nullable": True},
+                },
+                "required": False,
+            },
+        },
+    },
+    "config": {"type": "string", "nullable": True},
+}
+
+REPLICA_SCHEMA = {
+    "user": {"type": "string"},
+    "password": {"type": "string"},
+    "suffix": {"type": "string", "nullable": True},
+}

--- a/src/utils.py
+++ b/src/utils.py
@@ -10,6 +10,7 @@ import re
 import secrets
 import string
 import subprocess  # nosec B404
+import textwrap
 
 import yaml
 from jinja2 import Environment, FileSystemLoader
@@ -154,6 +155,55 @@ def handle_exec_error(func):
     return wrapper
 
 
+def create_postgresql_catalogs(cat_name, cat_info, backend):
+    """Create the postgresql connector catalog files.
+
+    Args:
+        cat_name: catalog name.
+        cat_info: the templated configuration values.
+        backend: the db configuration values.
+
+    Returns:
+        catalogs: the PostgreSQL catalogs.
+    """
+    catalogs = {}
+    for replica_info in backend["replicas"].values():
+        user_name = replica_info.get("user")
+        user_pwd = replica_info.get("password")
+        suffix = replica_info.get("suffix", "")
+        catalog_name = f"{cat_name}{suffix}"
+
+        catalog_content = textwrap.dedent(
+            f"""\
+            connector.name={backend['connector']}
+            connection-url={backend['url']}/{cat_info['database']}?{backend['params']}
+            connection-user={user_name}
+            connection-password={user_pwd}
+        """
+        )
+        catalog_content += backend.get("config", "")
+        catalogs[catalog_name] = catalog_content
+    return catalogs
+
+
+def get_catalog_files(catalog_def, backends):
+    """Prepare the catalog files for all connectors.
+
+    Args:
+        catalog_def: the catalog definition.
+        backends: the templated backednds.
+
+    Returns:
+        catalogs: dictionary of all catalog files.
+    """
+    catalogs = {}
+    for cat_name, cat_info in catalog_def.items():
+        backend = backends[cat_info["backend"]]
+        if backend["connector"] == "postgresql":
+            catalogs = create_postgresql_catalogs(cat_name, cat_info, backend)
+    return catalogs
+
+
 def create_cert_and_catalog_dicts(config):
     """Identify certs and connection values from config.
 
@@ -165,7 +215,9 @@ def create_cert_and_catalog_dicts(config):
         catalogs: dictionary of catalog values.
     """
     catalogs_with_certs = yaml.safe_load(config)
-    catalogs = catalogs_with_certs.get("catalogs")
+    catalog_def = catalogs_with_certs.get("catalogs")
+    backends = catalogs = catalogs_with_certs.get("backends")
+    catalogs = get_catalog_files(catalog_def, backends)
     certs = catalogs_with_certs.get("certs")
     return certs, catalogs
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -199,6 +199,9 @@ def get_catalog_files(catalog_def, backends):
 
     Returns:
         catalogs: dictionary of all catalog files.
+
+    Raises:
+        ValueError: in case connector type is not supported.
     """
     catalogs = {}
     for cat_name, cat_info in catalog_def.items():
@@ -208,6 +211,8 @@ def get_catalog_files(catalog_def, backends):
                 cat_name, cat_info, backend
             )
             catalogs.update(pg_catalogs)
+        else:
+            raise ValueError("Invalid connector type.")
     return catalogs
 
 
@@ -223,7 +228,7 @@ def create_cert_and_catalog_dicts(config):
     """
     catalogs_with_certs = yaml.safe_load(config)
     catalog_def = catalogs_with_certs.get("catalogs")
-    backends = catalogs = catalogs_with_certs.get("backends")
+    backends = catalogs_with_certs.get("backends")
     catalogs = get_catalog_files(catalog_def, backends)
     certs = catalogs_with_certs.get("certs")
     return certs, catalogs

--- a/src/utils.py
+++ b/src/utils.py
@@ -204,7 +204,10 @@ def get_catalog_files(catalog_def, backends):
     for cat_name, cat_info in catalog_def.items():
         backend = backends[cat_info["backend"]]
         if backend["connector"] == "postgresql":
-            catalogs = create_postgresql_catalogs(cat_name, cat_info, backend)
+            pg_catalogs = create_postgresql_catalogs(
+                cat_name, cat_info, backend
+            )
+            catalogs.update(pg_catalogs)
     return catalogs
 
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -173,10 +173,14 @@ def create_postgresql_catalogs(cat_name, cat_info, backend):
         suffix = replica_info.get("suffix", "")
         catalog_name = f"{cat_name}{suffix}"
 
+        url = f"{backend['url']}/{cat_info['database']}"
+        if backend.get("params"):
+            url = f"{url}?{backend['params']}"
+
         catalog_content = textwrap.dedent(
             f"""\
             connector.name={backend['connector']}
-            connection-url={backend['url']}/{cat_info['database']}?{backend['params']}
+            connection-url={url}
             connection-user={user_name}
             connection-password={user_pwd}
         """

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -43,10 +43,10 @@ EXAMPLE_CATALOG_NAME = "example-db"
 TEMP_CATALOG_NAME = "temp-db"
 TEMP_CATALOG_CONFIG = """\
 catalogs:
-  temp-db: 
+  temp-db:
     backend: dwh
     database: temp-db
-backends: 
+backends:
   dwh:
     connector: postgresql
     url: jdbc:postgresql://host.com:5432
@@ -59,14 +59,14 @@ backends:
 
 CATALOG_CONFIG = """\
 catalogs:
-  example-db: 
+  example-db:
     backend: dwh
     database: example-db
-  temp-db: 
+  temp-db:
     backend: dwh
     database: temp-db
 
-backends: 
+backends:
   dwh:
     connector: postgresql
     url: jdbc:postgresql://host.com:5432

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -43,24 +43,37 @@ EXAMPLE_CATALOG_NAME = "example-db"
 TEMP_CATALOG_NAME = "temp-db"
 TEMP_CATALOG_CONFIG = """\
 catalogs:
-    temp-db: |
-        connector.name=postgresql
-        connection-url=jdbc:postgresql://host.com:5432/temp-db
-        connection-user=testing
-        connection-password=test
+  temp-db: 
+    backend: dwh
+    database: temp-db
+backends: 
+  dwh:
+    connector: postgresql
+    url: jdbc:postgresql://host.com:5432
+    replicas:
+      ro:
+        user: testing
+        password: test
 """
+
+
 CATALOG_CONFIG = """\
 catalogs:
-    example-db: |
-        connector.name=postgresql
-        connection-url=jdbc:postgresql://host.com:5432/database
-        connection-user=testing
-        connection-password=test
-    temp-db: |
-        connector.name=postgresql
-        connection-url=jdbc:postgresql://host.com:5432/temp-db
-        connection-user=testing
-        connection-password=test
+  example-db: 
+    backend: dwh
+    database: example-db
+  temp-db: 
+    backend: dwh
+    database: temp-db
+
+backends: 
+  dwh:
+    connector: postgresql
+    url: jdbc:postgresql://host.com:5432
+    replicas:
+      ro:
+        user: testing
+        password: test
 """
 
 CATALOG_QUERY = "SHOW CATALOGS"

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -8,11 +8,26 @@
 SERVER_PORT = "8080"
 TEST_CATALOG_CONFIG = """\
 catalogs:
-    example-db: |
-        connector.name=postgresql
-        connection-url=jdbc:postgresql://host.com:5432/database?ssl=true&sslmode=require&sslrootcert={SSL_PATH}&sslrootcertpassword={SSL_PWD}
-        connection-user=testing
-        connection-password=pd3h@!}93*hdu
+  example:
+    backend: dwh
+    database: example
+backends:
+  dwh:
+    connector: postgresql
+    url: jdbc:postgresql://example.com:5432
+    params: ssl=true&sslmode=require&sslrootcert={SSL_PATH}&sslrootcertpassword={SSL_PWD}
+    replicas:
+      rw:
+        user: trino
+        password: pwd1
+        suffix: _developer
+      ro:
+        user: trino_ro
+        password: pwd2
+    config: |
+      case-insensitive-name-matching=true
+      decimal-mapping=allow_overflow
+      decimal-rounding-mode=HALF_UP
 certs:
     example-cert: |
         -----BEGIN CERTIFICATE-----
@@ -21,19 +36,34 @@ certs:
 """
 UPDATED_CATALOG_CONFIG = """\
 catalogs:
-    updated-db: |
-        connector.name=postgresql
-        connection-url=jdbc:postgresql://host.com:5432/database?ssl=true&sslmode=require&sslrootcert={SSL_PATH}&sslrootcertpassword={SSL_PWD}
-        connection-user=testing
-        connection-password=pd3h@!}93*hdu
+  updated:
+    backend: dwh
+    database: updated-db
+backends:
+  dwh:
+    connector: postgresql
+    url: jdbc:postgresql://updated.com:5432
+    params: ssl=true&sslmode=require&sslrootcert={SSL_PATH}&sslrootcertpassword={SSL_PWD}
+    replicas:
+      rw:
+        user: trino
+        password: pwd1
+        suffix: _developer
+      ro:
+        user: trino_ro
+        password: pwd2
+    config: |
+      case-insensitive-name-matching=true
+      decimal-mapping=allow_overflow
+      decimal-rounding-mode=HALF_UP
 certs:
-    updated-cert: |
+    example-cert: |
         -----BEGIN CERTIFICATE-----
         CERTIFICATE CONTENT...
         -----END CERTIFICATE-----
 """
-TEST_CATALOG_PATH = "/usr/lib/trino/etc/catalog/example-db.properties"
-UPDATED_CATALOG_PATH = "/usr/lib/trino/etc/catalog/updated-db.properties"
+TEST_CATALOG_PATH = "/usr/lib/trino/etc/catalog/example.properties"
+UPDATED_CATALOG_PATH = "/usr/lib/trino/etc/catalog/updated.properties"
 RANGER_PROPERTIES_PATH = "/usr/lib/ranger/install.properties"
 POLICY_MGR_URL = "http://ranger-k8s:6080"
 

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -11,6 +11,9 @@ catalogs:
   example:
     backend: dwh
     database: example
+  updated-db:
+    backend: dwh
+    database: updated-db
 backends:
   dwh:
     connector: postgresql

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -37,6 +37,37 @@ certs:
         CERTIFICATE CONTENT...
         -----END CERTIFICATE-----
 """
+INCORRECT_CATALOG_CONFIG = """\
+catalogs:
+  example:
+    database: example
+  updated-db:
+    backend: dwh
+    database: updated-db
+backends:
+  dwh:
+    connector: postgresql
+    url: jdbc:postgresql://example.com:5432
+    params: ssl=true&sslmode=require&sslrootcert={SSL_PATH}&sslrootcertpassword={SSL_PWD}
+    replicas:
+      rw:
+        user: trino
+        password: pwd1
+        suffix: _developer
+      ro:
+        user: trino_ro
+        password: pwd2
+    config: |
+      case-insensitive-name-matching=true
+      decimal-mapping=allow_overflow
+      decimal-rounding-mode=HALF_UP
+certs:
+    example-cert: |
+        -----BEGIN CERTIFICATE-----
+        CERTIFICATE CONTENT...
+        -----END CERTIFICATE-----
+"""
+
 UPDATED_CATALOG_CONFIG = """\
 catalogs:
   updated:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -22,6 +22,7 @@ from ops.pebble import CheckStatus
 from ops.testing import Harness
 from unit.helpers import (
     DEFAULT_JVM_STRING,
+    INCORRECT_CATALOG_CONFIG,
     JAVA_HOME,
     SERVER_PORT,
     TEST_CATALOG_CONFIG,
@@ -282,6 +283,20 @@ class TestCharm(TestCase):
         # Validate catalog.properties file created.
         container = harness.model.unit.get_container("trino")
         self.assertTrue(container.exists(TEST_CATALOG_PATH))
+
+    def test_catalog_invalid_config(self):
+        """The catalog directory is updated to add the new catalog."""
+        harness = self.harness
+        simulate_lifecycle_coordinator(harness)
+
+        self.harness.update_config(
+            {"catalog-config": INCORRECT_CATALOG_CONFIG}
+        )
+
+        self.assertEqual(
+            harness.model.unit.status,
+            BlockedStatus("Invalid catalog-config schema"),
+        )
 
     def test_catalog_removed(self):
         """The catalog directory is updated to remove existing catalogs."""

--- a/tox.ini
+++ b/tox.ini
@@ -116,7 +116,7 @@ commands =
     codespell {toxinidir} --skip {toxinidir}/.git --skip {toxinidir}/.tox --ignore-words-list "ro" \
       --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
       --skip {toxinidir}/.mypy_cache --skip {toxinidir}/icon.svg
-    pflake8 {[vars]src_path} {[vars]tst_path}
+    pflake8 {[vars]src_path} {[vars]tst_path} --max-complexity=15
     isort --check-only --diff {[vars]src_path} {[vars]tst_path}
     black --line-length 79 --check --diff {[vars]src_path} {[vars]tst_path}
     mypy {[vars]all_path} --ignore-missing-imports --follow-imports=skip --install-types --non-interactive

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ passenv =
 description = Run integration tests
 deps =
     ipdb==0.13.9
-    juju==3.1.0.1
+    juju==3.5.2.0
     pytest==7.4.0
     pytest-operator==0.29.0
     pytest-asyncio==0.21.0
@@ -45,7 +45,7 @@ commands =
 description = Run integration tests
 deps =
     ipdb==0.13.9
-    juju==3.1.0.1
+    juju==3.5.2.0
     pytest==7.4.0
     pytest-operator==0.29.0
     pytest-asyncio==0.21.0

--- a/tox.ini
+++ b/tox.ini
@@ -113,7 +113,7 @@ deps =
     flake8-test-docs>=1.0
 commands =
     pydocstyle {[vars]src_path}
-    codespell {toxinidir} --skip {toxinidir}/.git --skip {toxinidir}/.tox \
+    codespell {toxinidir} --skip {toxinidir}/.git --skip {toxinidir}/.tox --ignore-words-list "ro" \
       --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
       --skip {toxinidir}/.mypy_cache --skip {toxinidir}/icon.svg
     pflake8 {[vars]src_path} {[vars]tst_path}


### PR DESCRIPTION
With the existing structure of the catalog-config.yaml file, this quickly becomes large enough that k8s secrets no longer support the size resulting in an error when adding additional catalogs. https://warthogs.atlassian.net/browse/CSS-10465

This PR:
- Updates the config file format to use a backend structure to prevent repetition when adding multiple databases from the same server.
- Adds logic to the charm code for reading this config and turning it into catalogs in trino. 

Please note, for now this just supports the addition of `postgresql` connectors, in the future we can add additional backends and charm logic for other supported connectors but it is very hard to generalised for all as every connector differs considerably in configuration values.