### PR TITLE
fix: error "ranger.service.name: must not be empty" on Trino start

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -21,3 +21,4 @@ jobs:
       builder-runner-label: "self-hosted-linux-amd64-noble-xlarge"
       microk8s-addons: "dns ingress rbac storage metallb:10.15.119.2-10.15.119.4 registry"
       trivy-severity-config: CRITICAL
+      with-uv: true

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -13,11 +13,9 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
+      runs-on: "self-hosted-linux-amd64-noble-xlarge"
       channel: 1.34-strict/stable
       modules: '["test_charm.py", "test_policy.py", "test_resources.py", "test_scaling.py", "test_upgrades.py", "test_catalog_updates.py", "test_trino_catalog_relation.py", "test_managers.py", "test_pg_catalog_relation.py"]'
       juju-channel: 3/stable
-      self-hosted-runner: true
-      self-hosted-runner-label: "self-hosted-linux-amd64-noble-xlarge"
-      builder-runner-label: "self-hosted-linux-amd64-noble-xlarge"
       microk8s-addons: "dns ingress rbac storage metallb:10.15.119.2-10.15.119.4 registry"
       trivy-severity-config: CRITICAL

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -21,4 +21,3 @@ jobs:
       builder-runner-label: "self-hosted-linux-amd64-noble-xlarge"
       microk8s-addons: "dns ingress rbac storage metallb:10.15.119.2-10.15.119.4 registry"
       trivy-severity-config: CRITICAL
-      with-uv: true

--- a/src/charm.py
+++ b/src/charm.py
@@ -812,6 +812,7 @@ class TrinoK8SCharm(CharmBase):
             "METRICS_PORT": METRICS_PORT,
             "JMX_PORT": JMX_PORT,
             "RANGER_RELATION": self.state.ranger_enabled or False,
+            "REPOSITORY_NAME": self.config.get("ranger-service-name"),
             "ACL_ACCESS_MODE": self.config["acl-mode-default"],
             "ACL_USER_PATTERN": self.config["acl-user-pattern"],
             "ACL_CATALOG_PATTERN": self.config["acl-catalog-pattern"],

--- a/tests/unit/test_catalog_freshness.py
+++ b/tests/unit/test_catalog_freshness.py
@@ -100,6 +100,7 @@ class TestCatalogConfigFreshness(TestCase):
                         "METRICS_PORT": 9090,
                         "OAUTH_USER_MAPPING": None,
                         "RANGER_RELATION": False,
+                        "REPOSITORY_NAME": None,
                         "RESOURCE_GROUPS_CONFIG": None,
                         "SESSION_PROPERTY_MANAGER_CONFIG": None,
                         "ACL_ACCESS_MODE": "owner",

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -131,6 +131,7 @@ class TestCharm(TestCase):
                         "METRICS_PORT": 9090,
                         "OAUTH_USER_MAPPING": None,
                         "RANGER_RELATION": False,
+                        "REPOSITORY_NAME": None,
                         "RESOURCE_GROUPS_CONFIG": None,
                         "SESSION_PROPERTY_MANAGER_CONFIG": None,
                         "ACL_ACCESS_MODE": "owner",


### PR DESCRIPTION
This PR fixes this [bug](https://warthogs.atlassian.net/browse/CSS-22130) by making sure the `ranger-service-name` is part of the env used in `_configure_trino` which uses the Jinja templates to create the Trino config files that are pushed to the Trino home directory.