### PR TITLE
CSS-11010 Add bigquery connector and refactor catalog handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ juju grant-secret <secret-id> trino-k8s-worker
 
 ### The config file
 To add or remove catalogs the configuration parameter `catalog-config` should be updated.
-The below is an example of the `catalog_config.yaml`. It lists the catalogs to add, and points to a juju secret in which the credntials are stored. Any commonality is included as part of the `backend` these configuration properties will be applied to all catalogs with the same backend.
+The below is an example of the `catalog_config.yaml`. It lists the catalogs to add, and points to a juju secret in which the credentials are stored. Any commonality is included as part of the `backend` these configuration properties will be applied to all catalogs with the same backend.
 ```
 catalogs:
   example: 

--- a/README.md
+++ b/README.md
@@ -55,63 +55,98 @@ juju relate trino-k8s nginx-ingress-integrator
 
 Once deployed, the hostname will default to the name of the application (trino-k8s), and can be configured using the external-hostname configuration on the Trino operator.
 
-## Trino connectors
-Adding or removing a connector from Trino is done using the `juju config` parameter `catalog-config`, as there are likely to be a number of catalogs to connect this is recommended to be done through a `catalog_config.yaml` file.
-The below is an example of the `catalog_config.yaml`, which connects 1 postgresql database without TLS and 1 with TLS.
+## Trino catalogs
+Adding a catalog to Trino requires user or service account credentiials. For this we use Juju secrets.
+
+### Juju secrets
+Juju secrets are used to manage connector credentials. The format of these differ by connector type. Note: the same secret can be shared by multiple trino catalogs.
+
+For PostgreSQL (`postgresql-user-creds.yaml`):
+```
+rw: 
+  user: trino
+  password: "pwd1" 
+  suffix: _developer
+ro:
+  user: trino_ro
+  password: "pwd2"
+```
+
+For PostgreSQL certificates (`certificates.yaml`):
+```
+postgresql-cert: |
+  -----BEGIN CERTIFICATE-----
+  YOUR CERTIFICATE CONTENT
+  -----END CERTIFICATE-----
+```
+
+For BigQuery (`bigquery-service-accounts.yaml`):
+```
+<your-project-id>: |
+    {
+      "type": "service_account",
+      "project_id": "example-project",
+      "private_key_id": "key123",
+      "private_key": "-----BEGIN PRIVATE KEY-----\YOUR PRIVATE KEY\n-----END PRIVATE KEY-----",
+      "client_email": "test-380@example-project.iam.gserviceaccount.com",
+      "client_id": "12345",
+      "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+      "token_uri": "https://oauth2.googleapis.com/token",
+      "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+      "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/test-380.project.iam.gserviceaccount.com",
+      "universe_domain": "googleapis.com"
+    }
+```
+These secrets can be created by running the following:
+```
+juju add-secret postgresql-credentials replicas#file=postgresql-user-creds.yaml cert#file=certificates.yaml
+juju add-secret bigquery-service-accounts service-accounts#file=bigquery-service-accounts.yaml
+```
+And access granted to trino coordinator and worker with the following:
+```
+juju grant-secret <secret-id> trino-k8s-coodinator
+juju grant-secret <secret-id> trino-k8s-worker
+```
 
 ### The config file
+To add or remove catalogs the configuration parameter `catalog-config` should be updated.
+The below is an example of the `catalog_config.yaml`. It lists the catalogs to add, and points to a juju secret in which the credntials are stored. Any commonality is included as part of the `backend` these configuration properties will be applied to all catalogs with the same backend.
 ```
 catalogs:
   example: 
     backend: dwh
     database: example  
-  another-example:
-    backend: dwh
-    database: another-db
+    secret-id: crt7gpnmp25c760ji150
+  ge_bigquery:
+    backend: bigquery
+    project: <project-id>
+    secret-id: crt7d1vmp25c760ji14g
 
-backends:
+backends: 
   dwh:
     connector: postgresql
-    url: jdbc:postgresql://host.example.com:5432
+    url: jdbc:postgresql://<database-host>:5432
     params: ssl=true&sslmode=require&sslrootcert={SSL_PATH}&sslrootcertpassword={SSL_PWD}
-    replicas:
-      rw: 
-        user: trino
-        password: pwd1
-        suffix: _developer
-      ro:
-        user: trino_ro
-        password: pwd2
     config: |
       case-insensitive-name-matching=true
       decimal-mapping=allow_overflow
       decimal-rounding-mode=HALF_UP
-
-certs:
-  production_cert: |
-    -----BEGIN CERTIFICATE-----
-    Certificate values...
-    -----END CERTIFICATE-----
+  bigquery:
+    connector: bigquery
+    config: |
+      bigquery.case-insensitive-name-matching=true
 ```
-Note: the required fields change significantly by connector, see the Trino documentation on this [here](https://trino.io/docs/current/connector.html). Currently only Elasticsearch, PostgreSQL, Google sheets, MySQL, Prometheus and Redis connectors are supported by the charm. 
 
-The user provided should have the maximum permissions you would want any user to have. Restictions to access can be made on this user but no further permissions can be granted.
+Note: the allowed fields change significantly by connector, see the Trino documentation on this [here](https://trino.io/docs/current/connector.html).
 
-`{SSL_PATH}` and `{SSL PWD}` variables will be replaced with the truststore path and password by the charm, as long as the certificte has been added to the `certs` key this will be added to the trustore automatically.
+The `{SSL_PATH}` and `{SSL PWD}` variables will be replaced with the truststore path and password by the charm.
 
-### Adding or removing a catalog
-Once you have your `catalog_config.yaml` file you can configure the Trino charm with the below:
-```
-juju config trino-k8s catalog-config=@/path/to/file/trino_catalogs.yaml
-```
-To add or remove a connector simply update the file and run the above again.
+The catalog-config can be applied with the following:
 
-### Connecting database clusters
-In order to connect clustered database systems to Trino please connect the read-only and read-write endpoints with 2 separate `juju actions`. The read-only database should be appended with `_ro` to distinguish between the two. 
 ```
