### PR TITLE
CSS-10565: java home is set in the rock

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -31,7 +31,7 @@ resources:
   trino-image:
     type: oci-image
     description: OCI image for trino
-    upstream-source: ghcr.io/canonical/charmed-trino-rock:418-22.04-edge
+    upstream-source: ghcr.io/canonical/charmed-trino-rock:436-22.04-edge
 
 storage:
   policy:

--- a/src/charm.py
+++ b/src/charm.py
@@ -38,7 +38,6 @@ from literals import (
     DEFAULT_CREDENTIALS,
     DEFAULT_JVM_OPTIONS,
     INDEX_NAME,
-    JAVA_HOME,
     JMX_PORT,
     LOG_FILES,
     METRICS_PORT,
@@ -320,14 +319,14 @@ class TrinoK8SCharm(CharmBase):
             )
 
         command = [
-            f"{JAVA_HOME}/bin/keytool",
+            "keytool",
             "-storepass",
             "changeit",
             "-storepasswd",
             "-new",
             self.state.java_truststore_pwd,
             "-keystore",
-            f"{JAVA_HOME}/lib/security/cacerts",
+            "$JAVA_HOME/lib/security/cacerts",
         ]
         try:
             container.exec(command).wait_output()

--- a/src/literals.py
+++ b/src/literals.py
@@ -46,10 +46,6 @@ RANGER_PLUGIN_FILES = {
     "access-control.jinja": "access-control.properties",
 }
 
-JAVA_ENV = {
-    "JAVA_HOME": "/usr/lib/jvm/java-21-openjdk-amd64",
-}
-
 SECRET_LABEL = "catalog-config"  # nosec
 
 # Connector literal
@@ -105,7 +101,6 @@ CONNECTOR_FIELDS = {
     },
 }
 
-JAVA_HOME = "/usr/lib/jvm/java-21-openjdk-amd64"
 
 # OpenSearch literals
 INDEX_NAME = "ranger_audits"

--- a/src/relations/opensearch.py
+++ b/src/relations/opensearch.py
@@ -11,7 +11,7 @@ from ops import framework
 from ops.model import BlockedStatus, WaitingStatus
 from ops.pebble import ExecError
 
-from literals import CERTIFICATE_NAME, INDEX_NAME, JAVA_HOME
+from literals import CERTIFICATE_NAME, INDEX_NAME
 from log import log_event_handler
 
 logger = logging.getLogger(__name__)
