### PR TITLE
CSS-11336 add timeout and max-concurrent-queries values as configs

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -106,7 +106,7 @@ options:
     description: |
       Specifies the maximum amount of time the client will wait for a response from
       the coordinator once a connection has been established. This timeout ensures
-      that client requests do not hang indefinitely if the coordinator is slow to
+      that client requests do not stalls indefinitely if the coordinator is slow to
       respond.
     type: string
     default: "10m"

--- a/config.yaml
+++ b/config.yaml
@@ -106,7 +106,7 @@ options:
     description: |
       Specifies the maximum amount of time the client will wait for a response from
       the coordinator once a connection has been established. This timeout ensures
-      that client requests do not stalls indefinitely if the coordinator is slow to
+      that client requests do not stall indefinitely if the coordinator is slow to
       respond.
     type: string
     default: "10m"

--- a/config.yaml
+++ b/config.yaml
@@ -102,3 +102,36 @@ options:
         "-Djdk.attach.allowAttachSelf=true"
         "-Dfile.encoding=UTF-8"
     type: string
+  coordinator-request-timeout:
+    description: |
+      Specifies the maximum amount of time the client will wait for a response from
+      the coordinator once a connection has been established. This timeout ensures
+      that client requests do not hang indefinitely if the coordinator is slow to
+      respond.
+    type: string
+    default: "10m"
+
+  coordinator-connect-timeout:
+    description: |
+      Specifies the maximum amount of time the client will wait for a connection
+      to be established with the coordinator. If the connection cannot be made within
+      this period, the client will give up and raise an error.
+    type: string
+    default: "30s"
+
+  worker-request-timeout:
+    description: |
+      Specifies the maximum amount of time the coordinator will wait for a response
+      from a worker node after the connection is established. This setting helps
+      manage scenarios where worker nodes are slow to respond, ensuring that
+      the coordinator does not wait indefinitely.
+    type: string
+    default: "30s"
+
+  max-concurrent-queries:
+    description: |
+      The maximum number of queries that Trino is allowed to run concurrently.
+      Any additional queries beyond this limit will be queued until a running query
+      finishes.
+    type: int
+    default: 5

--- a/src/charm.py
+++ b/src/charm.py
@@ -553,6 +553,14 @@ class TrinoK8SCharm(CharmBase):
             "JAVA_TRUSTSTORE_PWD": self.state.java_truststore_pwd,
             "USER_SECRET_ID": self.config.get("user-secret-id"),
             "JVM_OPTIONS": jvm_opts,
+            "COORDINATOR_REQUEST_TIMEOUT": self.config[
+                "coordinator-request-timeout"
+            ],
+            "COORDINATOR_CONNECT_TIMEOUT": self.config[
+                "coordinator-connect-timeout"
+            ],
+            "WORKER_REQUEST_TIMEOUT": self.config["worker-request-timeout"],
+            "MAX_CONCURRENT_QUERIES": self.config["max-concurrent-queries"],
         }
         return env
 

--- a/templates/config.jinja
+++ b/templates/config.jinja
@@ -1,14 +1,22 @@
 {% if CHARM_FUNCTION == "coordinator" %}
 coordinator=true
 discovery.uri={{ DISCOVERY_URI }}
+exchange.http-client.connect-timeout={{ COORDINATOR_CONNECT_TIMEOUT }}
+exchange.http-client.request-timeout={{ COORDINATOR_REQUEST_TIMEOUT }}
+query.max-concurrent-queries={{ MAX_CONCURRENT_QUERIES }}
+
 node-scheduler.include-coordinator=false
 {% elif CHARM_FUNCTION == "worker" %}
 coordinator=false
 discovery.uri={{ DISCOVERY_URI }}
+exchange.http-client.request-timeout={{ WORKER_REQUEST_TIMEOUT }}
+
 {% elif CHARM_FUNCTION == "all" %}
 coordinator=true
 node-scheduler.include-coordinator=true
 discovery.uri=http://localhost:8080
+query.max-concurrent-queries={{ MAX_CONCURRENT_QUERIES }}
+
 {% endif %}
 
 http-server.http.port=8080

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -134,6 +134,10 @@ class TestCharm(TestCase):
                         "JAVA_TRUSTSTORE_PWD": "truststore_pwd",
                         "USER_SECRET_ID": "secret:secret-id",
                         "JVM_OPTIONS": DEFAULT_JVM_STRING,
+                        "COORDINATOR_REQUEST_TIMEOUT": "10m",
+                        "COORDINATOR_CONNECT_TIMEOUT": "30s",
+                        "WORKER_REQUEST_TIMEOUT": "30s",
+                        "MAX_CONCURRENT_QUERIES": 5,
                     },
                 }
             },
@@ -271,6 +275,10 @@ class TestCharm(TestCase):
                         "JAVA_TRUSTSTORE_PWD": "truststore_pwd",
                         "USER_SECRET_ID": "secret:secret-id",
                         "JVM_OPTIONS": UPDATED_JVM_OPTIONS,
+                        "COORDINATOR_REQUEST_TIMEOUT": "10m",
+                        "COORDINATOR_CONNECT_TIMEOUT": "30s",
+                        "WORKER_REQUEST_TIMEOUT": "30s",
+                        "MAX_CONCURRENT_QUERIES": 5,
                     },
                 }
             },


### PR DESCRIPTION
Adds the following configuration values which are useful to be able to alter in a deployment:
- coordinator connect timeout
- worker request timeout
- coordinator request timeout
- maximum concurrent queries