-salesforce #read-write endpoint
-salesforce_ro #read-only endpoint
+juju run trino-k8s catalog-config=@catalog-config.yaml
 ```
+
 ## User management
 By default password authentication is enabled for Charmed Trino. This being said, Trino supports implementing multiple forms of authentication mechanisms at the same time. Available with the charm are Google Oauth and user/password authentication. We recommend user/password for application users which do no support Oauth, and Oauth for everything else.
 

--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -331,7 +331,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 39
+LIBPATCH = 40
 
 PYDEPS = ["ops>=2.0.0"]
 
@@ -389,6 +389,10 @@ class SecretsIllegalUpdateError(SecretError):
 
 class IllegalOperationError(DataInterfacesError):
     """To be used when an operation is not allowed to be performed."""
+
+
+class PrematureDataAccessError(DataInterfacesError):
+    """To be raised when the Relation Data may be accessed (written) before protocol init complete."""
 
 
 ##############################################################################
@@ -1453,6 +1457,8 @@ class EventHandlers(Object):
 class ProviderData(Data):
     """Base provides-side of the data products relation."""
 
+    RESOURCE_FIELD = "database"
+
     def __init__(
         self,
         model: Model,
@@ -1618,6 +1624,15 @@ class ProviderData(Data):
     def _update_relation_data(self, relation: Relation, data: Dict[str, str]) -> None:
         """Set values for fields not caring whether it's a secret or not."""
         req_secret_fields = []
+
+        keys = set(data.keys())
+        if self.fetch_relation_field(relation.id, self.RESOURCE_FIELD) is None and (
+            keys - {"endpoints", "read-only-endpoints", "replset"}
+        ):
+            raise PrematureDataAccessError(
+                "Premature access to relation data, update is forbidden before the connection is initialized."
+            )
+
         if relation.app:
             req_secret_fields = get_encoded_list(relation, relation.app, REQ_SECRET_FIELDS)
 
@@ -3290,6 +3305,8 @@ class KafkaRequiresEvents(CharmEvents):
 class KafkaProviderData(ProviderData):
     """Provider-side of the Kafka relation."""
 
+    RESOURCE_FIELD = "topic"
+
     def __init__(self, model: Model, relation_name: str) -> None:
         super().__init__(model, relation_name)
 
@@ -3538,6 +3555,8 @@ class OpenSearchRequiresEvents(CharmEvents):
 
 class OpenSearchProvidesData(ProviderData):
     """Provider-side of the OpenSearch relation."""
+
+    RESOURCE_FIELD = "index"
 
     def __init__(self, model: Model, relation_name: str) -> None:
         super().__init__(model, relation_name)

--- a/src/catalog_manager.py
+++ b/src/catalog_manager.py
@@ -131,7 +131,7 @@ class CatalogBase(ABC):
             secret_content: the content of the juju secret.
         """
 
-    def _configure_catalogs(self):
+    def configure_catalogs(self):
         """Manage catalog properties files and create the appropriate catalog instance.
 
         Raises:

--- a/src/catalog_manager.py
+++ b/src/catalog_manager.py
@@ -1,0 +1,243 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Trino catalog classes."""
+
+import logging
+import textwrap
+from abc import ABC, abstractmethod
+
+import yaml
+from ops.model import SecretNotFoundError
+
+from literals import (
+    BIGQUERY_BACKEND_SCHEMA,
+    POSTGRESQL_BACKEND_SCHEMA,
+    REPLICA_SCHEMA,
+)
+from utils import add_cert_to_truststore, validate_keys
+
+logger = logging.getLogger(__name__)
+
+
+class CatalogBase(ABC):
+    """The base class for all catalog configurations."""
+
+    def __init__(self, charm, truststore_pwd, name, info, backend):
+        """Construct.
+
+        Args:
+            charm: the Trino charm.
+            truststore_pwd: the truststore password.
+            name: the catalog name.
+            info: the catalog specific information.
+            backend: the backend template for configuration.
+        """
+        self.charm = charm
+        self.truststore_pwd = truststore_pwd
+        self.name = name
+        self.info = info
+        self.backend = backend
+
+    def _add_catalog(self, catalogs):
+        """Add catalogs to Trino.
+
+        Args:
+            catalogs: the catalogs to add.
+        """
+        container = self.charm.unit.get_container(self.charm.name)
+
+        for key, value in catalogs.items():
+            config = value.replace(
+                "{SSL_PATH}", str(self.charm.truststore_abs_path)
+            ).replace("{SSL_PWD}", self.truststore_pwd)
+
+            container.push(
+                self.charm.catalog_abs_path.joinpath(f"{key}.properties"),
+                config,
+                make_dirs=True,
+            )
+
+    def _add_certs(self, certs):
+        """Prepare and add certificates to Trino truststore.
+
+        Args:
+            certs: the certificates to add.
+        """
+        if not certs:
+            return
+
+        container = self.charm.unit.get_container(self.charm.name)
+
+        for name, cert in certs.items():
+            container.push(
+                self.charm.conf_abs_path.joinpath(f"{name}.crt"),
+                cert,
+                make_dirs=True,
+            )
+            try:
+                add_cert_to_truststore(
+                    container,
+                    name,
+                    cert,
+                    self.truststore_pwd,
+                    str(self.charm.conf_abs_path),
+                )
+                container.remove_path(
+                    self.charm.conf_abs_path.joinpath(f"{name}.crt")
+                )
+            except Exception as e:
+                logger.error(f"Failed to add {name} cert: {e}")
+
+    def _add_service_account(self, sa_string, sa_creds_path):
+        """Add service account credentials.
+
+        Args:
+            sa_string: the service account credentials as a string.
+            sa_creds_path: the path to the service account file.
+        """
+        container = self.charm.unit.get_container(self.charm.name)
+        container.push(sa_creds_path, sa_string, make_dirs=True)
+
+    def _get_secret_content(self, secret_id):
+        """Get the content of a Juju secret.
+
+        Args:
+            secret_id: the juju secret id.
+
+        Returns:
+            content: the content of the secret.
+
+        Raises:
+            SecretNotFoundError: in case the secret cannot be found.
+        """
+        try:
+            secret = self.charm.model.get_secret(id=secret_id)
+            content = secret.get_content(refresh=True)
+        except SecretNotFoundError:
+            logger.error(f"secret {secret_id!r} not found.")
+            raise
+        return content
+
+    @abstractmethod
+    def _get_credentials(self):
+        """Handle connector-specific logic for retrieving credentials."""
+
+    @abstractmethod
+    def _create_properties(self, secret_content):
+        """Handle connector-specific logic for creating the `.properties` file.
+
+        Args:
+            secret_content: the content of the juju secret.
+        """
+
+    def _configure_catalogs(self):
+        """Manage catalog properties files and create the appropriate catalog instance.
+
+        Raises:
+            Exception: in case of error adding catalog.
+        """
+        try:
+            secret_content = self._get_credentials()
+            catalogs = self._create_properties(secret_content)
+            self._add_catalog(catalogs)
+            connector = self.backend["connector"]
+            logger.info(
+                f"{connector} catalog {self.name!r} added successfully"
+            )
+        except Exception as e:
+            logger.error(f"Unable to add catalog {self.name!r}: {e}")
+            raise
+
+
+class PostgresqlCatalog(CatalogBase):
+    """Class for handling the PostgreSQL connector."""
+
+    def _get_credentials(self):
+        """Handle PostgreSQL catalog configuration.
+
+        Returns:
+            replicas: the database replica configuration.
+        """
+        validate_keys(self.backend, POSTGRESQL_BACKEND_SCHEMA)
+        secret = self._get_secret_content(self.info["secret-id"])
+        replicas = yaml.safe_load(secret["replicas"])
+        certs = yaml.safe_load(secret.get("cert", ""))
+        self._add_certs(certs)
+        return replicas
+
+    def _create_properties(self, replicas):
+        """Create the PostgreSQL connector catalog files.
+
+        Args:
+            replicas: the database replica configuration.
+
+        Returns:
+            catalogs: a dictionary of catalog name and configuration.
+        """
+        catalogs = {}
+        for replica_info in replicas.values():
+            validate_keys(replica_info, REPLICA_SCHEMA)
+            user_name = replica_info.get("user")
+            user_pwd = replica_info.get("password")
+            suffix = replica_info.get("suffix", "")
+
+            catalog_name = f"{self.name}{suffix}"
+            url = f"{self.backend['url']}/{self.info['database']}"
+            if self.backend.get("params"):
+                url = f"{url}?{self.backend['params']}"
+
+            catalog_content = textwrap.dedent(
+                f"""\
+                connector.name={self.backend['connector']}
+                connection-url={url}
+                connection-user={user_name}
+                connection-password={user_pwd}
+                """
+            )
+            catalog_content += self.backend.get("config", "")
+            catalogs[catalog_name] = catalog_content
+        return catalogs
+
+
+class BigqueryCatalog(CatalogBase):
+    """Class for handling the BigQuery connector."""
+
+    def _get_credentials(self):
+        """Handle BigQuery catalog configuration.
+
+        Returns:
+            sa_creds_path: the path of the service account credentials.
+        """
+        validate_keys(self.backend, BIGQUERY_BACKEND_SCHEMA)
+
+        secret = self._get_secret_content(self.info["secret-id"])
+        service_accounts = secret["service-accounts"]
+        sa_dict = yaml.safe_load(service_accounts)
+        sa_string = sa_dict[self.info["project"]]
+
+        sa_creds_path = self.charm.conf_abs_path.joinpath(f"{self.name}.json")
+        self._add_service_account(sa_string, sa_creds_path)
+        return sa_creds_path
+
+    def _create_properties(self, sa_creds_path):
+        """Create the BigQuery connector catalog files.
+
+        Args:
+            sa_creds_path: the path of the service account credentials.
+
+        Returns:
+            catalog: a dictionary of catalog name and configuration.
+        """
+        catalog = {}
+
+        catalog_content = textwrap.dedent(
+            f"""\
+            connector.name={self.backend['connector']}
+            bigquery.project-id={self.info['project']}
+            bigquery.credentials-file={sa_creds_path}
+            """
+        )
+        catalog_content += self.backend.get("config", "")
+        catalog[self.name] = catalog_content
+        return catalog

--- a/src/charm.py
+++ b/src/charm.py
@@ -428,7 +428,7 @@ class TrinoK8SCharm(CharmBase):
             catalog_instance = self._create_catalog_instance(
                 truststore_pwd, name, info, backend
             )
-            catalog_instance._configure_catalogs()
+            catalog_instance.configure_catalogs()
 
     def _create_catalog_instance(self, truststore_pwd, name, info, backend):
         """Create catalog instances based on connector type.
@@ -445,10 +445,14 @@ class TrinoK8SCharm(CharmBase):
         Raises:
             ValueError: in case the backend type is not supported.
         """
-        if backend["connector"] == "postgresql":
-            return PostgresqlCatalog(self, truststore_pwd, name, info, backend)
-        if backend["connector"] == "bigquery":
-            return BigqueryCatalog(self, truststore_pwd, name, info, backend)
+        catalog_map = {
+            "postgresql": PostgresqlCatalog,
+            "bigquery": BigqueryCatalog,
+        }
+        catalog_cls = catalog_map.get(backend["connector"], None)
+
+        if catalog_cls is not None:
+            return catalog_cls(self, truststore_pwd, name, info, backend)
 
         raise ValueError(f"Unsupported backend: {backend}")
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -576,11 +576,7 @@ class TrinoK8SCharm(CharmBase):
             self.state.catalog_config = self.config.get("catalog-config", "")
             self.state.user_secret_id = self.config.get("user-secret-id", "")
 
-        try:
-            self._configure_catalogs(event)
-        except Exception:
-            self.unit.status = BlockedStatus("Unable to configure catalogs.")
-            return
+        self._configure_catalogs(event)
 
         self.set_java_truststore_password(event)
         env = self._create_environment()

--- a/src/charm.py
+++ b/src/charm.py
@@ -420,7 +420,7 @@ class TrinoK8SCharm(CharmBase):
                 make_dirs=True,
             )
 
-    def _add_cert(self, truststore_pwd, certs):
+    def _add_certs(self, truststore_pwd, certs):
         """Prepare and add certificates to Trino truststore.
 
         Args:
@@ -485,7 +485,7 @@ class TrinoK8SCharm(CharmBase):
         certs = yaml.safe_load(secret.get("cert", ""))
 
         # Add certs to truststore
-        self._add_cert(truststore_pwd, certs)
+        self._add_certs(truststore_pwd, certs)
 
         # Create and add catalog
         catalogs = create_postgresql_properties(name, info, backend, replicas)
@@ -711,9 +711,8 @@ class TrinoK8SCharm(CharmBase):
 
         try:
             self._configure_catalogs(event)
-        except Exception as e:
-            logger.debug(f"Unable to configure catalogs: {e}")
-            self.unit.status = BlockedStatus("Invalid catalog-config schema")
+        except Exception:
+            self.unit.status = BlockedStatus("Unable to configure catalogs.")
             return
 
         self.set_java_truststore_password(event)

--- a/src/charm.py
+++ b/src/charm.py
@@ -701,12 +701,12 @@ class TrinoK8SCharm(CharmBase):
             self.state.catalog_config = self.config.get("catalog-config", "")
             self.state.user_secret_id = self.config.get("user-secret-id", "")
 
-        # try:
-        self._configure_catalogs(event)
-        # except Exception as e:
-        #     logger.debug(f"Unable to configure catalogs: {e}")
-        #     self.unit.status = BlockedStatus("Invalid catalog-config schema")
-        #     return
+        try:
+            self._configure_catalogs(event)
+        except Exception as e:
+            logger.debug(f"Unable to configure catalogs: {e}")
+            self.unit.status = BlockedStatus("Invalid catalog-config schema")
+            return
 
         self.set_java_truststore_password(event)
         env = self._create_environment()

--- a/src/literals.py
+++ b/src/literals.py
@@ -48,59 +48,6 @@ RANGER_PLUGIN_FILES = {
 
 SECRET_LABEL = "catalog-config"  # nosec
 
-# Connector literal
-CONNECTOR_FIELDS = {
-    "elasticsearch": {
-        "required": [
-            "connector.name",
-            "elasticsearch.host",
-            "elasticsearch.port",
-            "elasticsearch.default-schema-name",
-        ],
-        "optional": [],
-    },
-    "mysql": {
-        "required": [
-            "connector.name",
-            "connection-url",
-            "connection-user",
-            "connection-password",
-        ],
-        "optional": [
-            "case-insensitive-name-matching",
-            "case-insensitive-name-matching.cache-ttl",
-            "metadata.cache-ttl",
-            "metadata.cache-missing",
-            "metadata.cache-maximum-size",
-            "write.batch-size",
-            "dynamic-filtering.enabled",
-            "dynamic-filtering.wait-timeout",
-        ],
-    },
-    "postgresql": {
-        "required": [
-            "connector.name",
-            "connection-url",
-            "connection-user",
-            "connection-password",
-        ],
-        "optional": [
-            "case-insensitive-name-matching",
-            "case-insensitive-name-matching.cache-ttl",
-            "metadata.cache-ttl",
-            "metadata.cache-missing",
-            "metadata.cache-maximum-size",
-            "write.batch-size",
-            "dynamic-filtering.enabled",
-            "dynamic-filtering.wait-timeout",
-        ],
-    },
-    "redis": {
-        "required": ["connector.name", "redis.table-names", "redis.nodes"],
-        "optional": [],
-    },
-}
-
 
 # OpenSearch literals
 INDEX_NAME = "ranger_audits"

--- a/src/literals.py
+++ b/src/literals.py
@@ -119,36 +119,15 @@ DEFAULT_JVM_OPTIONS = [
 USER_SECRET_LABEL = "trino-user-management"  # nosec
 CATALOG_SCHEMA = {
     "backend": {"type": "string"},
-    "database": {"type": "string"},
+    "database": {"type": "string", "nullable": True},
+    "project": {"type": "string", "nullable": True},
+    "secret-id": {"type": "string"},
 }
 
 POSTGRESQL_BACKEND_SCHEMA = {
     "connector": {"type": "string"},
     "url": {"type": "string"},
     "params": {"type": "string"},
-    "replicas": {
-        "type": "dict",
-        "schema": {
-            "rw": {
-                "type": "dict",
-                "schema": {
-                    "user": {"type": "string"},
-                    "password": {"type": "string"},
-                    "suffix": {"type": "string", "nullable": True},
-                },
-                "required": False,
-            },
-            "ro": {
-                "type": "dict",
-                "schema": {
-                    "user": {"type": "string"},
-                    "password": {"type": "string"},
-                    "suffix": {"type": "string", "nullable": True},
-                },
-                "required": False,
-            },
-        },
-    },
     "config": {"type": "string", "nullable": True},
 }
 
@@ -156,4 +135,9 @@ REPLICA_SCHEMA = {
     "user": {"type": "string"},
     "password": {"type": "string"},
     "suffix": {"type": "string", "nullable": True},
+}
+
+BIGQUERY_BACKEND_SCHEMA = {
+    "connector": {"type": "string"},
+    "config": {"type": "string", "nullable": True},
 }

--- a/src/utils.py
+++ b/src/utils.py
@@ -170,12 +170,12 @@ def validate_keys(data, schema):
         raise ValueError(f"Data does not conform to schema: {schema}")
 
 
-def create_postgresql_properties(name, info, backend, replicas):
+def create_postgresql_properties(cat_name, cat_info, backend, replicas):
     """Create the postgresql connector catalog files.
 
     Args:
-        name: the catalog name.
-        info: the templated configuration values.
+        cat_name: catalog name.
+        cat_info: the templated configuration values.
         backend: the db configuration values.
         replicas: the ro and rw replicas.
 
@@ -183,14 +183,14 @@ def create_postgresql_properties(name, info, backend, replicas):
         catalogs: the PostgreSQL catalogs.
     """
     catalogs = {}
-    for replica in replicas.values():
-        validate_keys(replica, REPLICA_SCHEMA)
-        user_name = replica["user"]
-        user_pwd = replica["password"]
-        suffix = replica.get("suffix", "")
+    for replica_info in replicas.values():
+        validate_keys(replica_info, REPLICA_SCHEMA)
+        user_name = replica_info.get("user")
+        user_pwd = replica_info.get("password")
+        suffix = replica_info.get("suffix", "")
 
-        file_name = f"{name}{suffix}"
-        url = f"{backend['url']}/{info['database']}"
+        catalog_name = f"{cat_name}{suffix}"
+        url = f"{backend['url']}/{cat_info['database']}"
         if backend.get("params"):
             url = f"{url}?{backend['params']}"
 
@@ -203,7 +203,7 @@ def create_postgresql_properties(name, info, backend, replicas):
         """
         )
         catalog_content += backend.get("config", "")
-        catalogs[file_name] = catalog_content
+        catalogs[catalog_name] = catalog_content
     return catalogs
 
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -346,35 +346,46 @@ async def create_catalog_config(
     Returns:
         the catalog configuration.
     """
-    catalog_config = f"""\
-    catalogs:
-        postgresql-1:
-            backend: dwh
-            database: example
-            secret-id: {postgresql_secret_id}
-    """
-
     if include_bigquery:
-        catalog_config += f"""\
-        bigquery:
-            backend: bigquery
-            project: project-12345
-            secret-id: {bigquery_secret_id}
-    """
-
-    backend_config = """\
-    backends:
-        dwh:
-            connector: postgresql
-            url: jdbc:postgresql://example.com:5432
-            params: ssl=true&sslmode=require&sslrootcert={SSL_PATH}&sslrootcertpassword={SSL_PWD}
-            config: |
-                case-insensitive-name-matching=true
-                decimal-mapping=allow_overflow
-                decimal-rounding-mode=HALF_UP
-        bigquery:
-            connector: bigquery
-            config: |
-                bigquery.case-insensitive-name-matching=true
-    """
-    return catalog_config + backend_config
+        catalog_config = f"""\
+        catalogs:
+            postgresql-1:
+                backend: dwh
+                database: example
+                secret-id: {postgresql_secret_id}
+            bigquery:
+                backend: bigquery
+                project: project-12345
+                secret-id: {bigquery_secret_id}
+        backends:
+            dwh:
+                connector: postgresql
+                url: jdbc:postgresql://example.com:5432
+                params: ssl=true&sslmode=require&sslrootcert={{SSL_PATH}}&sslrootcertpassword={{SSL_PWD}}
+                config: |
+                    case-insensitive-name-matching=true
+                    decimal-mapping=allow_overflow
+                    decimal-rounding-mode=HALF_UP
+            bigquery:
+                connector: bigquery
+                config: |
+                    bigquery.case-insensitive-name-matching=true
+        """
+    else:
+        catalog_config = f"""\
+        catalogs:
+            postgresql-1:
+                backend: dwh
+                database: example
+                secret-id: {postgresql_secret_id}
+        backends:
+            dwh:
+                connector: postgresql
+                url: jdbc:postgresql://example.com:5432
+                params: ssl=true&sslmode=require&sslrootcert={{SSL_PATH}}&sslrootcertpassword={{SSL_PWD}}
+                config: |
+                    case-insensitive-name-matching=true
+                    decimal-mapping=allow_overflow
+                    decimal-rounding-mode=HALF_UP
+        """
+    return catalog_config

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -45,7 +45,7 @@ project-12345: |
       "type": "service_account",
       "project_id": "example-project",
       "private_key_id": "key123",
-      "private_key": "-----BEGIN PRIVATE KEY-----\\ndhQfcPA9zu\\n-----END PRIVATE KEY-----\\n",
+      "private_key": "-----BEGIN PRIVATE KEY-----\\nMIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDk0x6IbejGjKC8\\nV7staWrwXlEqheosQeEYDRDkRLLe/Tw5LuNnw9Rids7vjjQpRNiRttNfeOHm9360\\nK29TbPMnLT4Iy56jnW/c+9PYXenHP1k4br1TcZ2cFJdYEV6xu4jT0mKoN9304SVI\\nlXzLtfQdzsFp4SqWtr9gaH4KSBzJoeE3pX7iLgvM3o4bUh+WH16ejfiLJZ1zQkYA\\nmu96criFAm5YnuoO2PRTo2KGoLamf3VDXLDYiWs2cSJxifwblos3Eh2zgxVRALfo\\nirtjlwAzSMjTXSC2nOyJmrDUsQyA3gJFr7TPlIIEUkGehy6/fU1z8B1yTh0ojpsq\\n8naueTSFAgMBAAECggEAcEYWSSKEgEcn5sG1GYcL7XyZnp+uUqDQbRicHSSID1l5\\nXyVedt9jKhzZVDkV5tnc2UI3XDTXwpfVF1noeaqPc72DHpWp9OWeqXL2csdBmX2/\\nrSzIwFSS3K5Nw+xh5hr5+9TSi289/JUr0f1nChzw9l8oD2dnmiN4qzkZ/rl7RoK1\\ng6Nj7U2u7qy2gf2vMH0MzFh/O+tQ3nLjwmNeOdF03ZxVDUGrkaTBftfbwSI5te7F\\nljeU7EgZVatjlyIXfi0p8OULXu6/xxpDZPYvIUxZjitjodxa5ZykmhVMBHjDVRbq\\n5Boh4laGdSiayBKMb7BCT/TwlQIPA1eEzWUJXJ8YUQKBgQDr3DKxAIajCP6IdTVT\\n75tHqc2TCqIS6QfM62X4NIw/ETUtiAU9+Pq33OBnivDSjbI9NPpSLbX18ttyPugn\\nPcgC0EUf2+5/EniD7khqjZLQXLK4WZXN6M15NS87cznOm9qbWway15f+iWF4qr0d\\nN8jsVypbSEicWiKUrq2IiJSMrwKBgQD4XSEHxQtmX7nk/ImhqWl1C9QkwiAlvLxy\\nGUIUwHkpbxRHE1tovT3XS9shQK3MZzMYG6d60bNIMIkpyvbN4+ptikCFsSikuAkP\\nE1865ipxCUaInbMYk3lzuNfPO4hP52pjW5r67WD6O1qjLdTsacPXCCSepEjKe+Rd\\nktUiGv+nCwKBgHCVfHD3Ek1ydqVGZX06a4GqsSFWOwURzRJo7xSqaKOWIC8qtW3e\\nkjb/rPJf5RJsZr9GsZJWlXvgQBXpp0FMAVQufEB36AEqHPLE5DZQe9sP1JOg15wh\\nWytXUsNq/hX8WT49FhZ6SOhMRYWm4ny26ya9eM930oknkUgtlVIN9/KrAoGAAJVn\\ncHc8EZ+D9k/JmwGk58uBUhzKqowI/VOl3hqdrkU+jPQ0sMhRDuJ0v11Bi0tqyVG3\\nUQiRHUhP6jM55T313RAIGshRyiFMlCZ9gMvtqZpV+hg0xYgDLwxuJWSEa3ululoK\\nwTAxnCTrj5qZ93xAI483VtAYA7HK1ZV0vsHFfAUCgYB13ErBMkV3cOFsUHOYUzXo\\nQbeIhRDthqTw4xToTsCaZnweZDEtqmnJMfRmbAqzPNbRjGjd7uH5dssqD7H3kpA5\\noywUbHhRzvJJvmk0enpnbjP6NY51goJ/WUVM4n6AZC6v3cfE9HNBAiPEaDAZT/ul\\nbDOWB1LReVCV5YytEsR/KA==\\n-----END PRIVATE KEY-----",
       "client_email": "test-380@example-project.iam.gserviceaccount.com",
       "client_id": "12345",
       "auth_uri": "https://accounts.google.com/o/oauth2/auth",
@@ -54,7 +54,7 @@ project-12345: |
       "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/test-380.project.iam.gserviceaccount.com",
       "universe_domain": "googleapis.com"
     }
-"""  #nosec
+"""  # nosec
 
 POSTGRESQL_REPLICA_SECRET = """\
 rw:
@@ -64,7 +64,7 @@ rw:
 ro:
   user: trino_ro
   password: pwd2
-"""  #nosec
+"""  # nosec
 
 CATALOG_QUERY = "SHOW CATALOGS"
 TRINO_USER = "trino"
@@ -377,7 +377,9 @@ async def create_catalog_config(postgresql_secret_id, bigquery_secret_id):
     """
 
 
-async def create_reduced_catalog_config(postgresql_secret_id, bigquery_secret_id):
+async def create_reduced_catalog_config(
+    postgresql_secret_id, bigquery_secret_id
+):
     """Create and return catalog-config value.
 
     Args:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -305,12 +305,12 @@ async def curl_unit_ip(ops_test):
     return response
 
 
-async def add_juju_secret(ops_test: OpsTest, secret_type: str):
+async def add_juju_secret(ops_test: OpsTest, connector_type: str):
     """Add Juju user secret to model.
 
     Args:
         ops_test: PyTest object.
-        secret_type: Type of secret to add ('postgresql' or 'bigquery').
+        connector_type: Type of secret to add ('postgresql' or 'bigquery').
 
     Returns:
         secret ID of created secret.
@@ -318,15 +318,15 @@ async def add_juju_secret(ops_test: OpsTest, secret_type: str):
     Raises:
         ValueError: in case connector is not supported.
     """
-    if secret_type == "postgresql":
-        data_args = [f"replicas={POSTGRESQL_REPLICA_SECRET}"]
-    elif secret_type == "bigquery":
-        data_args = [f"service-accounts={BIGQUERY_SECRET}"]
+    if connector_type == "postgresql":
+        data_args = [f"replicas={POSTGRESQL_REPLICA_SECRET}"]  # nosec
+    elif connector_type == "bigquery":
+        data_args = [f"service-accounts={BIGQUERY_SECRET}"]  # nosec
     else:
-        raise ValueError(f"Unsupported secret type: {secret_type}")
+        raise ValueError(f"Unsupported secret type: {connector_type}")
 
     juju_secret = await ops_test.model.add_secret(
-        name=f"{secret_type}-secret", data_args=data_args
+        name=f"{connector_type}-secret", data_args=data_args
     )
 
     secret_id = juju_secret.split(":")[-1]

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -42,19 +42,20 @@ NGINX_NAME = "nginx-ingress-integrator"
 BIGQUERY_SECRET = """\
 project-12345: |
     {
-  "type": "service_account",
-  "project_id": "example-project",
-  "private_key_id": "key123",
-  "private_key": "-----BEGIN PRIVATE KEY-----dhQfcPA9zu\n-----END PRIVATE KEY-----\n",
-  "client_email": "test-380@example-project.iam.gserviceaccount.com",
-  "client_id": "12345",
-  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-  "token_uri": "https://oauth2.googleapis.com/token",
-  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
-  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/test-380.project.iam.gserviceaccount.com",
-  "universe_domain": "googleapis.com"
-}
+      "type": "service_account",
+      "project_id": "example-project",
+      "private_key_id": "key123",
+      "private_key": "-----BEGIN PRIVATE KEY-----\\ndhQfcPA9zu\\n-----END PRIVATE KEY-----\\n",
+      "client_email": "test-380@example-project.iam.gserviceaccount.com",
+      "client_id": "12345",
+      "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+      "token_uri": "https://oauth2.googleapis.com/token",
+      "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+      "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/test-380.project.iam.gserviceaccount.com",
+      "universe_domain": "googleapis.com"
+    }
 """  #nosec
+
 POSTGRESQL_REPLICA_SECRET = """\
 rw:
   user: trino

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -341,7 +341,7 @@ async def add_bigquery_juju_secret(ops_test: OpsTest):
     return secret_id
 
 
-def create_catalog_config(postgresql_secret_id, bigquery_secret_id):
+async def create_catalog_config(postgresql_secret_id, bigquery_secret_id):
     """Create and return catalog-config value.
 
     Args:
@@ -377,7 +377,7 @@ def create_catalog_config(postgresql_secret_id, bigquery_secret_id):
     """
 
 
-def create_reduced_catalog_config(postgresql_secret_id, bigquery_secret_id):
+async def create_reduced_catalog_config(postgresql_secret_id, bigquery_secret_id):
     """Create and return catalog-config value.
 
     Args:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -94,7 +94,6 @@ WORKER_QUERY = "SELECT * FROM system.runtime.nodes"
 WORKER_CONFIG = {"charm-function": "worker"}
 COORDINATOR_CONFIG = {
     "charm-function": "coordinator",
-    "catalog-config": TEMP_CATALOG_CONFIG,
 }
 
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -83,7 +83,7 @@ class TestDeployment:
         assert response.status_code == 200
 
         catalogs = await get_catalogs(ops_test, TRINO_USER, APP_NAME)
-        assert "postgresql-1" in str(catalogs)
+        assert catalogs
 
     async def test_trino_default_policy(self, ops_test: OpsTest):
         """Update the config and verify no catalog access."""

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -10,11 +10,11 @@ import pytest
 from conftest import deploy  # noqa: F401, pylint: disable=W0611
 from helpers import (
     APP_NAME,
-    CATALOG_CONFIG,
-    EXAMPLE_CATALOG_NAME,
-    TEMP_CATALOG_CONFIG,
-    TEMP_CATALOG_NAME,
     TRINO_USER,
+    add_bigquery_juju_secret,
+    add_postgresql_juju_secret,
+    create_catalog_config,
+    create_reduced_catalog_config,
     curl_unit_ip,
     get_catalogs,
     simulate_crash_and_restart,
@@ -41,25 +41,36 @@ class TestDeployment:
         logging.info(f"Found catalogs: {catalogs}")
         assert catalogs
 
-    async def test_add_catalog(self, ops_test: OpsTest):
-        """Adds a PostgreSQL connector and confirms database added."""
+    async def test_catalog_config(self, ops_test: OpsTest):
+        """Adds a PostgreSQL and BigQuery connector and asserts catalogs added."""
+        postgresql_secret_id = await add_postgresql_juju_secret(ops_test)
+        bigquery_secret_id = await add_bigquery_juju_secret(ops_test)
+
+        for app in ["trino-k8s", "trino-k8s-worker"]:
+            await ops_test.model.grant_secret("postgresql-secret", app)
+            await ops_test.model.grant_secret("bigquery-secret", app)
+
+        catalog_config = await create_catalog_config(
+            postgresql_secret_id, bigquery_secret_id
+        )
         catalogs = await update_catalog_config(
-            ops_test, CATALOG_CONFIG, TRINO_USER
+            ops_test, catalog_config, TRINO_USER
         )
 
         # Verify that both catalogs have been added.
-        assert TEMP_CATALOG_NAME in str(catalogs)
-        assert EXAMPLE_CATALOG_NAME in str(catalogs)
+        assert "postgresql-1" in str(catalogs)
+        assert "bigquery" in str(catalogs)
 
-    async def test_remove_catalog(self, ops_test: OpsTest):
-        """Removes an existing connector confirms database removed."""
+        updated_catalog_config = await create_reduced_catalog_config(
+            postgresql_secret_id, bigquery_secret_id
+        )
         catalogs = await update_catalog_config(
-            ops_test, TEMP_CATALOG_CONFIG, TRINO_USER
+            ops_test, updated_catalog_config, TRINO_USER
         )
 
-        # Verify that only the example catalog has been removed.
-        assert TEMP_CATALOG_NAME in str(catalogs)
-        assert EXAMPLE_CATALOG_NAME not in str(catalogs)
+        # Verify that only the bigquery catalog has been removed.
+        assert "postgresql-1" in str(catalogs)
+        assert "bigquery" not in str(catalogs)
 
     async def test_simulate_crash(self, ops_test: OpsTest):
         """Simulate the crash of the Trino coordinator charm.
@@ -72,7 +83,7 @@ class TestDeployment:
         assert response.status_code == 200
 
         catalogs = await get_catalogs(ops_test, TRINO_USER, APP_NAME)
-        assert TEMP_CATALOG_NAME in str(catalogs)
+        assert "postgresql-1" in str(catalogs)
 
     async def test_trino_default_policy(self, ops_test: OpsTest):
         """Update the config and verify no catalog access."""

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -12,7 +12,7 @@ project-12345: |
       "type": "service_account",
       "project_id": "example-project",
       "private_key_id": "key123",
-      "private_key": "-----BEGIN PRIVATE KEY-----\\ndhQfcPA9zu\\n-----END PRIVATE KEY-----\\n",
+      "private_key": "-----BEGIN PRIVATE KEY-----\\nMIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDk0x6IbejGjKC8\\nV7staWrwXlEqheosQeEYDRDkRLLe/Tw5LuNnw9Rids7vjjQpRNiRttNfeOHm9360\\nK29TbPMnLT4Iy56jnW/c+9PYXenHP1k4br1TcZ2cFJdYEV6xu4jT0mKoN9304SVI\\nlXzLtfQdzsFp4SqWtr9gaH4KSBzJoeE3pX7iLgvM3o4bUh+WH16ejfiLJZ1zQkYA\\nmu96criFAm5YnuoO2PRTo2KGoLamf3VDXLDYiWs2cSJxifwblos3Eh2zgxVRALfo\\nirtjlwAzSMjTXSC2nOyJmrDUsQyA3gJFr7TPlIIEUkGehy6/fU1z8B1yTh0ojpsq\\n8naueTSFAgMBAAECggEAcEYWSSKEgEcn5sG1GYcL7XyZnp+uUqDQbRicHSSID1l5\\nXyVedt9jKhzZVDkV5tnc2UI3XDTXwpfVF1noeaqPc72DHpWp9OWeqXL2csdBmX2/\\nrSzIwFSS3K5Nw+xh5hr5+9TSi289/JUr0f1nChzw9l8oD2dnmiN4qzkZ/rl7RoK1\\ng6Nj7U2u7qy2gf2vMH0MzFh/O+tQ3nLjwmNeOdF03ZxVDUGrkaTBftfbwSI5te7F\\nljeU7EgZVatjlyIXfi0p8OULXu6/xxpDZPYvIUxZjitjodxa5ZykmhVMBHjDVRbq\\n5Boh4laGdSiayBKMb7BCT/TwlQIPA1eEzWUJXJ8YUQKBgQDr3DKxAIajCP6IdTVT\\n75tHqc2TCqIS6QfM62X4NIw/ETUtiAU9+Pq33OBnivDSjbI9NPpSLbX18ttyPugn\\nPcgC0EUf2+5/EniD7khqjZLQXLK4WZXN6M15NS87cznOm9qbWway15f+iWF4qr0d\\nN8jsVypbSEicWiKUrq2IiJSMrwKBgQD4XSEHxQtmX7nk/ImhqWl1C9QkwiAlvLxy\\nGUIUwHkpbxRHE1tovT3XS9shQK3MZzMYG6d60bNIMIkpyvbN4+ptikCFsSikuAkP\\nE1865ipxCUaInbMYk3lzuNfPO4hP52pjW5r67WD6O1qjLdTsacPXCCSepEjKe+Rd\\nktUiGv+nCwKBgHCVfHD3Ek1ydqVGZX06a4GqsSFWOwURzRJo7xSqaKOWIC8qtW3e\\nkjb/rPJf5RJsZr9GsZJWlXvgQBXpp0FMAVQufEB36AEqHPLE5DZQe9sP1JOg15wh\\nWytXUsNq/hX8WT49FhZ6SOhMRYWm4ny26ya9eM930oknkUgtlVIN9/KrAoGAAJVn\\ncHc8EZ+D9k/JmwGk58uBUhzKqowI/VOl3hqdrkU+jPQ0sMhRDuJ0v11Bi0tqyVG3\\nUQiRHUhP6jM55T313RAIGshRyiFMlCZ9gMvtqZpV+hg0xYgDLwxuJWSEa3ululoK\\nwTAxnCTrj5qZ93xAI483VtAYA7HK1ZV0vsHFfAUCgYB13ErBMkV3cOFsUHOYUzXo\\nQbeIhRDthqTw4xToTsCaZnweZDEtqmnJMfRmbAqzPNbRjGjd7uH5dssqD7H3kpA5\\noywUbHhRzvJJvmk0enpnbjP6NY51goJ/WUVM4n6AZC6v3cfE9HNBAiPEaDAZT/ul\\nbDOWB1LReVCV5YytEsR/KA==\\n-----END PRIVATE KEY-----",
       "client_email": "test-380@example-project.iam.gserviceaccount.com",
       "client_id": "12345",
       "auth_uri": "https://accounts.google.com/o/oauth2/auth",
@@ -21,7 +21,7 @@ project-12345: |
       "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/test-380.project.iam.gserviceaccount.com",
       "universe_domain": "googleapis.com"
     }
-"""  #nosec
+"""  # nosec
 POSTGRESQL_REPLICA_SECRET = """\
 rw:
   user: trino
@@ -30,13 +30,13 @@ rw:
 ro:
   user: trino_ro
   password: pwd2
-"""  #nosec
+"""  # nosec
 POSTGRESQL_REPLICA_CERT = """\
 cert: |
   -----BEGIN CERTIFICATE-----
       CERTIFICATE CONTENT...
   -----END CERTIFICATE-----
-"""  #nosec
+"""  # nosec
 
 POSTGRESQL_1_CATALOG_PATH = (
     "/usr/lib/trino/etc/catalog/postgresql-1.properties"

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -9,18 +9,18 @@ SERVER_PORT = "8080"
 BIGQUERY_SECRET = """\
 project-12345: |
     {
-  "type": "service_account",
-  "project_id": "example-project",
-  "private_key_id": "key123",
-  "private_key": "-----BEGIN PRIVATE KEY-----dhQfcPA9zu\n-----END PRIVATE KEY-----\n",
-  "client_email": "test-380@example-project.iam.gserviceaccount.com",
-  "client_id": "12345",
-  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-  "token_uri": "https://oauth2.googleapis.com/token",
-  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
-  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/test-380.project.iam.gserviceaccount.com",
-  "universe_domain": "googleapis.com"
-}
+      "type": "service_account",
+      "project_id": "example-project",
+      "private_key_id": "key123",
+      "private_key": "-----BEGIN PRIVATE KEY-----\\ndhQfcPA9zu\\n-----END PRIVATE KEY-----\\n",
+      "client_email": "test-380@example-project.iam.gserviceaccount.com",
+      "client_id": "12345",
+      "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+      "token_uri": "https://oauth2.googleapis.com/token",
+      "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+      "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/test-380.project.iam.gserviceaccount.com",
+      "universe_domain": "googleapis.com"
+    }
 """  #nosec
 POSTGRESQL_REPLICA_SECRET = """\
 rw:

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -4,106 +4,40 @@
 
 """Literals used by the Trino K8s charm unit tests."""
 
-
 SERVER_PORT = "8080"
-TEST_CATALOG_CONFIG = """\
-catalogs:
-  example:
-    backend: dwh
-    database: example
-  updated-db:
-    backend: dwh
-    database: updated-db
-backends:
-  dwh:
-    connector: postgresql
-    url: jdbc:postgresql://example.com:5432
-    params: ssl=true&sslmode=require&sslrootcert={SSL_PATH}&sslrootcertpassword={SSL_PWD}
-    replicas:
-      rw:
-        user: trino
-        password: pwd1
-        suffix: _developer
-      ro:
-        user: trino_ro
-        password: pwd2
-    config: |
-      case-insensitive-name-matching=true
-      decimal-mapping=allow_overflow
-      decimal-rounding-mode=HALF_UP
-certs:
-    example-cert: |
-        -----BEGIN CERTIFICATE-----
-        CERTIFICATE CONTENT...
-        -----END CERTIFICATE-----
+
+BIGQUERY_SECRET = """\
+project-12345: |
+  base64encodedserviceaccountcredentials
 """
-INCORRECT_CATALOG_CONFIG = """\
-catalogs:
-  example:
-    database: example
-  updated-db:
-    backend: dwh
-    database: updated-db
-backends:
-  dwh:
-    connector: postgresql
-    url: jdbc:postgresql://example.com:5432
-    params: ssl=true&sslmode=require&sslrootcert={SSL_PATH}&sslrootcertpassword={SSL_PWD}
-    replicas:
-      rw:
-        user: trino
-        password: pwd1
-        suffix: _developer
-      ro:
-        user: trino_ro
-        password: pwd2
-    config: |
-      case-insensitive-name-matching=true
-      decimal-mapping=allow_overflow
-      decimal-rounding-mode=HALF_UP
-certs:
-    example-cert: |
-        -----BEGIN CERTIFICATE-----
-        CERTIFICATE CONTENT...
-        -----END CERTIFICATE-----
+POSTGRESQL_REPLICA_SECRET = """\
+rw:
+  user: trino
+  password: pwd1
+  suffix: _developer
+ro:
+  user: trino_ro
+  password: pwd2
+"""
+POSTGRESQL_REPLICA_CERT = """\
+cert: |
+  -----BEGIN CERTIFICATE-----
+      CERTIFICATE CONTENT...
+  -----END CERTIFICATE-----
 """
 
-UPDATED_CATALOG_CONFIG = """\
-catalogs:
-  updated:
-    backend: dwh
-    database: updated-db
-backends:
-  dwh:
-    connector: postgresql
-    url: jdbc:postgresql://updated.com:5432
-    params: ssl=true&sslmode=require&sslrootcert={SSL_PATH}&sslrootcertpassword={SSL_PWD}
-    replicas:
-      rw:
-        user: trino
-        password: pwd1
-        suffix: _developer
-      ro:
-        user: trino_ro
-        password: pwd2
-    config: |
-      case-insensitive-name-matching=true
-      decimal-mapping=allow_overflow
-      decimal-rounding-mode=HALF_UP
-certs:
-    example-cert: |
-        -----BEGIN CERTIFICATE-----
-        CERTIFICATE CONTENT...
-        -----END CERTIFICATE-----
-"""
-TEST_CATALOG_PATH = "/usr/lib/trino/etc/catalog/example.properties"
-UPDATED_CATALOG_PATH = "/usr/lib/trino/etc/catalog/updated.properties"
+POSTGRESQL_1_CATALOG_PATH = (
+    "/usr/lib/trino/etc/catalog/postgresql-1.properties"
+)
+POSTGRESQL_2_CATALOG_PATH = (
+    "/usr/lib/trino/etc/catalog/postgresql-2.properties"
+)
+BIGQUERY_CATALOG_PATH = "/usr/lib/trino/etc/catalog/bigquery.properties"
 RANGER_PROPERTIES_PATH = "/usr/lib/ranger/install.properties"
 POLICY_MGR_URL = "http://ranger-k8s:6080"
 
 RANGER_LIB = "/usr/lib/ranger"
 
-JAVA_HOME = "/usr/lib/jvm/java-21-openjdk-amd64"
 TEST_USERS = """\
     example_user: ubuntu123
     another_user: ubuntu345

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -8,8 +8,20 @@ SERVER_PORT = "8080"
 
 BIGQUERY_SECRET = """\
 project-12345: |
-  base64encodedserviceaccountcredentials
-"""
+    {
+  "type": "service_account",
+  "project_id": "example-project",
+  "private_key_id": "key123",
+  "private_key": "-----BEGIN PRIVATE KEY-----dhQfcPA9zu\n-----END PRIVATE KEY-----\n",
+  "client_email": "test-380@example-project.iam.gserviceaccount.com",
+  "client_id": "12345",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/test-380.project.iam.gserviceaccount.com",
+  "universe_domain": "googleapis.com"
+}
+"""  #nosec
 POSTGRESQL_REPLICA_SECRET = """\
 rw:
   user: trino
@@ -18,13 +30,13 @@ rw:
 ro:
   user: trino_ro
   password: pwd2
-"""
+"""  #nosec
 POSTGRESQL_REPLICA_CERT = """\
 cert: |
   -----BEGIN CERTIFICATE-----
       CERTIFICATE CONTENT...
   -----END CERTIFICATE-----
-"""
+"""  #nosec
 
 POSTGRESQL_1_CATALOG_PATH = (
     "/usr/lib/trino/etc/catalog/postgresql-1.properties"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -317,7 +317,7 @@ class TestCharm(TestCase):
 
         self.assertEqual(
             harness.model.unit.status,
-            BlockedStatus("Invalid catalog-config schema"),
+            BlockedStatus("Unable to configure catalogs."),
         )
 
     def test_catalog_removed(self):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -576,10 +576,6 @@ def simulate_lifecycle_coordinator(harness):
     )
     harness.charm.on.trino_pebble_ready.emit(container)
 
-    # Add worker and coordinator relation
-    harness.handle_exec("trino", ["keytool"], result=0)
-    harness.update_config({"catalog-config": TEST_CATALOG_CONFIG})
-    rel_id = harness.add_relation("trino-coordinator", "trino-k8s-worker")
     secret_id = harness.add_model_secret(
         "trino-k8s",
         {"users": TEST_USERS},

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -21,14 +21,15 @@ from ops.model import (
 from ops.pebble import CheckStatus
 from ops.testing import Harness
 from unit.helpers import (
+    BIGQUERY_CATALOG_PATH,
+    BIGQUERY_SECRET,
     DEFAULT_JVM_STRING,
-    INCORRECT_CATALOG_CONFIG,
+    POSTGRESQL_1_CATALOG_PATH,
+    POSTGRESQL_2_CATALOG_PATH,
+    POSTGRESQL_REPLICA_CERT,
+    POSTGRESQL_REPLICA_SECRET,
     SERVER_PORT,
-    TEST_CATALOG_CONFIG,
-    TEST_CATALOG_PATH,
     TEST_USERS,
-    UPDATED_CATALOG_CONFIG,
-    UPDATED_CATALOG_PATH,
     UPDATED_JVM_OPTIONS,
     USER_JVM_STRING,
 )
@@ -88,7 +89,14 @@ class TestCharm(TestCase):
     def test_ready(self):
         """The pebble plan is correctly generated when the charm is ready."""
         harness = self.harness
-        simulate_lifecycle_coordinator(harness)
+        (
+            _,
+            postgresql_secret_id,
+            bigquery_secret_id,
+        ) = simulate_lifecycle_coordinator(harness)
+        catalog_config = create_catalog_config(
+            postgresql_secret_id, bigquery_secret_id
+        )
 
         # Asserts status is active
         self.assertEqual(
@@ -106,7 +114,7 @@ class TestCharm(TestCase):
                     "startup": "enabled",
                     "on-check-failure": {"up": "ignore"},
                     "environment": {
-                        "CATALOG_CONFIG": TEST_CATALOG_CONFIG,
+                        "CATALOG_CONFIG": catalog_config,
                         "PASSWORD_DB_PATH": "/usr/lib/trino/etc/password.db",
                         "LOG_LEVEL": "info",
                         "OAUTH_CLIENT_ID": None,
@@ -212,7 +220,15 @@ class TestCharm(TestCase):
     def test_config_changed(self):
         """The pebble plan changes according to config changes."""
         harness = self.harness
-        simulate_lifecycle_coordinator(harness)
+        (
+            _,
+            postgresql_secret_id,
+            bigquery_secret_id,
+        ) = simulate_lifecycle_coordinator(harness)
+
+        catalog_config = create_catalog_config(
+            postgresql_secret_id, bigquery_secret_id
+        )
 
         # Update the config.
         self.harness.update_config(
@@ -235,7 +251,7 @@ class TestCharm(TestCase):
                     "startup": "enabled",
                     "on-check-failure": {"up": "ignore"},
                     "environment": {
-                        "CATALOG_CONFIG": TEST_CATALOG_CONFIG,
+                        "CATALOG_CONFIG": catalog_config,
                         "PASSWORD_DB_PATH": "/usr/lib/trino/etc/password.db",
                         "LOG_LEVEL": "info",
                         "OAUTH_CLIENT_ID": "test-client-id",
@@ -274,23 +290,30 @@ class TestCharm(TestCase):
     def test_catalog_added(self):
         """The catalog directory is updated to add the new catalog."""
         harness = self.harness
-        simulate_lifecycle_coordinator(harness)
+        (
+            _,
+            postgresql_secret_id,
+            bigquery_secret_id,
+        ) = simulate_lifecycle_coordinator(harness)
+
+        catalog_config = create_added_catalog_config(
+            postgresql_secret_id, bigquery_secret_id
+        )
 
         # Update the config.
-        self.harness.update_config({"catalog-config": TEST_CATALOG_CONFIG})
+        self.harness.update_config({"catalog-config": catalog_config})
 
         # Validate catalog.properties file created.
         container = harness.model.unit.get_container("trino")
-        self.assertTrue(container.exists(TEST_CATALOG_PATH))
+        self.assertTrue(container.exists(POSTGRESQL_2_CATALOG_PATH))
+        self.assertTrue(container.exists(BIGQUERY_CATALOG_PATH))
 
     def test_catalog_invalid_config(self):
         """The catalog directory is updated to add the new catalog."""
         harness = self.harness
         simulate_lifecycle_coordinator(harness)
 
-        self.harness.update_config(
-            {"catalog-config": INCORRECT_CATALOG_CONFIG}
-        )
+        self.harness.update_config({"catalog-config": "catalog: incorrect"})
 
         self.assertEqual(
             harness.model.unit.status,
@@ -307,7 +330,8 @@ class TestCharm(TestCase):
 
         # Validate catalog.properties file created.
         container = harness.model.unit.get_container("trino")
-        self.assertFalse(container.exists(TEST_CATALOG_PATH))
+        self.assertFalse(container.exists(POSTGRESQL_1_CATALOG_PATH))
+        self.assertFalse(container.exists(BIGQUERY_CATALOG_PATH))
 
     def test_update_status_up(self):
         """The charm updates the unit status to active based on UP status."""
@@ -361,26 +385,46 @@ class TestCharm(TestCase):
         The coordinator and worker Trino charms relate correctly.
         """
         harness = self.harness
-        rel_id = simulate_lifecycle_coordinator(harness)
+
+        (
+            rel_id,
+            postgresql_secret_id,
+            bigquery_secret_id,
+        ) = simulate_lifecycle_coordinator(harness)
+
+        catalog_config = create_catalog_config(
+            postgresql_secret_id, bigquery_secret_id
+        )
         relation_data = harness.get_relation_data(rel_id, harness.charm.app)
         secret = harness.model.get_secret(label="catalog-config")
         content = secret.get_content()
 
         assert relation_data["discovery-uri"] == "http://trino-k8s:8080"
         assert "secret:" in relation_data["catalog-secret-id"]
-        assert content["catalogs"] == TEST_CATALOG_CONFIG
+        assert content["catalogs"] == catalog_config
 
     def test_trino_worker_secret_changed(self):
         """Test the worker catalogs change when the secret content changes."""
         harness = self.harness
-        container, _, secret_id = simulate_lifecycle_worker(harness)
+        (
+            container,
+            _,
+            postgresql_secret_id,
+            bigquery_secret_id,
+            secret_id,
+        ) = simulate_lifecycle_worker(harness)
+
+        catalog_config = create_added_catalog_config(
+            postgresql_secret_id, bigquery_secret_id
+        )
         secret = harness.model.get_secret(id=secret_id)
-        secret.set_content({"catalogs": UPDATED_CATALOG_CONFIG})
+
+        secret.set_content({"catalogs": catalog_config})
         harness.charm.on.secret_changed.emit(
             label="catalog-config", id=secret_id
         )
 
-        self.assertTrue(container.exists(UPDATED_CATALOG_PATH))
+        self.assertTrue(container.exists(POSTGRESQL_1_CATALOG_PATH))
 
     def test_trino_coordinator_relation_broken(self):
         """Test trino relation.
@@ -403,9 +447,10 @@ class TestCharm(TestCase):
         The coordinator and worker Trino charms relate correctly.
         """
         harness = self.harness
-        container, _, _ = simulate_lifecycle_worker(harness)
+        container, _, _, _, _ = simulate_lifecycle_worker(harness)
 
-        self.assertTrue(container.exists(TEST_CATALOG_PATH))
+        self.assertTrue(container.exists(BIGQUERY_CATALOG_PATH))
+        self.assertTrue(container.exists(POSTGRESQL_1_CATALOG_PATH))
 
     def test_trino_worker_relation_broken(self):
         """Test trino relation broken.
@@ -413,16 +458,19 @@ class TestCharm(TestCase):
         The coordinator and worker Trino charms relation is broken.
         """
         harness = self.harness
-        container, event, _ = simulate_lifecycle_worker(harness)
+        container, event, _, _, _ = simulate_lifecycle_worker(harness)
 
         harness.charm.trino_worker._on_relation_broken(event)
-        self.assertFalse(container.exists(TEST_CATALOG_PATH))
+        self.assertFalse(container.exists(POSTGRESQL_1_CATALOG_PATH))
 
     def test_trino_single_node_deployment(self):
         """Test pebble plan is created with single node deployment."""
         harness = self.harness
         harness.add_relation("peer", "trino")
 
+        harness.handle_exec(
+            "trino", ["/bin/sh"], result="/usr/lib/jvm/java-21-openjdk-amd64/"
+        )
         harness.handle_exec("trino", ["keytool"], result=0)
         container = harness.model.unit.get_container("trino")
         harness.handle_exec("trino", ["htpasswd"], result=0)
@@ -459,14 +507,34 @@ def simulate_lifecycle_worker(harness):
     # Simulate pebble readiness.
     harness.handle_exec("trino", ["keytool"], result=0)
     harness.handle_exec("trino", ["htpasswd"], result=0)
+    harness.handle_exec(
+        "trino", ["/bin/sh"], result="/usr/lib/jvm/java-21-openjdk-amd64/"
+    )
     harness.update_config({"charm-function": "worker"})
+
+    # Add catalog secrets
+    bigquery_secret_id = harness.add_model_secret(
+        "trino-k8s",
+        {"service-accounts": BIGQUERY_SECRET},
+    )
+
+    postgresql_secret_id = harness.add_model_secret(
+        "trino-k8s",
+        {
+            "replicas": POSTGRESQL_REPLICA_SECRET,
+            "cert": POSTGRESQL_REPLICA_CERT,
+        },
+    )
+    catalog_config = create_catalog_config(
+        postgresql_secret_id, bigquery_secret_id
+    )
 
     container = harness.model.unit.get_container("trino")
     harness.charm.on.trino_pebble_ready.emit(container)
 
     secret_id = harness.add_model_secret(
         "trino-k8s",
-        {"catalogs": TEST_CATALOG_CONFIG},
+        {"catalogs": catalog_config},
     )
     rel_id = harness.add_relation("trino-worker", "trino-k8s")
     harness.add_relation_unit(rel_id, "trino-k8s-worker/0")
@@ -479,7 +547,13 @@ def simulate_lifecycle_worker(harness):
     }
     event = make_relation_event("trino-worker", rel_id, data)
     harness.charm.trino_worker._on_relation_changed(event)
-    return container, event, secret_id
+    return (
+        container,
+        event,
+        postgresql_secret_id,
+        bigquery_secret_id,
+        secret_id,
+    )
 
 
 def simulate_lifecycle_coordinator(harness):
@@ -497,19 +571,40 @@ def simulate_lifecycle_coordinator(harness):
     # Simulate pebble readiness.
     container = harness.model.unit.get_container("trino")
     harness.handle_exec("trino", ["htpasswd"], result=0)
-    harness.charm.on.trino_pebble_ready.emit(container)
-
-    # Add worker and coordinator relation
-    harness.handle_exec("trino", ["keytool"], result=0)
-    harness.update_config({"catalog-config": TEST_CATALOG_CONFIG})
-    rel_id = harness.add_relation("trino-coordinator", "trino-k8s-worker")
+    harness.handle_exec(
+        "trino", ["/bin/sh"], result="/usr/lib/jvm/java-21-openjdk-amd64/"
+    )
     secret_id = harness.add_model_secret(
         "trino-k8s",
         {"users": TEST_USERS},
     )
 
+    harness.charm.on.trino_pebble_ready.emit(container)
+
+    # Add catalog secrets
+    bigquery_secret_id = harness.add_model_secret(
+        "trino-k8s",
+        {"service-accounts": BIGQUERY_SECRET},
+    )
+
+    postgresql_secret_id = harness.add_model_secret(
+        "trino-k8s",
+        {
+            "replicas": POSTGRESQL_REPLICA_SECRET,
+            "cert": POSTGRESQL_REPLICA_CERT,
+        },
+    )
+    catalog_config = create_catalog_config(
+        postgresql_secret_id, bigquery_secret_id
+    )
+
+    # Add worker and coordinator relation
+    harness.handle_exec("trino", ["keytool"], result=0)
+    harness.update_config({"catalog-config": catalog_config})
+    rel_id = harness.add_relation("trino-coordinator", "trino-k8s-worker")
+
     harness.update_config({"user-secret-id": secret_id})
-    return rel_id
+    return rel_id, postgresql_secret_id, bigquery_secret_id
 
 
 def make_relation_event(app, rel_id, data):
@@ -540,6 +635,82 @@ def make_relation_event(app, rel_id, data):
             ),
         },
     )
+
+
+def create_catalog_config(postgresql_secret_id, bigquery_secret_id):
+    """Create and return catalog-config value.
+
+    Args:
+        postgresql_secret_id: the juju secret id for postgresql
+        bigquery_secret_id: the juju secret id for bigquery
+
+    Returns:
+        the catalog configuration.
+    """
+    return f"""\
+    catalogs:
+        postgresql-1:
+            backend: dwh
+            database: example
+            secret-id: {postgresql_secret_id}
+        bigquery:
+            backend: bigquery
+            project: project-12345
+            secret-id: {bigquery_secret_id}
+    backends:
+        dwh:
+            connector: postgresql
+            url: jdbc:postgresql://example.com:5432
+            params: ssl=true&sslmode=require&sslrootcert={{SSL_PATH}}&sslrootcertpassword={{SSL_PWD}}
+            config: |
+                case-insensitive-name-matching=true
+                decimal-mapping=allow_overflow
+                decimal-rounding-mode=HALF_UP
+        bigquery:
+            connector: bigquery
+            config: |
+                bigquery.case-insensitive-name-matching=true
+    """
+
+
+def create_added_catalog_config(postgresql_secret_id, bigquery_secret_id):
+    """Create and return catalog-config value, with added catalog.
+
+    Args:
+        postgresql_secret_id: the juju secret id for postgresql
+        bigquery_secret_id: the juju secret id for bigquery
+
+    Returns:
+        the catalog configuration, with an added catalog.
+    """
+    return f"""\
+    catalogs:
+        postgresql-1:
+            backend: dwh
+            database: example
+            secret-id: {postgresql_secret_id}
+        postgresql-2:
+            backend: dwh
+            database: updated-db
+            secret-id: {postgresql_secret_id}
+        bigquery:
+            backend: bigquery
+            project: project-12345
+            secret-id: {bigquery_secret_id}
+    backends:
+        dwh:
+            connector: postgresql
+            url: jdbc:postgresql://example.com:5432
+            params: ssl=true&sslmode=require&sslrootcert={{SSL_PATH}}&sslrootcertpassword={{SSL_PWD}}
+            config: |
+                case-insensitive-name-matching=true
+                decimal-mapping=allow_overflow
+                decimal-rounding-mode=HALF_UP
+        bigquery:
+            connector: bigquery
+            config: |
+                bigquery.case-insensitive-name-matching=true
+    """
 
 
 class TestState(TestCase):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -313,12 +313,10 @@ class TestCharm(TestCase):
         harness = self.harness
         simulate_lifecycle_coordinator(harness)
 
-        self.harness.update_config({"catalog-config": "catalog: incorrect"})
-
-        self.assertEqual(
-            harness.model.unit.status,
-            BlockedStatus("Unable to configure catalogs."),
-        )
+        with self.assertRaises(KeyError):
+            self.harness.update_config(
+                {"catalog-config": "catalog: incorrect"}
+            )
 
     def test_catalog_removed(self):
         """The catalog directory is updated to remove existing catalogs."""

--- a/tests/unit/test_policy.py
+++ b/tests/unit/test_policy.py
@@ -14,12 +14,7 @@ from unittest import TestCase, mock
 from ops.model import ActiveStatus, MaintenanceStatus
 from ops.pebble import CheckStatus
 from ops.testing import Harness
-from unit.helpers import (
-    POLICY_MGR_URL,
-    RANGER_LIB,
-    RANGER_PROPERTIES_PATH,
-    TEST_CATALOG_CONFIG,
-)
+from unit.helpers import POLICY_MGR_URL, RANGER_LIB, RANGER_PROPERTIES_PATH
 
 from charm import TrinoK8SCharm
 
@@ -228,7 +223,6 @@ def simulate_lifecycle(harness):
 
     # Add worker and coordinator relation
     harness.handle_exec("trino", ["keytool"], result=0)
-    harness.update_config({"catalog-config": TEST_CATALOG_CONFIG})
     harness.add_relation("trino-coordinator", "trino-k8s-worker")
 
     rel_id = harness.add_relation("policy", "trino-k8s")

--- a/tox.ini
+++ b/tox.ini
@@ -120,4 +120,4 @@ commands =
     isort --check-only --diff {[vars]src_path} {[vars]tst_path}
     black --line-length 79 --check --diff {[vars]src_path} {[vars]tst_path}
     mypy {[vars]all_path} --ignore-missing-imports --follow-imports=skip --install-types --non-interactive
-    pylint {[vars]all_path} --disable=E0401,W1203,W0613,W0718,R0903,W1514,C0103,R0913,C0301,W0212,R0902,C0104,E1121,R0801,E1120
+    pylint {[vars]all_path} --disable=E0401,W1203,W0613,W0718,R0903,W1514,C0103,R0913,C0301,W0212,R0902,C0104,E1121,R0801,E1120,W0237

--- a/tox.ini
+++ b/tox.ini
@@ -120,4 +120,4 @@ commands =
     isort --check-only --diff {[vars]src_path} {[vars]tst_path}
     black --line-length 79 --check --diff {[vars]src_path} {[vars]tst_path}
     mypy {[vars]all_path} --ignore-missing-imports --follow-imports=skip --install-types --non-interactive
-    pylint {[vars]all_path} --disable=E0401,W1203,W0613,W0718,R0903,W1514,C0103,R0913,C0301,W0212,R0902,C0104,E1121,R0801,E1120,W0237
+    pylint {[vars]all_path} --disable=E0401,W1203,W0613,W0718,R0903,W1514,C0103,R0913,C0301,W0212,R0902,C0104,E1121,R0801,E1120,W0237,R0917


### PR DESCRIPTION
This PR:
- Adds logic for handling bigquery connector. Mainly reading from a secret containing service account credentials and creating a `.properties` file with the appropriate values.
- Refactors the catalog-config and catalog handling methods in order to:
-- Move all credentials to juju secrets
-- Remove the expectation that only postgresql is used as the connector.
- Updates unit and integration tests to include bigquery and work with refactoring
- Updated `README` with instructions on creating juju secrets and applying the catalog.

Note: the private key included for testing is a self signed throw away for use with integration tests. (trino will error if attempts to decode it fail). Open to alternatives as to where this should be kept.