### PR TITLE
CSS-11844 Adds the google sheet connector

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -34,7 +34,7 @@ from ops.model import (
 )
 from ops.pebble import CheckStatus, ExecError
 
-from catalog_manager import BigqueryCatalog, PostgresqlCatalog
+from catalog_manager import BigqueryCatalog, GsheetCatalog, PostgresqlCatalog
 from literals import (
     CATALOG_DIR,
     CATALOG_SCHEMA,
@@ -469,6 +469,7 @@ class TrinoK8SCharm(CharmBase):
         catalog_map = {
             "postgresql": PostgresqlCatalog,
             "bigquery": BigqueryCatalog,
+            "gsheets": GsheetCatalog,
         }
         catalog_cls = catalog_map.get(backend["connector"], None)
 

--- a/src/literals.py
+++ b/src/literals.py
@@ -70,6 +70,7 @@ CATALOG_SCHEMA = {
     "backend": {"type": "string"},
     "database": {"type": "string", "nullable": True},
     "project": {"type": "string", "nullable": True},
+    "metasheet-id": {"type": "string", "nullable": True},
     "secret-id": {"type": "string"},
 }
 
@@ -87,6 +88,11 @@ REPLICA_SCHEMA = {
 }
 
 BIGQUERY_BACKEND_SCHEMA = {
+    "connector": {"type": "string"},
+    "config": {"type": "string", "nullable": True},
+}
+
+GSHEETS_BACKEND_SCHEMA = {
     "connector": {"type": "string"},
     "config": {"type": "string", "nullable": True},
 }

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -57,7 +57,7 @@ project-12345: |
 """  # nosec
 
 GSHEETS_SECRET = """\
-gsheet-1: |
+gsheets-1: |
     {
       "type": "service_account",
       "project_id": "example-project",

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -56,6 +56,23 @@ project-12345: |
     }
 """  # nosec
 
+GSHEETS_SECRET = """\
+gsheet-1: |
+    {
+      "type": "service_account",
+      "project_id": "example-project",
+      "private_key_id": "key123",
+      "private_key": "-----BEGIN PRIVATE KEY-----\\nMIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDk0x6IbejGjKC8\\nV7staWrwXlEqheosQeEYDRDkRLLe/Tw5LuNnw9Rids7vjjQpRNiRttNfeOHm9360\\nK29TbPMnLT4Iy56jnW/c+9PYXenHP1k4br1TcZ2cFJdYEV6xu4jT0mKoN9304SVI\\nlXzLtfQdzsFp4SqWtr9gaH4KSBzJoeE3pX7iLgvM3o4bUh+WH16ejfiLJZ1zQkYA\\nmu96criFAm5YnuoO2PRTo2KGoLamf3VDXLDYiWs2cSJxifwblos3Eh2zgxVRALfo\\nirtjlwAzSMjTXSC2nOyJmrDUsQyA3gJFr7TPlIIEUkGehy6/fU1z8B1yTh0ojpsq\\n8naueTSFAgMBAAECggEAcEYWSSKEgEcn5sG1GYcL7XyZnp+uUqDQbRicHSSID1l5\\nXyVedt9jKhzZVDkV5tnc2UI3XDTXwpfVF1noeaqPc72DHpWp9OWeqXL2csdBmX2/\\nrSzIwFSS3K5Nw+xh5hr5+9TSi289/JUr0f1nChzw9l8oD2dnmiN4qzkZ/rl7RoK1\\ng6Nj7U2u7qy2gf2vMH0MzFh/O+tQ3nLjwmNeOdF03ZxVDUGrkaTBftfbwSI5te7F\\nljeU7EgZVatjlyIXfi0p8OULXu6/xxpDZPYvIUxZjitjodxa5ZykmhVMBHjDVRbq\\n5Boh4laGdSiayBKMb7BCT/TwlQIPA1eEzWUJXJ8YUQKBgQDr3DKxAIajCP6IdTVT\\n75tHqc2TCqIS6QfM62X4NIw/ETUtiAU9+Pq33OBnivDSjbI9NPpSLbX18ttyPugn\\nPcgC0EUf2+5/EniD7khqjZLQXLK4WZXN6M15NS87cznOm9qbWway15f+iWF4qr0d\\nN8jsVypbSEicWiKUrq2IiJSMrwKBgQD4XSEHxQtmX7nk/ImhqWl1C9QkwiAlvLxy\\nGUIUwHkpbxRHE1tovT3XS9shQK3MZzMYG6d60bNIMIkpyvbN4+ptikCFsSikuAkP\\nE1865ipxCUaInbMYk3lzuNfPO4hP52pjW5r67WD6O1qjLdTsacPXCCSepEjKe+Rd\\nktUiGv+nCwKBgHCVfHD3Ek1ydqVGZX06a4GqsSFWOwURzRJo7xSqaKOWIC8qtW3e\\nkjb/rPJf5RJsZr9GsZJWlXvgQBXpp0FMAVQufEB36AEqHPLE5DZQe9sP1JOg15wh\\nWytXUsNq/hX8WT49FhZ6SOhMRYWm4ny26ya9eM930oknkUgtlVIN9/KrAoGAAJVn\\ncHc8EZ+D9k/JmwGk58uBUhzKqowI/VOl3hqdrkU+jPQ0sMhRDuJ0v11Bi0tqyVG3\\nUQiRHUhP6jM55T313RAIGshRyiFMlCZ9gMvtqZpV+hg0xYgDLwxuJWSEa3ululoK\\nwTAxnCTrj5qZ93xAI483VtAYA7HK1ZV0vsHFfAUCgYB13ErBMkV3cOFsUHOYUzXo\\nQbeIhRDthqTw4xToTsCaZnweZDEtqmnJMfRmbAqzPNbRjGjd7uH5dssqD7H3kpA5\\noywUbHhRzvJJvmk0enpnbjP6NY51goJ/WUVM4n6AZC6v3cfE9HNBAiPEaDAZT/ul\\nbDOWB1LReVCV5YytEsR/KA==\\n-----END PRIVATE KEY-----",
+      "client_email": "test-380@example-project.iam.gserviceaccount.com",
+      "client_id": "12345",
+      "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+      "token_uri": "https://oauth2.googleapis.com/token",
+      "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+      "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/test-380.project.iam.gserviceaccount.com",
+      "universe_domain": "googleapis.com"
+    }
+"""  # nosec
+
 POSTGRESQL_REPLICA_SECRET = """\
 rw:
   user: trino
@@ -311,7 +328,7 @@ async def add_juju_secret(ops_test: OpsTest, connector_type: str):
 
     Args:
         ops_test: PyTest object.
-        connector_type: Type of secret to add ('postgresql' or 'bigquery').
+        connector_type: Type of connector secret to add.
 
     Returns:
         secret ID of created secret.
@@ -323,6 +340,8 @@ async def add_juju_secret(ops_test: OpsTest, connector_type: str):
         data_args = [f"replicas={POSTGRESQL_REPLICA_SECRET}"]  # nosec
     elif connector_type == "bigquery":
         data_args = [f"service-accounts={BIGQUERY_SECRET}"]  # nosec
+    elif connector_type == "gsheets":
+        data_args = [f"service-accounts={GSHEETS_SECRET}"]  # nosec
     else:
         raise ValueError(f"Unsupported secret type: {connector_type}")
 
@@ -335,13 +354,17 @@ async def add_juju_secret(ops_test: OpsTest, connector_type: str):
 
 
 async def create_catalog_config(
-    postgresql_secret_id, bigquery_secret_id, include_bigquery=True
+    postgresql_secret_id,
+    bigquery_secret_id,
+    gsheets_secret_id,
+    include_bigquery=True,
 ):
     """Create and return catalog-config value.
 
     Args:
         postgresql_secret_id: the juju secret id for postgresql
         bigquery_secret_id: the juju secret id for bigquery
+        gsheets_secret_id: the juju secret id for gsheets
         include_bigquery: flag to indicate if bigquery configuration should be included.
 
     Returns:
@@ -358,6 +381,10 @@ async def create_catalog_config(
                 backend: bigquery
                 project: project-12345
                 secret-id: {bigquery_secret_id}
+            gsheets-1:
+                backend: gsheets
+                metasheet-id: 1Es4HhWALUQjoa-bQh4a8B5HROz7dpGMfq_HbfoaW5LM
+                secret-id: {gsheets_secret_id}
         backends:
             dwh:
                 connector: postgresql
@@ -371,6 +398,8 @@ async def create_catalog_config(
                 connector: bigquery
                 config: |
                     bigquery.case-insensitive-name-matching=true
+            gsheets:
+                connector: gsheets
         """
     else:
         catalog_config = f"""\
@@ -379,6 +408,10 @@ async def create_catalog_config(
                 backend: dwh
                 database: example
                 secret-id: {postgresql_secret_id}
+            gsheets-1:
+                backend: gsheets
+                metasheet-id: 1Es4HhWALUQjoa-bQh4a8B5HROz7dpGMfq_HbfoaW5LM
+                secret-id: {gsheets_secret_id}
         backends:
             dwh:
                 connector: postgresql
@@ -388,5 +421,7 @@ async def create_catalog_config(
                     case-insensitive-name-matching=true
                     decimal-mapping=allow_overflow
                     decimal-rounding-mode=HALF_UP
+            gsheets:
+                connector: gsheets
         """
     return catalog_config

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -43,13 +43,15 @@ class TestDeployment:
         """Adds a PostgreSQL and BigQuery connector and asserts catalogs added."""
         postgresql_secret_id = await add_juju_secret(ops_test, "postgresql")
         bigquery_secret_id = await add_juju_secret(ops_test, "bigquery")
+        gsheet_secret_id = await add_juju_secret(ops_test, "gsheets")
 
         for app in ["trino-k8s", "trino-k8s-worker"]:
             await ops_test.model.grant_secret("postgresql-secret", app)
             await ops_test.model.grant_secret("bigquery-secret", app)
+            await ops_test.model.grant_secret("gsheet-secret", app)
 
         catalog_config = await create_catalog_config(
-            postgresql_secret_id, bigquery_secret_id, True
+            postgresql_secret_id, bigquery_secret_id, gsheet_secret_id, True
         )
         catalogs = await update_catalog_config(
             ops_test, catalog_config, TRINO_USER
@@ -58,9 +60,10 @@ class TestDeployment:
         # Verify that both catalogs have been added.
         assert "postgresql-1" in str(catalogs)
         assert "bigquery" in str(catalogs)
+        assert "gsheet-1" in str(catalogs)
 
         updated_catalog_config = await create_catalog_config(
-            postgresql_secret_id, bigquery_secret_id, False
+            postgresql_secret_id, bigquery_secret_id, gsheet_secret_id, False
         )
 
         catalogs = await update_catalog_config(

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -60,7 +60,7 @@ class TestDeployment:
         # Verify that both catalogs have been added.
         assert "postgresql-1" in str(catalogs)
         assert "bigquery" in str(catalogs)
-        assert "gsheet-1" in str(catalogs)
+        assert "gsheets-1" in str(catalogs)
 
         updated_catalog_config = await create_catalog_config(
             postgresql_secret_id, bigquery_secret_id, gsheet_secret_id, False
@@ -73,6 +73,7 @@ class TestDeployment:
         # Verify that only the bigquery catalog has been removed.
         assert "postgresql-1" in str(catalogs)
         assert "bigquery" not in str(catalogs)
+        assert "gsheets-1" in str(catalogs)
 
     async def test_simulate_crash(self, ops_test: OpsTest):
         """Simulate the crash of the Trino coordinator charm.

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -48,7 +48,7 @@ class TestDeployment:
         for app in ["trino-k8s", "trino-k8s-worker"]:
             await ops_test.model.grant_secret("postgresql-secret", app)
             await ops_test.model.grant_secret("bigquery-secret", app)
-            await ops_test.model.grant_secret("gsheet-secret", app)
+            await ops_test.model.grant_secret("gsheets-secret", app)
 
         catalog_config = await create_catalog_config(
             postgresql_secret_id, bigquery_secret_id, gsheet_secret_id, True

--- a/tests/integration/test_resources.py
+++ b/tests/integration/test_resources.py
@@ -3,18 +3,14 @@
 
 """Trino charm integration test config."""
 import logging
+import time
 
 import pytest
-import time
 import pytest_asyncio
-from helpers import (
-    APP_NAME,
-    BASE_DIR,
-    TRINO_IMAGE,
-)
-from pytest_operator.plugin import OpsTest
-from lightkube.resources.apps_v1 import StatefulSet
+from helpers import APP_NAME, BASE_DIR, TRINO_IMAGE
 from lightkube import Client  # pyright: ignore
+from lightkube.resources.apps_v1 import StatefulSet
+from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
 

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -6,6 +6,23 @@
 
 SERVER_PORT = "8080"
 
+GSHEET_SECRET = """\
+gsheets-1: |
+    {
+      "type": "service_account",
+      "project_id": "example-project",
+      "private_key_id": "key123",
+      "private_key": "-----BEGIN PRIVATE KEY-----\\nMIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDk0x6IbejGjKC8\\nV7staWrwXlEqheosQeEYDRDkRLLe/Tw5LuNnw9Rids7vjjQpRNiRttNfeOHm9360\\nK29TbPMnLT4Iy56jnW/c+9PYXenHP1k4br1TcZ2cFJdYEV6xu4jT0mKoN9304SVI\\nlXzLtfQdzsFp4SqWtr9gaH4KSBzJoeE3pX7iLgvM3o4bUh+WH16ejfiLJZ1zQkYA\\nmu96criFAm5YnuoO2PRTo2KGoLamf3VDXLDYiWs2cSJxifwblos3Eh2zgxVRALfo\\nirtjlwAzSMjTXSC2nOyJmrDUsQyA3gJFr7TPlIIEUkGehy6/fU1z8B1yTh0ojpsq\\n8naueTSFAgMBAAECggEAcEYWSSKEgEcn5sG1GYcL7XyZnp+uUqDQbRicHSSID1l5\\nXyVedt9jKhzZVDkV5tnc2UI3XDTXwpfVF1noeaqPc72DHpWp9OWeqXL2csdBmX2/\\nrSzIwFSS3K5Nw+xh5hr5+9TSi289/JUr0f1nChzw9l8oD2dnmiN4qzkZ/rl7RoK1\\ng6Nj7U2u7qy2gf2vMH0MzFh/O+tQ3nLjwmNeOdF03ZxVDUGrkaTBftfbwSI5te7F\\nljeU7EgZVatjlyIXfi0p8OULXu6/xxpDZPYvIUxZjitjodxa5ZykmhVMBHjDVRbq\\n5Boh4laGdSiayBKMb7BCT/TwlQIPA1eEzWUJXJ8YUQKBgQDr3DKxAIajCP6IdTVT\\n75tHqc2TCqIS6QfM62X4NIw/ETUtiAU9+Pq33OBnivDSjbI9NPpSLbX18ttyPugn\\nPcgC0EUf2+5/EniD7khqjZLQXLK4WZXN6M15NS87cznOm9qbWway15f+iWF4qr0d\\nN8jsVypbSEicWiKUrq2IiJSMrwKBgQD4XSEHxQtmX7nk/ImhqWl1C9QkwiAlvLxy\\nGUIUwHkpbxRHE1tovT3XS9shQK3MZzMYG6d60bNIMIkpyvbN4+ptikCFsSikuAkP\\nE1865ipxCUaInbMYk3lzuNfPO4hP52pjW5r67WD6O1qjLdTsacPXCCSepEjKe+Rd\\nktUiGv+nCwKBgHCVfHD3Ek1ydqVGZX06a4GqsSFWOwURzRJo7xSqaKOWIC8qtW3e\\nkjb/rPJf5RJsZr9GsZJWlXvgQBXpp0FMAVQufEB36AEqHPLE5DZQe9sP1JOg15wh\\nWytXUsNq/hX8WT49FhZ6SOhMRYWm4ny26ya9eM930oknkUgtlVIN9/KrAoGAAJVn\\ncHc8EZ+D9k/JmwGk58uBUhzKqowI/VOl3hqdrkU+jPQ0sMhRDuJ0v11Bi0tqyVG3\\nUQiRHUhP6jM55T313RAIGshRyiFMlCZ9gMvtqZpV+hg0xYgDLwxuJWSEa3ululoK\\nwTAxnCTrj5qZ93xAI483VtAYA7HK1ZV0vsHFfAUCgYB13ErBMkV3cOFsUHOYUzXo\\nQbeIhRDthqTw4xToTsCaZnweZDEtqmnJMfRmbAqzPNbRjGjd7uH5dssqD7H3kpA5\\noywUbHhRzvJJvmk0enpnbjP6NY51goJ/WUVM4n6AZC6v3cfE9HNBAiPEaDAZT/ul\\nbDOWB1LReVCV5YytEsR/KA==\\n-----END PRIVATE KEY-----",
+      "client_email": "test-380@example-project.iam.gserviceaccount.com",
+      "client_id": "12345",
+      "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+      "token_uri": "https://oauth2.googleapis.com/token",
+      "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+      "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/test-380.project.iam.gserviceaccount.com",
+      "universe_domain": "googleapis.com"
+    }
+"""  # nosec
+
 BIGQUERY_SECRET = """\
 project-12345: |
     {

--- a/tox.ini
+++ b/tox.ini
@@ -32,13 +32,12 @@ passenv =
 description = Run integration tests
 deps =
     ipdb==0.13.9
-    juju==3.5.2.0
+    juju==3.5.2.1
     pytest==7.4.0
     pytest-operator==0.29.0
     pytest-asyncio==0.21.0
     trino==0.326.0
     apache-ranger==0.0.11
-    websockets<14.0
     -r{toxinidir}/requirements.txt
 commands =
    pytest {[vars]tst_path}integration -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
@@ -47,13 +46,12 @@ commands =
 description = Run integration tests
 deps =
     ipdb==0.13.9
-    juju==3.5.2.0
+    juju==3.5.2.1
     pytest==7.4.0
     pytest-operator==0.29.0
     pytest-asyncio==0.21.0
     trino==0.326.0
     apache-ranger==0.0.11
-    websockets<14.0
     -r{toxinidir}/requirements.txt
 commands =
     pytest {[vars]tst_path}integration/{env:TEST_FILE} -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -38,6 +38,7 @@ deps =
     pytest-asyncio==0.21.0
     trino==0.326.0
     apache-ranger==0.0.11
+    websockets<14.0
     -r{toxinidir}/requirements.txt
 commands =
    pytest {[vars]tst_path}integration -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
@@ -52,6 +53,7 @@ deps =
     pytest-asyncio==0.21.0
     trino==0.326.0
     apache-ranger==0.0.11
+    websockets<14.0
     -r{toxinidir}/requirements.txt
 commands =
     pytest {[vars]tst_path}integration/{env:TEST_FILE} -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}


### PR DESCRIPTION
This PR adds the logic for adding the service account credentials and catalog for the google sheet connector. 

Please note the service account credentials included here are purely for testing, they are self signed certificates I have generated locally and the account does not exist.

It also adds:
- Unit tests
- Integration tests
- Documentation on the connector

Note: pinning websockets version was required due to: https://github.com/juju/python-libjuju/issues/1184