### PR TITLE
update java home to use environment variable not string

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -318,6 +318,10 @@ class TrinoK8SCharm(CharmBase):
                 self.state.java_truststore_pwd or generate_password()
             )
 
+        out, _ = container.exec(
+            ["/bin/sh", "-c", "echo $JAVA_HOME"]
+        ).wait_output()
+        java_home = out.strip()
         command = [
             "keytool",
             "-storepass",
@@ -326,7 +330,7 @@ class TrinoK8SCharm(CharmBase):
             "-new",
             self.state.java_truststore_pwd,
             "-keystore",
-            "$JAVA_HOME/lib/security/cacerts",
+            f"{java_home}/lib/security/cacerts",
         ]
         try:
             container.exec(command).wait_output()
@@ -459,8 +463,8 @@ class TrinoK8SCharm(CharmBase):
 
         try:
             certs, catalogs = create_cert_and_catalog_dicts(catalog_config)
-        except Exception as e:
-            logger.debug(f"Unable to create catalogs: {e}.")
+        except Exception:
+            logger.debug("Unable to create catalogs.")
             raise
 
         self._add_catalogs(container, catalogs, truststore_pwd)

--- a/src/utils.py
+++ b/src/utils.py
@@ -17,11 +17,7 @@ from cerberus import Validator
 from jinja2 import Environment, FileSystemLoader
 from ops.pebble import ExecError
 
-from literals import (
-    CATALOG_SCHEMA,
-    POSTGRESQL_BACKEND_SCHEMA,
-    REPLICA_SCHEMA,
-)
+from literals import CATALOG_SCHEMA, POSTGRESQL_BACKEND_SCHEMA, REPLICA_SCHEMA
 
 logger = logging.getLogger(__name__)
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -423,6 +423,9 @@ class TestCharm(TestCase):
         harness = self.harness
         harness.add_relation("peer", "trino")
 
+        harness.handle_exec(
+            "trino", ["/bin/sh"], result="/usr/lib/jvm/java-21-openjdk-amd64/"
+        )
         harness.handle_exec("trino", ["keytool"], result=0)
         container = harness.model.unit.get_container("trino")
         harness.handle_exec("trino", ["htpasswd"], result=0)
@@ -459,6 +462,9 @@ def simulate_lifecycle_worker(harness):
     # Simulate pebble readiness.
     harness.handle_exec("trino", ["keytool"], result=0)
     harness.handle_exec("trino", ["htpasswd"], result=0)
+    harness.handle_exec(
+        "trino", ["/bin/sh"], result="/usr/lib/jvm/java-21-openjdk-amd64/"
+    )
     harness.update_config({"charm-function": "worker"})
 
     container = harness.model.unit.get_container("trino")
@@ -497,6 +503,9 @@ def simulate_lifecycle_coordinator(harness):
     # Simulate pebble readiness.
     container = harness.model.unit.get_container("trino")
     harness.handle_exec("trino", ["htpasswd"], result=0)
+    harness.handle_exec(
+        "trino", ["/bin/sh"], result="/usr/lib/jvm/java-21-openjdk-amd64/"
+    )
     harness.charm.on.trino_pebble_ready.emit(container)
 
     # Add worker and coordinator relation

--- a/tests/unit/test_policy.py
+++ b/tests/unit/test_policy.py
@@ -224,6 +224,9 @@ def simulate_lifecycle(harness):
     # Simulate pebble readiness.
     container = harness.model.unit.get_container("trino")
     harness.handle_exec("trino", ["htpasswd"], result=0)
+    harness.handle_exec(
+        "trino", ["/bin/sh"], result="/usr/lib/jvm/java-21-openjdk-amd64/"
+    )
     harness.charm.on.trino_pebble_ready.emit(container)
 
     # Add worker and coordinator relation


### PR DESCRIPTION
`"$JAVA_HOME/lib/security/cacerts"`, was being interpreted as the string `JAVA_HOME` and so failing to update the cacerts password. This PR gets the value from the environment and then uses it directly in the exec command.

It also removes the debug logging of the error when failing to update the catalog as this logs also the secret. I'll create another PR for better error handling but  this is to immediately remove this.