### PR TITLE
Formatting and adding additional jvm options

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -101,8 +101,8 @@ options:
         "-XX:-OmitStackTraceInFastThrow"
         "-Djdk.attach.allowAttachSelf=true"
         "-Dfile.encoding=UTF-8"
-        "-XX:+ExitOnOutOfMemoryError",
-        "-XX:+HeapDumpOnOutOfMemoryError",
+        "-XX:+ExitOnOutOfMemoryError"
+        "-XX:+HeapDumpOnOutOfMemoryError"
     type: string
   coordinator-request-timeout:
     description: |

--- a/config.yaml
+++ b/config.yaml
@@ -101,6 +101,8 @@ options:
         "-XX:-OmitStackTraceInFastThrow"
         "-Djdk.attach.allowAttachSelf=true"
         "-Dfile.encoding=UTF-8"
+        "-XX:+ExitOnOutOfMemoryError",
+        "-XX:+HeapDumpOnOutOfMemoryError",
     type: string
   coordinator-request-timeout:
     description: |

--- a/src/literals.py
+++ b/src/literals.py
@@ -62,6 +62,8 @@ DEFAULT_JVM_OPTIONS = [
     "-XX:-OmitStackTraceInFastThrow",
     "-Djdk.attach.allowAttachSelf=true",
     "-Dfile.encoding=UTF-8",
+    "-XX:+ExitOnOutOfMemoryError",
+    "-XX:+HeapDumpOnOutOfMemoryError",
 ]
 USER_SECRET_LABEL = "trino-user-management"  # nosec
 CATALOG_SCHEMA = {

--- a/tests/integration/test_resources.py
+++ b/tests/integration/test_resources.py
@@ -15,6 +15,7 @@ from helpers import (
 from pytest_operator.plugin import OpsTest
 from lightkube.resources.apps_v1 import StatefulSet
 from lightkube import Client  # pyright: ignore
+
 logger = logging.getLogger(__name__)
 
 
@@ -58,12 +59,12 @@ class TestResources:
         """Test setting resources."""
         await ops_test.model.applications[APP_NAME].set_config(
             {
-            "workload-memory-requests": "1Gi",
-            "workload-memory-limits": "2Gi",
-            "workload-cpu-requests": "1",
-            "workload-cpu-limits": "2",
+                "workload-memory-requests": "1Gi",
+                "workload-memory-limits": "2Gi",
+                "workload-cpu-requests": "1",
+                "workload-cpu-limits": "2",
             }
-    )
+        )
         time.sleep(10)
         client = Client()
         statefulset = client.get(
@@ -77,5 +78,5 @@ class TestResources:
             if container.name == "trino":
                 current_limits = container.resources.limits or {}
                 current_requests = container.resources.requests or {}
-                assert current_limits == {'cpu': '1', 'memory': '2Gi'}
-                assert current_requests == {'cpu': '1', 'memory': '1Gi'}
+                assert current_limits == {"cpu": "1", "memory": "2Gi"}
+                assert current_requests == {"cpu": "1", "memory": "1Gi"}

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -63,6 +63,8 @@ DEFAULT_JVM_STRING = " ".join(
         "-XX:-OmitStackTraceInFastThrow",
         "-Djdk.attach.allowAttachSelf=true",
         "-Dfile.encoding=UTF-8",
+        "-XX:+ExitOnOutOfMemoryError",
+        "-XX:+HeapDumpOnOutOfMemoryError",
     ]
 )
 
@@ -75,6 +77,8 @@ UPDATED_JVM_OPTIONS = " ".join(
         "-XX:-OmitStackTraceInFastThrow",
         "-Djdk.attach.allowAttachSelf=true",
         "-Dfile.encoding=UTF-8",
+        "-XX:+ExitOnOutOfMemoryError",
+        "-XX:+HeapDumpOnOutOfMemoryError",
         "-Xxs10G",
     ]
 )


### PR DESCRIPTION
Add the following properties as defaults
```
    "-XX:+ExitOnOutOfMemoryError",
    "-XX:+HeapDumpOnOutOfMemoryError",
```
Based on the recommendation here: https://trino.io/docs/current/installation/deployment.html#jvm-config

Additionally some reformatting of other files in line with black formatting requirements.