### PR TITLE
Added Redshift Trino connector

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,8 @@ newgrp snap_microk8s
 mkdir -p ~/.kube/ && microk8s config > ~/.kube/config
 
 # Enable the necessary Microk8s addons:
-sudo microk8s enable hostpath-storage dns
+sudo microk8s enable hostpath-storage
+sudo microk8s enable dns
 sudo microk8s enable registry
 
 # Set up a short alias for Kubernetes CLI:
@@ -93,7 +94,7 @@ cd trino_rock
 # Note: to build trino rock, you need to have at least 30GB of free disk space.
 # The first run may take 45 to 60 minutes.
 rockcraft pack
-rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false oci-archive:trino_468-24.04-edge_amd64.rock docker://localhost:32000/trino-rock:468
+rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false oci-archive:trino_<version>-24.04-edge_amd64.rock docker://localhost:32000/trino-rock:<version>
 ```
 
 ### Deploy charm
@@ -102,10 +103,10 @@ rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false oci-archive:trin
 charmcraft pack
 
 # Deploy the coordinator:
-juju deploy ./trino-k8s_ubuntu-22.04-amd64.charm --resource trino-image=localhost:32000/trino-rock:468 --config charm-function=coordinator trino-k8s
+juju deploy ./trino-k8s_ubuntu-22.04-amd64.charm --resource trino-image=localhost:32000/trino-rock:<version> --config charm-function=coordinator trino-k8s
 
 # Deploy the worker:
-juju deploy ./trino-k8s_ubuntu-22.04-amd64.charm --resource trino-image=localhost:32000/trino-rock:468 --config charm-function=worker trino-k8s-worker
+juju deploy ./trino-k8s_ubuntu-22.04-amd64.charm --resource trino-image=localhost:32000/trino-rock:<version> --config charm-function=worker trino-k8s-worker
 
 # Check deployment was successful:
 kubectl get pods -n trino-k8s
@@ -118,10 +119,10 @@ Note: due to the requirements of the `discovery_uri`, when using a separate coor
 ### Refresh charm
 ```bash
 # Refresh the coordinator:
-juju refresh --path="./trino-k8s_ubuntu-22.04-amd64.charm" trino-k8s --resource trino-image=localhost:32000/trino-rock:468 
+juju refresh --path="./trino-k8s_ubuntu-22.04-amd64.charm" trino-k8s --resource trino-image=localhost:32000/trino-rock:<version> 
 
 # Refresh the worker:
-juju refresh --path="./trino-k8s_ubuntu-22.04-amd64.charm" trino-k8s-worker --resource trino-image=localhost:32000/trino-rock:468 
+juju refresh --path="./trino-k8s_ubuntu-22.04-amd64.charm" trino-k8s-worker --resource trino-image=localhost:32000/trino-rock:<version> 
 ```
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ This charm is used to deploy Trino Server in a k8s cluster. For local deployment
 
 ## Set up your development environment
 ### Install Microk8s
-```
+```bash
 # Install Microk8s from snap:
 sudo snap install microk8s --channel 1.25-strict/stable
 
@@ -32,12 +32,14 @@ mkdir -p ~/.kube/ && microk8s config > ~/.kube/config
 
 # Enable the necessary Microk8s addons:
 sudo microk8s enable hostpath-storage dns
+sudo microk8s enable registry
 
 # Set up a short alias for Kubernetes CLI:
 sudo snap alias microk8s.kubectl kubectl
 ```
+
 ### Install Charmcraft
-```
+```bash
 # Install lxd from snap:
 sudo snap install lxd --classic --channel=5.12/stable
 
@@ -47,10 +49,11 @@ sudo snap install charmcraft --classic --channel=2.2/stable
 # Charmcraft relies on LXD. Configure LXD:
 lxd init --auto
 ```
+
 ### Set up the Juju OLM
-```
+```bash
 # Install the Juju CLI client, juju:
-sudo snap install juju --channel=3.1/stable
+sudo snap install juju --channel=3.4/stable
 
 # Install a "juju" controller into your "microk8s" cloud:
 juju bootstrap microk8s trino-controller
@@ -65,16 +68,44 @@ juju model-config logging-config="<root>=INFO;unit=DEBUG"
 juju status
 juju debug-log
 ```
