### PR TITLE
fix: do not call update twice per config change

### DIFF
--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -34,6 +34,7 @@ application charm code:
 from charms.data_platform_libs.v0.data_interfaces import (
     DatabaseCreatedEvent,
     DatabaseRequires,
+    DatabaseEntityCreatedEvent,
 )
 
 class ApplicationCharm(CharmBase):
@@ -45,6 +46,7 @@ class ApplicationCharm(CharmBase):
         # Charm events defined in the database requires charm library.
         self.database = DatabaseRequires(self, relation_name="database", database_name="database")
         self.framework.observe(self.database.on.database_created, self._on_database_created)
+        self.framework.observe(self.database.on.database_entity_created, self._on_database_entity_created)
 
     def _on_database_created(self, event: DatabaseCreatedEvent) -> None:
         # Handle the created database
@@ -61,12 +63,17 @@ class ApplicationCharm(CharmBase):
 
         # Set active status
         self.unit.status = ActiveStatus("received database credentials")
+
+    def _on_database_entity_created(self, event: DatabaseEntityCreatedEvent) -> None:
+        # Handle the created entity
+        ...
 ```
 
 As shown above, the library provides some custom events to handle specific situations,
 which are listed below:
 
 -  database_created: event emitted when the requested database is created.
+-  database_entity_created: event emitted when the requested entity is created.
 -  endpoints_changed: event emitted when the read/write endpoints of the database have changed.
 -  read_only_endpoints_changed: event emitted when the read-only endpoints of the database
   have changed. Event is not triggered if read/write endpoints changed too.
@@ -141,7 +148,6 @@ class ApplicationCharm(CharmBase):
             event.endpoints,
         )
         ...
-
 ```
 
 When it's needed to check whether a plugin (extension) is enabled on the PostgreSQL
@@ -154,7 +160,6 @@ parts:
   charm:
     charm-binary-python-packages:
       - psycopg[binary]
-
 ```
 
 ### Provider Charm
@@ -187,6 +192,7 @@ class SampleCharm(CharmBase):
         self.provided_database.set_credentials(event.relation.id, username, password)
         # set other variables for the relation event.set_tls("False")
 ```
+
 As shown above, the library provides a custom event (database_requested) to handle
 the situation when an application charm requests a new database to be created.
 It's preferred to subscribe to this event instead of relation changed event to avoid
@@ -207,6 +213,7 @@ from charms.data_platform_libs.v0.data_interfaces import (
     BootstrapServerChangedEvent,
     KafkaRequires,
     TopicCreatedEvent,
+    TopicEntityCreatedEvent,
 )
 
 class ApplicationCharm(CharmBase):
@@ -219,6 +226,9 @@ class ApplicationCharm(CharmBase):
         )
         self.framework.observe(
             self.kafka.on.topic_created, self._on_kafka_topic_created
+        )
+        self.framework.observe(
+            self.kafka.on.topic_entity_created, self._on_kafka_topic_entity_created
         )
 
     def _on_kafka_bootstrap_server_changed(self, event: BootstrapServerChangedEvent):
@@ -238,6 +248,9 @@ class ApplicationCharm(CharmBase):
         zookeeper_uris = event.zookeeper_uris
         ...
 
+    def _on_kafka_topic_entity_created(self, event: TopicEntityCreatedEvent):
+        # Event triggered when an entity was created for this application
+        ...
 ```
 
 As shown above, the library provides some custom events to handle specific situations,
@@ -268,6 +281,7 @@ from charms.data_platform_libs.v0.data_interfaces import (
         # Charm events defined in the Kafka Provides charm library.
         self.kafka_provider = KafkaProvides(self, relation_name="kafka_client")
         self.framework.observe(self.kafka_provider.on.topic_requested, self._on_topic_requested)
+        self.framework.observe(self.kafka_provider.on.topic_entity_requested, self._on_entity_requested)
         # Kafka generic helper
         self.kafka = KafkaHelper()
 
@@ -283,6 +297,9 @@ from charms.data_platform_libs.v0.data_interfaces import (
         self.kafka_provider.set_tls(relation_id, "False")
         self.kafka_provider.set_zookeeper_uris(relation_id, ...)
 
+    def _on_entity_requested(self, event: EntityRequestedEvent):
+        # Handle the on_topic_entity_requested event.
+        ...
 ```
 As shown above, the library provides a custom event (topic_requested) to handle
 the situation when an application charm requests a new topic to be created.
@@ -331,7 +348,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 49
+LIBPATCH = 50
 
 PYDEPS = ["ops>=2.0.0"]
 
@@ -349,6 +366,8 @@ added - keys that were added
 changed - keys that still exist but have new values
 deleted - key that were deleted"""
 
+ENTITY_USER = "USER"
+ENTITY_GROUP = "GROUP"
 
 PROV_SECRET_PREFIX = "secret-"
 PROV_SECRET_FIELDS = "provided-secrets"
@@ -587,6 +606,7 @@ class SecretGroupsAggregate(str):
         self.USER = SecretGroup("user")
         self.TLS = SecretGroup("tls")
         self.MTLS = SecretGroup("mtls")
+        self.ENTITY = SecretGroup("entity")
         self.EXTRA = SecretGroup("extra")
 
     def __setattr__(self, name, value):
@@ -953,7 +973,7 @@ class DataDict(UserDict):
 
 
 class Data(ABC):
-    """Base relation data mainpulation (abstract) class."""
+    """Base relation data manipulation (abstract) class."""
 
     SCOPE = Scope.APP
 
@@ -966,6 +986,8 @@ class Data(ABC):
         "tls": SECRET_GROUPS.TLS,
         "tls-ca": SECRET_GROUPS.TLS,
         "mtls-cert": SECRET_GROUPS.MTLS,
+        "entity-name": SECRET_GROUPS.ENTITY,
+        "entity-password": SECRET_GROUPS.ENTITY,
     }
 
     SECRET_FIELDS = []
@@ -1729,6 +1751,24 @@ class ProviderData(Data):
         """
         self.update_relation_data(relation_id, {"username": username, "password": password})
 
