### PR TITLE
fix: ranger plugin config post v479 upgrade

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -50,7 +50,6 @@ from literals import (
     PASSWORD_DB,
     RUN_TRINO_COMMAND,
     TRINO_HOME,
-    TRINO_PLUGIN_DIR,
     TRINO_PORTS,
     USER_SECRET_LABEL,
 )

--- a/src/charm.py
+++ b/src/charm.py
@@ -933,9 +933,7 @@ class TrinoK8SCharm(CharmBase):
             )
 
             # Handle Ranger plugin
-            if self.state.ranger_enabled and not container.exists(
-                f"{TRINO_PLUGIN_DIR}/ranger"
-            ):
+            if self.state.ranger_enabled:
                 # No leadership check required as coordinator
                 # and single node cannot scale.
                 self.policy._configure_ranger_plugin(container)

--- a/src/charm.py
+++ b/src/charm.py
@@ -811,7 +811,6 @@ class TrinoK8SCharm(CharmBase):
             "METRICS_PORT": METRICS_PORT,
             "JMX_PORT": JMX_PORT,
             "RANGER_RELATION": self.state.ranger_enabled or False,
-            "REPOSITORY_NAME": self.config.get("ranger-service-name"),
             "ACL_ACCESS_MODE": self.config["acl-mode-default"],
             "ACL_USER_PATTERN": self.config["acl-user-pattern"],
             "ACL_CATALOG_PATTERN": self.config["acl-catalog-pattern"],

--- a/tests/unit/test_catalog_freshness.py
+++ b/tests/unit/test_catalog_freshness.py
@@ -100,7 +100,6 @@ class TestCatalogConfigFreshness(TestCase):
                         "METRICS_PORT": 9090,
                         "OAUTH_USER_MAPPING": None,
                         "RANGER_RELATION": False,
-                        "REPOSITORY_NAME": None,
                         "RESOURCE_GROUPS_CONFIG": None,
                         "SESSION_PROPERTY_MANAGER_CONFIG": None,
                         "ACL_ACCESS_MODE": "owner",

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -131,7 +131,6 @@ class TestCharm(TestCase):
                         "METRICS_PORT": 9090,
                         "OAUTH_USER_MAPPING": None,
                         "RANGER_RELATION": False,
-                        "REPOSITORY_NAME": None,
                         "RESOURCE_GROUPS_CONFIG": None,
                         "SESSION_PROPERTY_MANAGER_CONFIG": None,
                         "ACL_ACCESS_MODE": "owner",


### PR DESCRIPTION
before the [upgrade to v479](https://github.com/canonical/trino-k8s-operator/pull/107) the ranger plugin was called `apache-ranger` so the check `and not container.exists(f"{TRINO_PLUGIN_DIR}/ranger")` was useless and `_configure_ranger_plugin` always executed.

with the upgrade the plugin has been [renamed](https://github.com/trinodb/trino/pull/25238) to `ranger` which makes the check valid so the `_configure_ranger_plugin` does not execute if the directory is already there. 

this means that during a pod restart the ranger service files depend only on `_configure_trino` which does not have all the necessary envs. this wasn't an issue before because `_configure_ranger_plugin` would always fire and make up for it. there was an attempt to fix this in a previous [PR](https://github.com/canonical/trino-k8s-operator/pull/109) but it was not sufficient. that fix allows trino to start correctly but there are other issues down the road. this PR ensures the correct behavior as before the upgrade.