### PR TITLE
fix: check leader on relation created in trino-catalog lib

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   integration-tests:
-    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@fix_integration_test
     secrets: inherit
     with:
       runs-on: "self-hosted-linux-amd64-noble-xlarge"

--- a/lib/charms/trino_k8s/v0/trino_catalog.py
+++ b/lib/charms/trino_k8s/v0/trino_catalog.py
@@ -23,7 +23,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 
 
@@ -231,6 +231,8 @@ class TrinoCatalogRequirer(Object):
 
     def _on_relation_created(self, event) -> None:
         """Publish app name so the provider can build a readable username."""
+        if not self.charm.unit.is_leader():
+            return
         event.relation.data[self.charm.app]["app_name"] = self.charm.app.name
 
     def get_trino_info(self) -> Optional[dict]:

--- a/tests/integration/trino_catalog_requirer_charm/lib/charms/trino_k8s/v0/trino_catalog.py
+++ b/tests/integration/trino_catalog_requirer_charm/lib/charms/trino_k8s/v0/trino_catalog.py
@@ -23,7 +23,8 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
+
 
 
 logger = logging.getLogger(__name__)
@@ -230,6 +231,8 @@ class TrinoCatalogRequirer(Object):
 
     def _on_relation_created(self, event) -> None:
         """Publish app name so the provider can build a readable username."""
+        if not self.charm.unit.is_leader():
+            return
         event.relation.data[self.charm.app]["app_name"] = self.charm.app.name
 
     def get_trino_info(self) -> Optional[dict]:


### PR DESCRIPTION
This PR introduces a fix in the trino-catalog library. The issue was encountered in staging where the Superset UI app has multiple units and is related to Trino through this library. The non-leader units failed upon relation-created since only the leader is able to write to the databag.