+    def set_entity_credentials(
+        self, relation_id: int, entity_name: str, entity_password: Optional[str] = None
+    ) -> None:
+        """Set entity credentials.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            entity_name: name of the created entity
+            entity_password: password of the created entity.
+        """
+        self.update_relation_data(
+            relation_id,
+            {"entity-name": entity_name, "entity-password": entity_password},
+        )
+
     def set_tls(self, relation_id: int, tls: str) -> None:
         """Set whether TLS is enabled.
 
@@ -1766,7 +1806,16 @@ class ProviderData(Data):
 class RequirerData(Data):
     """Requirer-side of the relation."""
 
-    SECRET_FIELDS = ["username", "password", "tls", "tls-ca", "uris", "read-only-uris"]
+    SECRET_FIELDS = [
+        "username",
+        "password",
+        "tls",
+        "tls-ca",
+        "uris",
+        "read-only-uris",
+        "entity-name",
+        "entity-password",
+    ]
 
     def __init__(
         self,
@@ -1774,10 +1823,16 @@ class RequirerData(Data):
         relation_name: str,
         extra_user_roles: Optional[str] = None,
         additional_secret_fields: Optional[List[str]] = [],
+        extra_group_roles: Optional[str] = None,
+        entity_type: Optional[str] = None,
     ):
         """Manager of base client relations."""
         super().__init__(model, relation_name)
         self.extra_user_roles = extra_user_roles
+        self.extra_group_roles = extra_group_roles
+        self.entity_type = entity_type
+        self._validate_entity_type()
+
         self._remote_secret_fields = list(self.SECRET_FIELDS)
         self._local_secret_fields = [
             field
@@ -1788,18 +1843,37 @@ class RequirerData(Data):
             self._remote_secret_fields += additional_secret_fields
         self.data_component = self.local_unit
 
-    # Internal helper functions
+    # Internal functions
 
     def _is_resource_created_for_relation(self, relation: Relation) -> bool:
         if not relation.app:
             return False
 
-        data = self.fetch_relation_data([relation.id], ["username", "password"]).get(
-            relation.id, {}
+        data = self.fetch_relation_data(
+            [relation.id],
+            ["username", "password", "entity-name", "entity-password"],
+        ).get(relation.id, {})
+
+        return any(
+            [
+                all(bool(data.get(field)) for field in ("username", "password")),
+                all(bool(data.get(field)) for field in ("entity-name",)),
+            ]
         )
-        return bool(data.get("username")) and bool(data.get("password"))
+
+    def _validate_entity_type(self) -> None:
+        """Validates the consistency of the provided entity-type and its extra roles."""
+        if self.entity_type and self.entity_type not in {ENTITY_USER, ENTITY_GROUP}:
+            raise ValueError("Invalid entity-type. Possible values are USER and GROUP")
+
+        if self.entity_type == ENTITY_USER and self.extra_group_roles:
+            raise ValueError("Inconsistent entity information. Use extra_user_roles instead")
+
+        if self.entity_type == ENTITY_GROUP and self.extra_user_roles:
+            raise ValueError("Inconsistent entity information. Use extra_group_roles instead")
 
     # Public functions
+
     def is_resource_created(self, relation_id: Optional[int] = None) -> bool:
         """Check if the resource has been created.
 
@@ -1856,6 +1930,26 @@ class RequirerEventHandlers(EventHandlers):
         """Manager of base client relations."""
         super().__init__(charm, relation_data, unique_key)
 
+    def _main_credentials_shared(self, diff: Diff) -> bool:
+        """Whether the relation data-bag contains username / password keys."""
+        user_secret = self.relation_data._generate_secret_field_name(SECRET_GROUPS.USER)
+        return any(
+            [
+                user_secret in diff.added,
+                "username" in diff.added and "password" in diff.added,
+            ]
+        )
+
+    def _entity_credentials_shared(self, diff: Diff) -> bool:
+        """Whether the relation data-bag contains rolename / password keys."""
+        entity_secret = self.relation_data._generate_secret_field_name(SECRET_GROUPS.ENTITY)
+        return any(
+            [
+                entity_secret in diff.added,
+                "entity-name" in diff.added,
+            ]
+        )
+
     # Event handlers
 
     def _on_relation_created_event(self, event: RelationCreatedEvent) -> None:
@@ -1902,6 +1996,21 @@ class ProviderEventHandlers(EventHandlers):
         """Manager of base client relations."""
         super().__init__(charm, relation_data, unique_key)
 
+    @staticmethod
+    def _validate_entity_consistency(event: RelationEvent, diff: Diff) -> None:
+        """Validates that entity information is not changed after relation is established.
+
+        - When entity-type changes, backwards compatibility is broken.
+        - When extra-user-roles changes, role membership checks become incredibly complex.
+        - When extra-group-roles changes, role membership checks become incredibly complex.
+        """
+        if not isinstance(event, RelationChangedEvent):
+            return
+
+        for key in ["entity-type", "extra-user-roles", "extra-group-roles"]:
+            if key in diff.changed:
+                raise ValueError(f"Cannot change {key} after relation has already been created")
+
     # Event handlers
 
     def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
