### PR TITLE
[CSS-17394] - Update health check endpoint and tox deps

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -13,7 +13,7 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
-      channel: 1.28-strict/stable
+      channel: 1.34-strict/stable
       modules: '["test_charm.py", "test_policy.py", "test_resources.py", "test_scaling.py", "test_upgrades.py", "test_catalog_updates.py"]'
       juju-channel: 3.6/stable
       self-hosted-runner: true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,10 +6,10 @@ black==22.8.0
 coverage[toml]==6.4.4
 codespell==2.2.1
 
-flake8==5.0.4
-flake8-builtins==1.5.3
-flake8-copyright==0.2.3
-flake8-docstrings==1.6.0
+flake8==7.0.0
+flake8-builtins==3.0.0
+flake8-copyright==0.2.4
+flake8-docstrings==1.7.0
 flake8-docstrings-complete>=1.0.3
 flake8-test-docs>=1.0
 
@@ -22,7 +22,7 @@ mypy
 pep8-naming==0.13.2
 pydocstyle
 pylint
-pyproject-flake8==5.0.4.post1
+pyproject-flake8==7.0.0
 pytest==7.4.0
 pytest-operator==0.31.1
 pytest-asyncio==0.21.0

--- a/src/charm.py
+++ b/src/charm.py
@@ -258,12 +258,10 @@ class TrinoK8SCharm(CharmBase):
             self.unit.status = BlockedStatus(str(err))
             return
 
-        if self.config["charm-function"] in ["coordinator", "all"]:
-            check = container.get_check("up")
-            if check.status != CheckStatus.UP:
-                self.unit.status = MaintenanceStatus("Status check: DOWN")
-                self._restart_trino()
-                return
+        check = container.get_check("up")
+        if check.status != CheckStatus.UP:
+            self.unit.status = MaintenanceStatus("Status check: DOWN")
+            return
 
         self.unit.status = ActiveStatus("Status check: UP")
 
@@ -640,19 +638,15 @@ class TrinoK8SCharm(CharmBase):
                     "on-check-failure": {"up": "ignore"},
                 }
             },
+            "checks": {
+                "up": {
+                    "override": "replace",
+                    "period": "30s",
+                    "http": {"url": "http://localhost:8080/v1/info"},
+                }
+            },
         }
         if self.config["charm-function"] in ["coordinator", "all"]:
-            pebble_layer.update(
-                {
-                    "checks": {
-                        "up": {
-                            "override": "replace",
-                            "period": "30s",
-                            "http": {"url": "http://localhost:8080/"},
-                        }
-                    }
-                },
-            )
             # Handle Ranger plugin
             if self.state.ranger_enabled and not container.exists(
                 f"{TRINO_PLUGIN_DIR}/ranger"


### PR DESCRIPTION
As outlined in [CSS-17394](https://warthogs.atlassian.net/browse/CSS-17394), we've been getting a number of instances where Trino responds with `502 bad gateway`. A potential cause of this is:
- The charm has been using `http://localhost:8080/` as it's health check endpoint. In the Helm charts, it uses `http://localhost:8080/v1/info` as this returns a JSON rather than generating HTML as the first endpoint does.
- In the `update_status` hook, once the up check fails, the charm calls `self._restart_trino()`, causing Trino to constantly restart. This results in the following output of `juju show-status-log trino-coordinator/0`:

```
Time                   Type       Status       Message
16 Sep 2025 16:02:03Z  juju-unit  executing    running trino-pebble-check-failed hook
16 Sep 2025 16:02:08Z  juju-unit  executing    running trino-pebble-check-recovered hook
16 Sep 2025 16:02:15Z  juju-unit  executing    running trino-pebble-check-failed hook
16 Sep 2025 16:02:18Z  juju-unit  executing    running trino-pebble-check-recovered hook
16 Sep 2025 16:02:24Z  juju-unit  executing    running trino-pebble-check-failed hook
16 Sep 2025 16:02:29Z  juju-unit  executing    running trino-pebble-check-recovered hook
16 Sep 2025 16:02:36Z  juju-unit  executing    running trino-pebble-check-failed hook
16 Sep 2025 16:02:41Z  juju-unit  executing    running trino-pebble-check-recovered hook
16 Sep 2025 16:02:48Z  juju-unit  executing    running trino-pebble-check-failed hook
16 Sep 2025 16:02:54Z  juju-unit  executing    running trino-pebble-check-recovered hook
16 Sep 2025 16:03:00Z  juju-unit  executing    running trino-pebble-check-failed hook
16 Sep 2025 16:03:06Z  juju-unit  executing    running trino-pebble-check-recovered hook
16 Sep 2025 16:56:21Z  juju-unit  idle         
16 Sep 2025 17:02:05Z  juju-unit  executing    running trino-pebble-check-failed hook
16 Sep 2025 17:02:58Z  juju-unit  idle         
16 Sep 2025 17:02:58Z  workload   active       Status check: UP
16 Sep 2025 17:04:06Z  juju-unit  executing    running trino-pebble-check-recovered hook
16 Sep 2025 17:07:00Z  workload   maintenance  Status check: DOWN
16 Sep 2025 20:05:05Z  juju-unit  idle         
16 Sep 2025 20:32:34Z  workload   active       Status check: UP
```

It is worth noting that this only happens on the coordinator unit, where the health check is enabled. This PR:

- Modifies the health check endpoint to `/v1/info` and applies it to the worker units as well.
- Removes the functionality of restarting Trino in the `update_status` hook when the `up` check fails, which is in line with our other charms.
- Updates the tox linting dependencies as these versions are now required by the latest GH runner changes.

[CSS-17394]: https://warthogs.atlassian.net/browse/CSS-17394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