@@ -99,10 +99,10 @@ class OpensearchRelationHandler(framework.Object):
         if certificate and not relation_broken:
             container.push("/opensearch.crt", certificate)
             command = [
-                f"{JAVA_HOME}/bin/keytool",
+                "keytool",
                 "-importcert",
                 "-keystore",
-                f"{JAVA_HOME}/lib/security/cacerts",
+                "$JAVA_HOME/lib/security/cacerts",
                 "-file",
                 "/opensearch.crt",
                 "-alias",
@@ -114,10 +114,10 @@ class OpensearchRelationHandler(framework.Object):
         else:
             container.remove_path("/opensearch.crt")
             command = [
-                f"{JAVA_HOME}/bin/keytool",
+                "keytool",
                 "-delete",
                 "-keystore",
-                f"{JAVA_HOME}/lib/security/cacerts",
+                "$JAVA_HOME/lib/security/cacerts",
                 "-alias",
                 CERTIFICATE_NAME,
                 "-storepass",

--- a/src/relations/policy.py
+++ b/src/relations/policy.py
@@ -11,7 +11,6 @@ from ops.model import MaintenanceStatus
 from ops.pebble import ExecError
 
 from literals import (
-    JAVA_ENV,
     RANGER_PLUGIN_FILES,
     RANGER_PLUGIN_HOME,
     TRINO_PLUGIN_DIR,
@@ -184,7 +183,6 @@ class PolicyRelationHandler(framework.Object):
         container.exec(
             command,
             working_dir=str(self.ranger_abs_path),
-            environment=JAVA_ENV,
         ).wait()
 
     def _push_plugin_files(
@@ -239,7 +237,6 @@ class PolicyRelationHandler(framework.Object):
         container.exec(
             command,
             working_dir=str(self.ranger_abs_path),
-            environment=JAVA_ENV,
         ).wait()
 
     def restart_ranger_plugin(self, event):

--- a/src/utils.py
+++ b/src/utils.py
@@ -19,7 +19,6 @@ from ops.pebble import ExecError
 
 from literals import (
     CATALOG_SCHEMA,
-    JAVA_ENV,
     POSTGRESQL_BACKEND_SCHEMA,
     REPLICA_SCHEMA,
 )
@@ -271,9 +270,8 @@ def add_cert_to_truststore(container, name, cert, storepass, conf_path):
     Raises:
         ExecError: In case of error during keytool certificate import
     """
-    java_home = JAVA_ENV["JAVA_HOME"]
     command = [
-        f"{java_home}/bin/keytool",
+        "keytool",
         "-import",
         "-v",
         "-alias",

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -23,7 +23,6 @@ from ops.testing import Harness
 from unit.helpers import (
     DEFAULT_JVM_STRING,
     INCORRECT_CATALOG_CONFIG,
-    JAVA_HOME,
     SERVER_PORT,
     TEST_CATALOG_CONFIG,
     TEST_CATALOG_PATH,
@@ -424,7 +423,7 @@ class TestCharm(TestCase):
         harness = self.harness
         harness.add_relation("peer", "trino")
 
-        harness.handle_exec("trino", [f"{JAVA_HOME}/bin/keytool"], result=0)
+        harness.handle_exec("trino", ["keytool"], result=0)
         container = harness.model.unit.get_container("trino")
         harness.handle_exec("trino", ["htpasswd"], result=0)
         harness.charm.on.trino_pebble_ready.emit(container)
@@ -458,7 +457,7 @@ def simulate_lifecycle_worker(harness):
     harness.add_relation("peer", "trino")
 
     # Simulate pebble readiness.
-    harness.handle_exec("trino", [f"{JAVA_HOME}/bin/keytool"], result=0)
+    harness.handle_exec("trino", ["keytool"], result=0)
     harness.handle_exec("trino", ["htpasswd"], result=0)
     harness.update_config({"charm-function": "worker"})
 
@@ -501,7 +500,7 @@ def simulate_lifecycle_coordinator(harness):
     harness.charm.on.trino_pebble_ready.emit(container)
 
     # Add worker and coordinator relation
-    harness.handle_exec("trino", [f"{JAVA_HOME}/bin/keytool"], result=0)
+    harness.handle_exec("trino", ["keytool"], result=0)
     harness.update_config({"catalog-config": TEST_CATALOG_CONFIG})
     rel_id = harness.add_relation("trino-coordinator", "trino-k8s-worker")
     secret_id = harness.add_model_secret(

--- a/tests/unit/test_policy.py
+++ b/tests/unit/test_policy.py
@@ -15,7 +15,6 @@ from ops.model import ActiveStatus, MaintenanceStatus
 from ops.pebble import CheckStatus
 from ops.testing import Harness
 from unit.helpers import (
-    JAVA_HOME,
     POLICY_MGR_URL,
     RANGER_LIB,
     RANGER_PROPERTIES_PATH,
@@ -147,7 +146,7 @@ class TestPolicy(TestCase):
 
         rel_id = harness.add_relation("opensearch", "opensearch-app")
         harness.add_relation_unit(rel_id, "opensearch-app/0")
-        harness.handle_exec("trino", [f"{JAVA_HOME}/bin/keytool"], result=0)
+        harness.handle_exec("trino", ["keytool"], result=0)
         event = make_relation_event(
             "opensearch", rel_id, OPENSEARCH_RELATION_CHANGED_DATA
         )
@@ -228,7 +227,7 @@ def simulate_lifecycle(harness):
     harness.charm.on.trino_pebble_ready.emit(container)
 
     # Add worker and coordinator relation
-    harness.handle_exec("trino", [f"{JAVA_HOME}/bin/keytool"], result=0)
+    harness.handle_exec("trino", ["keytool"], result=0)
     harness.update_config({"catalog-config": TEST_CATALOG_CONFIG})
     harness.add_relation("trino-coordinator", "trino-k8s-worker")
 


### PR DESCRIPTION
This PR basically removes references to Java in the charm, so that we can update the rock without updating the charm. However, we do expect the rock to configure JAVA_HOME

p.s: integration tests would fail until I update the rock. So the [PR](https://github.com/canonical/charmed-trino-rock/pull/11) on the rock should be merged before.