@@ -1936,6 +2045,8 @@ class DataPeerData(RequirerData, ProviderData):
         additional_secret_group_mapping: Dict[str, str] = {},
         secret_field_name: Optional[str] = None,
         deleted_label: Optional[str] = None,
+        extra_group_roles: Optional[str] = None,
+        entity_type: Optional[str] = None,
     ):
         RequirerData.__init__(
             self,
@@ -1943,6 +2054,8 @@ class DataPeerData(RequirerData, ProviderData):
             relation_name,
             extra_user_roles,
             additional_secret_fields,
+            extra_group_roles,
+            entity_type,
         )
         self.secret_field_name = secret_field_name if secret_field_name else self.SECRET_FIELD_NAME
         self.deleted_label = deleted_label
@@ -2006,6 +2119,7 @@ class DataPeerData(RequirerData, ProviderData):
             SECRET_GROUPS.get_group("user"),
             SECRET_GROUPS.get_group("tls"),
             SECRET_GROUPS.get_group("mtls"),
+            SECRET_GROUPS.get_group("entity"),
         ]
         for group in SECRET_GROUPS.groups():
             if group in ignores:
@@ -2464,6 +2578,8 @@ class DataPeer(DataPeerData, DataPeerEventHandlers):
         secret_field_name: Optional[str] = None,
         deleted_label: Optional[str] = None,
         unique_key: str = "",
+        extra_group_roles: Optional[str] = None,
+        entity_type: Optional[str] = None,
     ):
         DataPeerData.__init__(
             self,
@@ -2474,6 +2590,8 @@ class DataPeer(DataPeerData, DataPeerEventHandlers):
             additional_secret_group_mapping,
             secret_field_name,
             deleted_label,
+            extra_group_roles,
+            entity_type,
         )
         DataPeerEventHandlers.__init__(self, charm, self, unique_key)
 
@@ -2500,6 +2618,8 @@ class DataPeerUnit(DataPeerUnitData, DataPeerEventHandlers):
         secret_field_name: Optional[str] = None,
         deleted_label: Optional[str] = None,
         unique_key: str = "",
+        extra_group_roles: Optional[str] = None,
+        entity_type: Optional[str] = None,
     ):
         DataPeerData.__init__(
             self,
@@ -2510,6 +2630,8 @@ class DataPeerUnit(DataPeerUnitData, DataPeerEventHandlers):
             additional_secret_group_mapping,
             secret_field_name,
             deleted_label,
+            extra_group_roles,
+            entity_type,
         )
         DataPeerEventHandlers.__init__(self, charm, self, unique_key)
 
@@ -2553,6 +2675,8 @@ class DataPeerOtherUnit(DataPeerOtherUnitData, DataPeerOtherUnitEventHandlers):
         additional_secret_group_mapping: Dict[str, str] = {},
         secret_field_name: Optional[str] = None,
         deleted_label: Optional[str] = None,
+        extra_group_roles: Optional[str] = None,
+        entity_type: Optional[str] = None,
     ):
         DataPeerOtherUnitData.__init__(
             self,
@@ -2564,6 +2688,8 @@ class DataPeerOtherUnit(DataPeerOtherUnitData, DataPeerOtherUnitEventHandlers):
             additional_secret_group_mapping,
             secret_field_name,
             deleted_label,
+            extra_group_roles,
+            entity_type,
         )
         DataPeerOtherUnitEventHandlers.__init__(self, charm, self)
 
@@ -2573,18 +2699,6 @@ class DataPeerOtherUnit(DataPeerOtherUnitData, DataPeerOtherUnitEventHandlers):
 ################################################################################
 
 # Generic events
-
-
-class ExtraRoleEvent(RelationEvent):
-    """Base class for data events."""
-
-    @property
-    def extra_user_roles(self) -> Optional[str]:
-        """Returns the extra user roles that were requested."""
-        if not self.relation.app:
-            return None
-
-        return self.relation.data[self.relation.app].get("extra-user-roles")
 
 
 class RelationEventWithSecret(RelationEvent):
@@ -2616,6 +2730,68 @@ class RelationEventWithSecret(RelationEvent):
     def secrets_enabled(self):
         """Is this Juju version allowing for Secrets usage?"""
         return JujuVersion.from_environ().has_secrets
+
+
+class EntityProvidesEvent(RelationEvent):
+    """Base class for data events."""
+
+    @property
+    def extra_user_roles(self) -> Optional[str]:
+        """Returns the extra user roles that were requested."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("extra-user-roles")
+
+    @property
+    def extra_group_roles(self) -> Optional[str]:
+        """Returns the extra group roles that were requested."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("extra-group-roles")
+
+    @property
+    def entity_type(self) -> Optional[str]:
+        """Returns the entity_type that were requested."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("entity-type")
+
+
+class EntityRequiresEvent(RelationEventWithSecret):
+    """Base class for authentication fields for events.
+
+    The amount of logic added here is not ideal -- but this was the only way to preserve
+    the interface when moving to Juju Secrets
+    """
+
+    @property
+    def entity_name(self) -> Optional[str]:
+        """Returns the name for the created entity."""
+        if not self.relation.app:
+            return None
+
+        if self.secrets_enabled:
+            secret = self._get_secret("entity")
+            if secret:
+                return secret.get("entity-name")
+
+        return self.relation.data[self.relation.app].get("entity-name")
+
+    @property
+    def entity_password(self) -> Optional[str]:
+        """Returns the password for the created entity."""
+        if not self.relation.app:
+            return None
+
+        if self.secrets_enabled:
+            secret = self._get_secret("entity")
+            if secret:
+                return secret.get("entity-password")
+
+        return self.relation.data[self.relation.app].get("entity-password")
 
 
 class AuthenticationEvent(RelationEventWithSecret):
@@ -2693,8 +2869,16 @@ class DatabaseProvidesEvent(RelationEvent):
         return self.relation.data[self.relation.app].get("database")
 
 
-class DatabaseRequestedEvent(DatabaseProvidesEvent, ExtraRoleEvent):
+class DatabaseRequestedEvent(DatabaseProvidesEvent):
     """Event emitted when a new database is requested for use on this relation."""
+
+    @property
+    def extra_user_roles(self) -> Optional[str]:
+        """Returns the extra user roles that were requested."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("extra-user-roles")
 
     @property
     def external_node_connectivity(self) -> bool:
@@ -2708,6 +2892,10 @@ class DatabaseRequestedEvent(DatabaseProvidesEvent, ExtraRoleEvent):
         )
 
 
+class DatabaseEntityRequestedEvent(DatabaseProvidesEvent, EntityProvidesEvent):
+    """Event emitted when a new entity is requested for use on this relation."""
+
+
 class DatabaseProvidesEvents(CharmEvents):
     """Database events.
 
@@ -2715,6 +2903,7 @@ class DatabaseProvidesEvents(CharmEvents):
     """
 
     database_requested = EventSource(DatabaseRequestedEvent)
+    database_entity_requested = EventSource(DatabaseEntityRequestedEvent)
 
 
 class DatabaseRequiresEvent(RelationEventWithSecret):
@@ -2808,6 +2997,10 @@ class DatabaseCreatedEvent(AuthenticationEvent, DatabaseRequiresEvent):
     """Event emitted when a new database is created for use on this relation."""
 
 
+class DatabaseEntityCreatedEvent(EntityRequiresEvent, DatabaseRequiresEvent):
+    """Event emitted when a new entity is created for use on this relation."""
+
+
 class DatabaseEndpointsChangedEvent(AuthenticationEvent, DatabaseRequiresEvent):
     """Event emitted when the read/write endpoints are changed."""
 