-### Deploy charm
+
+### Set up Rockcraft
+```bash
+sudo snap install rockcraft --edge --classic
+sudo snap install skopeo --edge --devmode
+
+# Note: Docker must be installed after LXD is initialized due to firewall rules incompatibility.
+sudo snap install docker
+sudo groupadd docker
+sudo usermod -aG docker $USER
+newgrp docker
+
+# Note: disabling and enabling docker snap is required to avoid sudo requirement. 
+# As described in https://github.com/docker-snap/docker-snap.
+sudo snap disable docker
+sudo snap enable docker
 ```
+
+### Pack the rock
+```bash
+cd trino_rock
+
+# Note: to build trino rock, you need to have at least 30GB of free disk space.
+# The first run may take 45 to 60 minutes.
+rockcraft pack
+rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false oci-archive:trino_468-24.04-edge_amd64.rock docker://localhost:32000/trino-rock:468
+```
+
+### Deploy charm
+```bash
 # Pack the charm:
 charmcraft pack
 
 # Deploy the coordinator:
-juju deploy ./trino-k8s_ubuntu-22.04-amd64.charm --resource trino-image=trinodb/trino:418
+juju deploy ./trino-k8s_ubuntu-22.04-amd64.charm --resource trino-image=localhost:32000/trino-rock:468 --config charm-function=coordinator trino-k8s
 
 # Deploy the worker:
-juju deploy ./trino-k8s_ubuntu-22.04-amd64.charm --resource trino-image=trinodb/trino:418 --config charm-function=worker trino-k8s-worker
+juju deploy ./trino-k8s_ubuntu-22.04-amd64.charm --resource trino-image=localhost:32000/trino-rock:468 --config charm-function=worker trino-k8s-worker
 
 # Check deployment was successful:
 kubectl get pods -n trino-k8s
@@ -83,6 +114,16 @@ kubectl get pods -n trino-k8s
 For development of the `policy` relation please use the `trino-image=ghcr.io/canonical/trino:418` instead.
 
 Note: due to the requirements of the `discovery_uri`, when using a separate coordinator and worker, the default `discovery_uri` value of `http://trino-k8s:8080` will only work if the trino coordinator deployment is named `trino-k8s`. If using another alias please update the worker and coordinator charm configurations accordingly.
+
+### Refresh charm
+```bash
+# Refresh the coordinator:
+juju refresh --path="./trino-k8s_ubuntu-22.04-amd64.charm" trino-k8s --resource trino-image=localhost:32000/trino-rock:468 
+
+# Refresh the worker:
+juju refresh --path="./trino-k8s_ubuntu-22.04-amd64.charm" trino-k8s-worker --resource trino-image=localhost:32000/trino-rock:468 
+```
+
 
 ## Trino configuration
 ```
@@ -110,10 +151,19 @@ SHOW CATALOGS;
 ```
 
 ## Cleanup
-```
+```bash
 # Remove TLS relation: 
-juju remove-relation tls-certificates-operator trino-k8s
+juju remove-relation nginx-ingress-integrator trino-k8s
 
 # Remove the application before retrying
 juju remove-application trino-k8s --force