@@ -2823,6 +3016,7 @@ class DatabaseRequiresEvents(CharmEvents):
     """
 
     database_created = EventSource(DatabaseCreatedEvent)
+    database_entity_created = EventSource(DatabaseEntityCreatedEvent)
     endpoints_changed = EventSource(DatabaseEndpointsChangedEvent)
     read_only_endpoints_changed = EventSource(DatabaseReadOnlyEndpointsChangedEvent)
 
@@ -2944,15 +3138,32 @@ class DatabaseProviderEventHandlers(ProviderEventHandlers):
         # Leader only
         if not self.relation_data.local_unit.is_leader():
             return
+
         # Check which data has changed to emit customs events.
         diff = self._diff(event)
 
-        # Emit a database requested event if the setup key (database name and optional
-        # extra user roles) was added to the relation databag by the application.
-        if "database" in diff.added:
+        # Validate entity information is not dynamically changed
+        self._validate_entity_consistency(event, diff)
+
+        # Emit a database requested event if the setup key (database name)
+        # was added to the relation databag, but the entity-type key was not.
+        if "database" in diff.added and "entity-type" not in diff.added:
             getattr(self.on, "database_requested").emit(
                 event.relation, app=event.app, unit=event.unit
             )
+
+            # To avoid unnecessary application restarts do not trigger other events.
+            return
+
+        # Emit an entity requested event if the setup key (database name)
+        # was added to the relation databag, in addition to the entity-type key.
+        if "database" in diff.added and "entity-type" in diff.added:
+            getattr(self.on, "database_entity_requested").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+            # To avoid unnecessary application restarts do not trigger other events.
+            return
 
     def _on_secret_changed_event(self, event: SecretChangedEvent) -> None:
         """Event emitted when the secret has changed."""
@@ -2979,9 +3190,18 @@ class DatabaseRequirerData(RequirerData):
         relations_aliases: Optional[List[str]] = None,
         additional_secret_fields: Optional[List[str]] = [],
         external_node_connectivity: bool = False,
+        extra_group_roles: Optional[str] = None,
+        entity_type: Optional[str] = None,
     ):
         """Manager of database client relations."""
-        super().__init__(model, relation_name, extra_user_roles, additional_secret_fields)
+        super().__init__(
+            model,
+            relation_name,
+            extra_user_roles,
+            additional_secret_fields,
+            extra_group_roles,
+            entity_type,
+        )
         self.database = database_name
         self.relations_aliases = relations_aliases
         self.external_node_connectivity = external_node_connectivity
@@ -3064,9 +3284,17 @@ class DatabaseRequirerEventHandlers(RequirerEventHandlers):
 
         if self.relation_data.relations_aliases:
             for relation_alias in self.relation_data.relations_aliases:
-                self.on.define_event(f"{relation_alias}_database_created", DatabaseCreatedEvent)
                 self.on.define_event(
-                    f"{relation_alias}_endpoints_changed", DatabaseEndpointsChangedEvent
+                    f"{relation_alias}_database_created",
+                    DatabaseCreatedEvent,
+                )
+                self.on.define_event(
+                    f"{relation_alias}_database_entity_created",
+                    DatabaseEntityCreatedEvent,
+                )
+                self.on.define_event(
+                    f"{relation_alias}_endpoints_changed",
+                    DatabaseEndpointsChangedEvent,
                 )
                 self.on.define_event(
                     f"{relation_alias}_read_only_endpoints_changed",
@@ -3156,6 +3384,10 @@ class DatabaseRequirerEventHandlers(RequirerEventHandlers):
 
         if self.relation_data.extra_user_roles:
             event_data["extra-user-roles"] = self.relation_data.extra_user_roles
+        if self.relation_data.extra_group_roles:
+            event_data["extra-group-roles"] = self.relation_data.extra_group_roles
+        if self.relation_data.entity_type:
+            event_data["entity-type"] = self.relation_data.entity_type
 
         # set external-node-connectivity field
         if self.relation_data.external_node_connectivity:
@@ -3174,10 +3406,7 @@ class DatabaseRequirerEventHandlers(RequirerEventHandlers):
                 is_subordinate = event.relation.data[key].get("subordinated") == "true"
 
         if is_subordinate:
-            if not remote_unit_data:
-                return
-
-            if remote_unit_data.get("state") != "ready":
+            if not remote_unit_data or remote_unit_data.get("state") != "ready":
                 return
 
         # Check which data has changed to emit customs events.
@@ -3187,12 +3416,13 @@ class DatabaseRequirerEventHandlers(RequirerEventHandlers):
         if any(newval for newval in diff.added if self.relation_data._is_secret_field(newval)):
             self.relation_data._register_secrets_to_relation(event.relation, diff.added)
 
+        app_databag = get_encoded_dict(event.relation, event.app, "data")
+        if app_databag is None:
+            app_databag = {}
+
         # Check if the database is created
         # (the database charm shared the credentials).
-        secret_field_user = self.relation_data._generate_secret_field_name(SECRET_GROUPS.USER)
-        if (
-            "username" in diff.added and "password" in diff.added
-        ) or secret_field_user in diff.added:
+        if self._main_credentials_shared(diff) and "entity-type" not in app_databag:
             # Emit the default event (the one without an alias).
             logger.info("database created at %s", datetime.now())
             getattr(self.on, "database_created").emit(
@@ -3202,8 +3432,20 @@ class DatabaseRequirerEventHandlers(RequirerEventHandlers):
             # Emit the aliased event (if any).
             self._emit_aliased_event(event, "database_created")
 
-            # To avoid unnecessary application restarts do not trigger
-            # “endpoints_changed“ event if “database_created“ is triggered.
+            # To avoid unnecessary application restarts do not trigger other events.
+            return
+
+        if self._entity_credentials_shared(diff) and "entity-type" in app_databag:
+            # Emit the default event (the one without an alias).
+            logger.info("entity created at %s", datetime.now())
+            getattr(self.on, "database_entity_created").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+            # Emit the aliased event (if any).
+            self._emit_aliased_event(event, "database_entity_created")
+
+            # To avoid unnecessary application restarts do not trigger other events.
             return
 
         # Emit an endpoints changed event if the database
@@ -3218,8 +3460,7 @@ class DatabaseRequirerEventHandlers(RequirerEventHandlers):
             # Emit the aliased event (if any).
             self._emit_aliased_event(event, "endpoints_changed")
 
-            # To avoid unnecessary application restarts do not trigger
-            # “read_only_endpoints_changed“ event if “endpoints_changed“ is triggered.
+            # To avoid unnecessary application restarts do not trigger other events.
             return
 
         # Emit a read only endpoints changed event if the database
@@ -3247,6 +3488,8 @@ class DatabaseRequires(DatabaseRequirerData, DatabaseRequirerEventHandlers):
         relations_aliases: Optional[List[str]] = None,
         additional_secret_fields: Optional[List[str]] = [],
         external_node_connectivity: bool = False,
+        extra_group_roles: Optional[str] = None,
+        entity_type: Optional[str] = None,
     ):
         DatabaseRequirerData.__init__(
             self,
@@ -3257,6 +3500,8 @@ class DatabaseRequires(DatabaseRequirerData, DatabaseRequirerEventHandlers):
             relations_aliases,
             additional_secret_fields,
             external_node_connectivity,
+            extra_group_roles,
+            entity_type,
         )
         DatabaseRequirerEventHandlers.__init__(self, charm, self)
 
@@ -3322,8 +3567,20 @@ class KafkaClientMtlsCertUpdatedEvent(KafkaProvidesEvent):
         self.old_mtls_cert = snapshot["old_mtls_cert"]
 
 
-class TopicRequestedEvent(KafkaProvidesEvent, ExtraRoleEvent):
+class TopicRequestedEvent(KafkaProvidesEvent):
     """Event emitted when a new topic is requested for use on this relation."""
+
+    @property
+    def extra_user_roles(self) -> Optional[str]:
+        """Returns the extra user roles that were requested."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("extra-user-roles")
+
+
+class TopicEntityRequestedEvent(KafkaProvidesEvent, EntityProvidesEvent):
+    """Event emitted when a new entity is requested for use on this relation."""
 
 
 class KafkaProvidesEvents(CharmEvents):
@@ -3333,6 +3590,7 @@ class KafkaProvidesEvents(CharmEvents):
     """
 
     topic_requested = EventSource(TopicRequestedEvent)
+    topic_entity_requested = EventSource(TopicEntityRequestedEvent)
     mtls_cert_updated = EventSource(KafkaClientMtlsCertUpdatedEvent)
 
 
@@ -3376,6 +3634,10 @@ class TopicCreatedEvent(AuthenticationEvent, KafkaRequiresEvent):
     """Event emitted when a new topic is created for use on this relation."""
 
 
+class TopicEntityCreatedEvent(EntityRequiresEvent, KafkaRequiresEvent):
+    """Event emitted when a new entity is created for use on this relation."""
+
+
 class BootstrapServerChangedEvent(AuthenticationEvent, KafkaRequiresEvent):
     """Event emitted when the bootstrap server is changed."""
 
@@ -3387,6 +3649,7 @@ class KafkaRequiresEvents(CharmEvents):
     """
 
     topic_created = EventSource(TopicCreatedEvent)
+    topic_entity_created = EventSource(TopicEntityCreatedEvent)
     bootstrap_server_changed = EventSource(BootstrapServerChangedEvent)
 
 
@@ -3465,12 +3728,28 @@ class KafkaProviderEventHandlers(ProviderEventHandlers):
         # Check which data has changed to emit customs events.
         diff = self._diff(event)
 
-        # Emit a topic requested event if the setup key (topic name and optional
-        # extra user roles) was added to the relation databag by the application.
-        if "topic" in diff.added:
+        # Validate entity information is not dynamically changed
+        self._validate_entity_consistency(event, diff)
+
+        # Emit a topic requested event if the setup key (topic name)
+        # was added to the relation databag, but the entity-type key was not.
+        if "topic" in diff.added and "entity-type" not in diff.added:
             getattr(self.on, "topic_requested").emit(
                 event.relation, app=event.app, unit=event.unit
             )
+
+            # To avoid unnecessary application restarts do not trigger other events.
+            return
+
+        # Emit an entity requested event if the setup key (topic name)
+        # was added to the relation databag, in addition to the entity-type key.
+        if "topic" in diff.added and "entity-type" in diff.added:
+            getattr(self.on, "topic_entity_requested").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+            # To avoid unnecessary application restarts do not trigger other events.
+            return
 
     def _on_secret_changed_event(self, event: SecretChangedEvent):
         """Event notifying about a new value of a secret."""
@@ -3520,9 +3799,18 @@ class KafkaRequirerData(RequirerData):
         consumer_group_prefix: Optional[str] = None,
         additional_secret_fields: Optional[List[str]] = [],
         mtls_cert: Optional[str] = None,
+        extra_group_roles: Optional[str] = None,
+        entity_type: Optional[str] = None,
     ):
         """Manager of Kafka client relations."""
-        super().__init__(model, relation_name, extra_user_roles, additional_secret_fields)
+        super().__init__(
+            model,
+            relation_name,
+            extra_user_roles,
+            additional_secret_fields,
+            extra_group_roles,
+            entity_type,
+        )
         self.topic = topic
         self.consumer_group_prefix = consumer_group_prefix or ""
         self.mtls_cert = mtls_cert
@@ -3576,11 +3864,15 @@ class KafkaRequirerEventHandlers(RequirerEventHandlers):
         if self.relation_data.mtls_cert:
             relation_data["mtls-cert"] = self.relation_data.mtls_cert
 
-        if self.relation_data.extra_user_roles:
-            relation_data["extra-user-roles"] = self.relation_data.extra_user_roles
-
         if self.relation_data.consumer_group_prefix:
             relation_data["consumer-group-prefix"] = self.relation_data.consumer_group_prefix
+
+        if self.relation_data.extra_user_roles:
+            relation_data["extra-user-roles"] = self.relation_data.extra_user_roles
+        if self.relation_data.extra_group_roles:
+            relation_data["extra-group-roles"] = self.relation_data.extra_group_roles
+        if self.relation_data.entity_type:
+            relation_data["entity-type"] = self.relation_data.entity_type
 
         self.relation_data.update_relation_data(event.relation.id, relation_data)
 
@@ -3600,16 +3892,26 @@ class KafkaRequirerEventHandlers(RequirerEventHandlers):
         if any(newval for newval in diff.added if self.relation_data._is_secret_field(newval)):
             self.relation_data._register_secrets_to_relation(event.relation, diff.added)
 
-        secret_field_user = self.relation_data._generate_secret_field_name(SECRET_GROUPS.USER)
-        if (
-            "username" in diff.added and "password" in diff.added
-        ) or secret_field_user in diff.added:
+        app_databag = get_encoded_dict(event.relation, event.app, "data")
+        if app_databag is None:
+            app_databag = {}
+
+        if self._main_credentials_shared(diff) and "entity-type" not in app_databag:
             # Emit the default event (the one without an alias).
             logger.info("topic created at %s", datetime.now())
             getattr(self.on, "topic_created").emit(event.relation, app=event.app, unit=event.unit)
 
-            # To avoid unnecessary application restarts do not trigger
-            # “endpoints_changed“ event if “topic_created“ is triggered.
+            # To avoid unnecessary application restarts do not trigger other events.
+            return
+
+        if self._entity_credentials_shared(diff) and "entity-type" in app_databag:
+            # Emit the default event (the one without an alias).
+            logger.info("entity created at %s", datetime.now())
+            getattr(self.on, "topic_entity_created").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+            # To avoid unnecessary application restarts do not trigger other events.
             return
 
         # Emit an endpoints (bootstrap-server) changed event if the Kafka endpoints
@@ -3620,6 +3922,8 @@ class KafkaRequirerEventHandlers(RequirerEventHandlers):
             getattr(self.on, "bootstrap_server_changed").emit(
                 event.relation, app=event.app, unit=event.unit
             )  # here check if this is the right design
+
+            # To avoid unnecessary application restarts do not trigger other events.
             return
 
 
@@ -3635,6 +3939,8 @@ class KafkaRequires(KafkaRequirerData, KafkaRequirerEventHandlers):
         consumer_group_prefix: Optional[str] = None,
         additional_secret_fields: Optional[List[str]] = [],
         mtls_cert: Optional[str] = None,