+juju remove-application trino-k8s-worker --force
+```
+
+```bash
+# Remove LXD container for rock
+lxc project switch rockcraft
+
+# Remove the LXD container. This will save nearly 30GB of disk space. 
+lxc delete rockcraft-trino-amd64-4
 ```

--- a/src/charm.py
+++ b/src/charm.py
@@ -34,7 +34,7 @@ from ops.model import (
 )
 from ops.pebble import CheckStatus, ExecError
 
-from catalog_manager import BigqueryCatalog, GsheetCatalog, SqlCatalog
+from catalog_manager import BigqueryCatalog, GsheetCatalog
 from literals import (
     CATALOG_DIR,
     CATALOG_SCHEMA,
@@ -58,6 +58,7 @@ from relations.opensearch import OpensearchRelationHandler
 from relations.policy import PolicyRelationHandler
 from relations.trino_coordinator import TrinoCoordinator
 from relations.trino_worker import TrinoWorker
+from sql_catalog import RedshiftCatalog, SqlCatalog
 from state import State
 from utils import (
     add_users_to_password_db,
@@ -469,6 +470,7 @@ class TrinoK8SCharm(CharmBase):
         catalog_map = {
             "postgresql": SqlCatalog,
             "mysql": SqlCatalog,
+            "redshift": RedshiftCatalog,
             "bigquery": BigqueryCatalog,
             "gsheets": GsheetCatalog,
         }

--- a/src/sql_catalog.py
+++ b/src/sql_catalog.py
@@ -1,0 +1,77 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Trino catalog classes."""
+
+import logging
+import textwrap
+
+import yaml
+
+from catalog_manager import CatalogBase
+from literals import REPLICA_SCHEMA, SQL_BACKEND_SCHEMA
+from utils import validate_keys
+
+logger = logging.getLogger(__name__)
+
+
+class SqlCatalog(CatalogBase):
+    """Class for handling the PostgreSQL and MySQL connectors."""
+
+    def _get_credentials(self):
+        """Handle PostgreSQL/MySQL/Redshift catalog configuration.
+
+        Returns:
+            replicas: the database replica configuration.
+        """
+        validate_keys(self.backend, SQL_BACKEND_SCHEMA)
+        secret = self._get_secret_content(self.info["secret-id"])
+        replicas = yaml.safe_load(secret["replicas"])
+        certs = yaml.safe_load(secret.get("cert", ""))
+        self._add_certs(certs)
+        return replicas
+
+    def _get_db_url(self):
+        """Get database url for the connection."""
+        return f"{self.backend['url']}/{self.info.get('database','')}"
+
+    def _create_properties(self, replicas):
+        """Create the PostgreSQL/MySQL/Redshift connector catalog files.
+
+        Args:
+            replicas: the database replica configuration.
+
+        Returns:
+            catalogs: a dictionary of catalog name and configuration.
+        """
+        catalogs = {}
+        for replica_info in replicas.values():
+            validate_keys(replica_info, REPLICA_SCHEMA)
+            user_name = replica_info.get("user")
+            user_pwd = replica_info.get("password")
+            suffix = replica_info.get("suffix", "")
+
+            catalog_name = f"{self.name}{suffix}"
+            url = self._get_db_url()
+            if self.backend.get("params"):
+                url = f"{url}?{self.backend['params']}"
+
+            catalog_content = textwrap.dedent(
+                f"""\
+                connector.name={self.backend['connector']}
+                connection-url={url}
+                connection-user={user_name}
+                connection-password={user_pwd}
+                """
+            )
+            catalog_content += self.backend.get("config", "")
+            catalogs[catalog_name] = catalog_content
+        return catalogs
+
+
+class RedshiftCatalog(SqlCatalog):
+    """Class for handling the Redshift connector."""
+
+    def _get_db_url(self):
+        """Get database url for the connection."""
+        return f"{self.backend['url']}"

--- a/src/sql_catalog.py
+++ b/src/sql_catalog.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Trino catalog classes."""

--- a/src/sql_catalog.py
+++ b/src/sql_catalog.py
@@ -16,7 +16,11 @@ logger = logging.getLogger(__name__)
 
 
 class SqlCatalog(CatalogBase):
-    """Class for handling the PostgreSQL, MySQL and Redshift connectors."""
+    """Class for handling the PostgreSQL, MySQL and Redshift connectors.
+
+    Attrs:
+        db_url: Database url for the catalog
+    """
 
     @property
     def db_url(self):
@@ -71,7 +75,11 @@ class SqlCatalog(CatalogBase):
 
 
 class RedshiftCatalog(SqlCatalog):
-    """Class for handling the Redshift connector."""
+    """Class for handling the Redshift connector.
+
+    Attrs:
+        db_url: Database url for the catalog
+    """
 
     @property
     def db_url(self):

--- a/src/sql_catalog.py
+++ b/src/sql_catalog.py
@@ -16,7 +16,12 @@ logger = logging.getLogger(__name__)
 
 
 class SqlCatalog(CatalogBase):
-    """Class for handling the PostgreSQL and MySQL connectors."""
+    """Class for handling the PostgreSQL, MySQL and Redshift connectors."""
+
+    @property
+    def db_url(self):
+        """Get database URL for the connection."""
+        return f"{self.backend['url']}/{self.info.get('database', '')}"
 
     def _get_credentials(self):
         """Handle PostgreSQL/MySQL/Redshift catalog configuration.
@@ -30,10 +35,6 @@ class SqlCatalog(CatalogBase):
         certs = yaml.safe_load(secret.get("cert", ""))
         self._add_certs(certs)
         return replicas
-
-    def _get_db_url(self):
-        """Get database url for the connection."""
-        return f"{self.backend['url']}/{self.info.get('database','')}"
 
     def _create_properties(self, replicas):
         """Create the PostgreSQL/MySQL/Redshift connector catalog files.
@@ -52,7 +53,7 @@ class SqlCatalog(CatalogBase):
             suffix = replica_info.get("suffix", "")
 
             catalog_name = f"{self.name}{suffix}"
-            url = self._get_db_url()
+            url = self.db_url
             if self.backend.get("params"):
                 url = f"{url}?{self.backend['params']}"
 
@@ -72,6 +73,7 @@ class SqlCatalog(CatalogBase):
 class RedshiftCatalog(SqlCatalog):
     """Class for handling the Redshift connector."""
 
-    def _get_db_url(self):
-        """Get database url for the connection."""
+    @property
+    def db_url(self):
+        """Get database URL for the connection."""
         return f"{self.backend['url']}"

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -82,6 +82,13 @@ ro:
   password: pwd3
 """  # nosec
 
+
+REDSHIFT_REPLICA_SECRET = """\
+ro:
+  user: trino_ro
+  password: pwd4
+"""  # nosec
+
 CATALOG_QUERY = "SHOW CATALOGS"
 TRINO_USER = "trino"
 
@@ -322,6 +329,8 @@ async def add_juju_secret(ops_test: OpsTest, connector_type: str):
         data_args = [f"replicas={POSTGRESQL_REPLICA_SECRET}"]  # nosec
     elif connector_type == "mysql":
         data_args = [f"replicas=={MYSQL_REPLICA_SECRET}"]  # nosec
+    elif connector_type == "redshift":
+        data_args = [f"replicas=={REDSHIFT_REPLICA_SECRET}"]  # nosec
     elif connector_type == "bigquery":
         data_args = [f"service-accounts={BIGQUERY_SECRET}"]  # nosec
     elif connector_type == "gsheets":
@@ -340,6 +349,7 @@ async def add_juju_secret(ops_test: OpsTest, connector_type: str):
 async def create_catalog_config(
     postgresql_secret_id,
     mysql_secret_id,
+    redshift_secret_id,
     bigquery_secret_id,
     gsheets_secret_id,
     include_bigquery=True,
@@ -348,7 +358,8 @@ async def create_catalog_config(
 
     Args:
         postgresql_secret_id: the juju secret id for postgresql
-        mysql_secret_id: the juju secret id for postgresql
+        mysql_secret_id: the juju secret id for mysql
+        redshift_secret_id: the juju secret id for redshift
         bigquery_secret_id: the juju secret id for bigquery
         gsheets_secret_id: the juju secret id for gsheets
         include_bigquery: flag to indicate if bigquery configuration should be included.
@@ -366,6 +377,9 @@ async def create_catalog_config(
             mysql:
                 backend: mysql
                 secret-id: {mysql_secret_id}
+            redshift:
+                backend: redshift
+                secret-id: {redshift_secret_id}
             bigquery:
                 backend: bigquery
                 project: project-12345
@@ -391,6 +405,12 @@ async def create_catalog_config(
                     case-insensitive-name-matching=true
                     decimal-mapping=allow_overflow
                     decimal-rounding-mode=HALF_UP
+            redshift:
+                connector: redshift
+                url: jdbc:redshift://redshift.com:5439/example
+                params: SSL=TRUE
+                config: |
+                    case-insensitive-name-matching=true
             bigquery:
                 connector: bigquery
                 config: |
@@ -409,6 +429,9 @@ async def create_catalog_config(
             mysql:
                 backend: mysql
                 secret-id: {mysql_secret_id}
+            redshift:
+                backend: redshift
+                secret-id: {redshift_secret_id}
             gsheets-1:
                 backend: gsheets
                 metasheet-id: 1Es4HhWALUQjoa-bQh4a8B5HROz7dpGMfq_HbfoaW5LM
@@ -430,6 +453,12 @@ async def create_catalog_config(
                     case-insensitive-name-matching=true
                     decimal-mapping=allow_overflow
                     decimal-rounding-mode=HALF_UP
+            redshift:
+                connector: redshift
+                url: jdbc:redshift://redshift.com:5439/example
+                params: SSL=TRUE
+                config: |
+                    case-insensitive-name-matching=true
             gsheets:
                 connector: gsheets
         """

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -43,18 +43,21 @@ class TestDeployment:
         """Adds a PostgreSQL and BigQuery connector and asserts catalogs added."""
         postgresql_secret_id = await add_juju_secret(ops_test, "postgresql")
         mysql_secret_id = await add_juju_secret(ops_test, "mysql")
+        redshift_secret_id = await add_juju_secret(ops_test, "redshift")
         bigquery_secret_id = await add_juju_secret(ops_test, "bigquery")
         gsheet_secret_id = await add_juju_secret(ops_test, "gsheets")
 
         for app in ["trino-k8s", "trino-k8s-worker"]:
             await ops_test.model.grant_secret("postgresql-secret", app)
             await ops_test.model.grant_secret("mysql-secret", app)
+            await ops_test.model.grant_secret("redshift-secret", app)
             await ops_test.model.grant_secret("bigquery-secret", app)
             await ops_test.model.grant_secret("gsheets-secret", app)
 
         catalog_config = await create_catalog_config(
             postgresql_secret_id,
             mysql_secret_id,
+            redshift_secret_id,
             bigquery_secret_id,
             gsheet_secret_id,
             True,
@@ -66,12 +69,14 @@ class TestDeployment:
         # Verify that both catalogs have been added.
         assert "postgresql-1" in str(catalogs)
         assert "mysql" in str(catalogs)
+        assert "redshift" in str(catalogs)
         assert "bigquery" in str(catalogs)
         assert "gsheets-1" in str(catalogs)
 
         updated_catalog_config = await create_catalog_config(
             postgresql_secret_id,
             mysql_secret_id,
+            redshift_secret_id,
             bigquery_secret_id,
             gsheet_secret_id,
             False,
@@ -84,6 +89,7 @@ class TestDeployment:
         # Verify that only the bigquery catalog has been removed.
         assert "postgresql-1" in str(catalogs)
         assert "mysql" in str(catalogs)
+        assert "redshift" in str(catalogs)
         assert "bigquery" not in str(catalogs)
         assert "gsheets-1" in str(catalogs)
 

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -53,6 +53,11 @@ ro:
   user: trino_ro
   password: pwd3
 """  # nosec
+REDSHIFT_REPLICA_SECRET = """\
+ro:
+  user: trino_ro
+  password: pwd4
+"""  # nosec
 POSTGRESQL_REPLICA_CERT = """\
 cert: |
   -----BEGIN CERTIFICATE-----
@@ -67,6 +72,7 @@ POSTGRESQL_2_CATALOG_PATH = (
     "/usr/lib/trino/etc/catalog/postgresql-2.properties"
 )
 MYSQL_CATALOG_PATH = "/usr/lib/trino/etc/catalog/mysql.properties"
+REDSHIFT_CATALOG_PATH = "/usr/lib/trino/etc/catalog/redshift.properties"
 BIGQUERY_CATALOG_PATH = "/usr/lib/trino/etc/catalog/bigquery.properties"
 RANGER_AUDIT_PATH = "/usr/lib/trino/etc/ranger-trino-audit.xml"
 RANGER_SECURITY_PATH = "/usr/lib/trino/etc/ranger-trino-security.xml"

--- a/trino_rock/rockcraft.yaml
+++ b/trino_rock/rockcraft.yaml
@@ -80,6 +80,7 @@ parts:
       plugin/bigquery: usr/lib/trino/plugin/bigquery
       plugin/elasticsearch: usr/lib/trino/plugin/elasticsearch
       plugin/google-sheets: usr/lib/trino/plugin/google-sheets
+      plugin/redshift: usr/lib/trino/plugin/redshift
       plugin/mysql: usr/lib/trino/plugin/mysql
       plugin/password-authenticators: usr/lib/trino/plugin/password-authenticators # yamllint disable-line
       plugin/postgresql: usr/lib/trino/plugin/postgresql


### PR DESCRIPTION
This PR adds [Redshift Trino connector](https://trino.io/docs/current/connector/redshift.html) to trino-k8s-operator. 
* Moved SqlCatalog class to a new module without changing its code. I just extended this class for a slight change for Redshift by adding `_get_db_url` function.
* Changed the Rockfile for Trino to enable Redshift plugin.
* Fixed and extended Contributing.md document. It was stale so I needed to update it. I also added some new details for handling rocks. 