+        extra_group_roles: Optional[str] = None,
+        entity_type: Optional[str] = None,
     ) -> None:
         KafkaRequirerData.__init__(
             self,
@@ -3645,6 +3951,8 @@ class KafkaRequires(KafkaRequirerData, KafkaRequirerEventHandlers):
             consumer_group_prefix=consumer_group_prefix,
             additional_secret_fields=additional_secret_fields,
             mtls_cert=mtls_cert,
+            extra_group_roles=extra_group_roles,
+            entity_type=entity_type,
         )
         KafkaRequirerEventHandlers.__init__(self, charm, self)
 
@@ -3664,8 +3972,20 @@ class OpenSearchProvidesEvent(RelationEvent):
         return self.relation.data[self.relation.app].get("index")
 
 
-class IndexRequestedEvent(OpenSearchProvidesEvent, ExtraRoleEvent):
+class IndexRequestedEvent(OpenSearchProvidesEvent):
     """Event emitted when a new index is requested for use on this relation."""
+
+    @property
+    def extra_user_roles(self) -> Optional[str]:
+        """Returns the extra user roles that were requested."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("extra-user-roles")
+
+
+class IndexEntityRequestedEvent(OpenSearchProvidesEvent, EntityProvidesEvent):
+    """Event emitted when a new entity is requested for use on this relation."""
 
 
 class OpenSearchProvidesEvents(CharmEvents):
@@ -3675,6 +3995,7 @@ class OpenSearchProvidesEvents(CharmEvents):
     """
 
     index_requested = EventSource(IndexRequestedEvent)
+    index_entity_requested = EventSource(IndexEntityRequestedEvent)
 
 
 class OpenSearchRequiresEvent(DatabaseRequiresEvent):
@@ -3685,6 +4006,10 @@ class IndexCreatedEvent(AuthenticationEvent, OpenSearchRequiresEvent):
     """Event emitted when a new index is created for use on this relation."""
 
 
+class IndexEntityCreatedEvent(EntityRequiresEvent, OpenSearchRequiresEvent):
+    """Event emitted when a new index is created for use on this relation."""
+
+
 class OpenSearchRequiresEvents(CharmEvents):
     """OpenSearch events.
 
@@ -3692,6 +4017,7 @@ class OpenSearchRequiresEvents(CharmEvents):
     """
 
     index_created = EventSource(IndexCreatedEvent)
+    index_entity_created = EventSource(IndexEntityCreatedEvent)
     endpoints_changed = EventSource(DatabaseEndpointsChangedEvent)
     authentication_updated = EventSource(AuthenticationEvent)
 
@@ -3754,15 +4080,32 @@ class OpenSearchProvidesEventHandlers(ProviderEventHandlers):
         # Leader only
         if not self.relation_data.local_unit.is_leader():
             return
+
         # Check which data has changed to emit customs events.
         diff = self._diff(event)
 
-        # Emit an index requested event if the setup key (index name and optional extra user roles)
-        # have been added to the relation databag by the application.
-        if "index" in diff.added:
+        # Validate entity information is not dynamically changed
+        self._validate_entity_consistency(event, diff)
+
+        # Emit an index requested event if the setup key (index name)
+        # was added to the relation databag, but the entity-type key was not.
+        if "index" in diff.added and "entity-type" not in diff.added:
             getattr(self.on, "index_requested").emit(
                 event.relation, app=event.app, unit=event.unit
             )
+
+            # To avoid unnecessary application restarts do not trigger other events.
+            return
+
+        # Emit an entity requested event if the setup key (index name)
+        # was added to the relation databag, in addition to the entity-type key.
+        if "index" in diff.added and "entity-type" in diff.added:
+            getattr(self.on, "index_entity_requested").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+            # To avoid unnecessary application restarts do not trigger other events.
+            return
 
     def _on_secret_changed_event(self, event: SecretChangedEvent) -> None:
         """Event emitted when the relation data has changed."""
@@ -3787,9 +4130,18 @@ class OpenSearchRequiresData(RequirerData):
         index: str,
         extra_user_roles: Optional[str] = None,
         additional_secret_fields: Optional[List[str]] = [],
+        extra_group_roles: Optional[str] = None,
+        entity_type: Optional[str] = None,
     ):
         """Manager of OpenSearch client relations."""
-        super().__init__(model, relation_name, extra_user_roles, additional_secret_fields)
+        super().__init__(
+            model,
+            relation_name,
+            extra_user_roles,
+            additional_secret_fields,
+            extra_group_roles,
+            entity_type,
+        )
         self.index = index
 
 
@@ -3813,8 +4165,13 @@ class OpenSearchRequiresEventHandlers(RequirerEventHandlers):
         # Sets both index and extra user roles in the relation if the roles are provided.
         # Otherwise, sets only the index.
         data = {"index": self.relation_data.index}
+
         if self.relation_data.extra_user_roles:
             data["extra-user-roles"] = self.relation_data.extra_user_roles
+        if self.relation_data.extra_group_roles:
+            data["extra-group-roles"] = self.relation_data.extra_group_roles
+        if self.relation_data.entity_type:
+            data["entity-type"] = self.relation_data.entity_type
 
         self.relation_data.update_relation_data(event.relation.id, data)
 
@@ -3864,27 +4221,40 @@ class OpenSearchRequiresEventHandlers(RequirerEventHandlers):
                 event.relation, app=event.app, unit=event.unit
             )
 
+        app_databag = get_encoded_dict(event.relation, event.app, "data")
+        if app_databag is None:
+            app_databag = {}
+
         # Check if the index is created
         # (the OpenSearch charm shares the credentials).
-        if (
-            "username" in diff.added and "password" in diff.added
-        ) or secret_field_user in diff.added:
+        if self._main_credentials_shared(diff) and "entity-type" not in app_databag:
             # Emit the default event (the one without an alias).
             logger.info("index created at: %s", datetime.now())
             getattr(self.on, "index_created").emit(event.relation, app=event.app, unit=event.unit)
 
-            # To avoid unnecessary application restarts do not trigger
-            # “endpoints_changed“ event if “index_created“ is triggered.
+            # To avoid unnecessary application restarts do not trigger other events.
             return
 
-        # Emit a endpoints changed event if the OpenSearch application added or changed this info
-        # in the relation databag.
+        if self._entity_credentials_shared(diff) and "entity-type" in app_databag:
+            # Emit the default event (the one without an alias).
+            logger.info("entity created at: %s", datetime.now())
+            getattr(self.on, "index_entity_created").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+            # To avoid unnecessary application restarts do not trigger other events.
+            return
+
+        # Emit a endpoints changed event if the OpenSearch application
+        # added or changed this info in the relation databag.
         if "endpoints" in diff.added or "endpoints" in diff.changed:
             # Emit the default event (the one without an alias).
             logger.info("endpoints changed on %s", datetime.now())
             getattr(self.on, "endpoints_changed").emit(
                 event.relation, app=event.app, unit=event.unit
-            )  # here check if this is the right design
+            )
+
+            # To avoid unnecessary application restarts do not trigger other events.
             return
 
 
@@ -3898,6 +4268,8 @@ class OpenSearchRequires(OpenSearchRequiresData, OpenSearchRequiresEventHandlers
         index: str,
         extra_user_roles: Optional[str] = None,
         additional_secret_fields: Optional[List[str]] = [],
+        extra_group_roles: Optional[str] = None,
+        entity_type: Optional[str] = None,
     ) -> None:
         OpenSearchRequiresData.__init__(
             self,
@@ -3906,6 +4278,8 @@ class OpenSearchRequires(OpenSearchRequiresData, OpenSearchRequiresEventHandlers
             index,
             extra_user_roles,
             additional_secret_fields,
+            extra_group_roles,
+            entity_type,
         )
         OpenSearchRequiresEventHandlers.__init__(self, charm, self)
 
@@ -4048,6 +4422,12 @@ class EtcdProviderEventHandlers(ProviderEventHandlers):
         if any(newval for newval in new_data_keys if self.relation_data._is_secret_field(newval)):
             self.relation_data._register_secrets_to_relation(event.relation, new_data_keys)
 
+        # Check which data has changed to emit customs events.
+        diff = self._diff(event)
+
+        # Validate entity information is not dynamically changed
+        self._validate_entity_consistency(event, diff)
+
         getattr(self.on, "mtls_cert_updated").emit(event.relation, app=event.app, unit=event.unit)
         return
 
@@ -4100,9 +4480,18 @@ class EtcdRequirerData(RequirerData):
         mtls_cert: Optional[str],
         extra_user_roles: Optional[str] = None,
         additional_secret_fields: Optional[List[str]] = [],
+        extra_group_roles: Optional[str] = None,
+        entity_type: Optional[str] = None,
     ):
         """Manager of Etcd client relations."""
-        super().__init__(model, relation_name, extra_user_roles, additional_secret_fields)
+        super().__init__(
+            model,
+            relation_name,
+            extra_user_roles,
+            additional_secret_fields,
+            extra_group_roles,
+            entity_type,
+        )
         self.prefix = prefix
         self.mtls_cert = mtls_cert
 
@@ -4212,6 +4601,8 @@ class EtcdRequires(EtcdRequirerData, EtcdRequirerEventHandlers):
         mtls_cert: Optional[str],
         extra_user_roles: Optional[str] = None,
         additional_secret_fields: Optional[List[str]] = [],
+        extra_group_roles: Optional[str] = None,
+        entity_type: Optional[str] = None,
     ) -> None:
         EtcdRequirerData.__init__(
             self,
@@ -4221,6 +4612,8 @@ class EtcdRequires(EtcdRequirerData, EtcdRequirerEventHandlers):
             mtls_cert,
             extra_user_roles,
             additional_secret_fields,
+            extra_group_roles,
+            entity_type,
         )
         EtcdRequirerEventHandlers.__init__(self, charm, self)
         if not self.secrets_enabled:

--- a/src/charm.py
+++ b/src/charm.py
@@ -229,8 +229,8 @@ class TrinoK8SCharm(CharmBase):
             event: The event triggered when the relation changed.
         """
         self.unit.status = WaitingStatus("configuring trino")
-        self._update(event)
         self.trino_coordinator._update_coordinator_relation_data(event)
+        self._update(event)
 
     @log_event_handler(logger)
     def _on_update_status(self, event):

--- a/src/relations/trino_coordinator.py
+++ b/src/relations/trino_coordinator.py
@@ -88,8 +88,6 @@ class TrinoCoordinator(Object):
         for relation in coordinator_relations:
             relation.data[self.charm.app].update(relation_data)
 
-        self.charm._update(event)
-
     def _on_relation_broken(self, event):
         """Coordinator updates and re-validates relations on relation broken.
 

--- a/src/relations/trino_coordinator.py
+++ b/src/relations/trino_coordinator.py
@@ -61,6 +61,7 @@ class TrinoCoordinator(Object):
             return
 
         self._update_coordinator_relation_data(event)
+        self.charm._update(event)
 
     def _update_coordinator_relation_data(self, event):
         """Update the `trino-coordinator` relation databag.


### PR DESCRIPTION
# Description

Current implementation of `_on_config_changed` ends up calling `_update` twice. It causes a race condition between catalog files being created twice and `trino` reading them. This PR attempts to fix it.

Note that there has not been enough manual testing for the changes.