### PR TITLE
feat: set targetServerType at the catalog replica level

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,16 @@ rw:
   user: trino
   password: "pwd1" 
   suffix: _developer
+  params: ssl=true&sslmode=require&sslrootcert={SSL_PATH}&sslrootcertpassword={SSL_PWD}&targetServerType=primary
 ro:
   user: trino_ro
   password: "pwd2"
+  params: ssl=true&sslmode=require&sslrootcert={SSL_PATH}&sslrootcertpassword={SSL_PWD}&targetServerType=preferSecondary
 ```
+
+Each replica can declare its own `params` to override the backend-level `params` for that catalog file. This is the recommended pattern for controlling JDBC routing per replica where the rw replica targets the primary and the ro replica routes to secondaries. The backend-level `params` is used as a fallback for replicas that do not set their own.
+
+If `params` is omitted from a replica, the backend's `params` applies to that replica unchanged.
 
 For PostgreSQL certificates (`certificates.yaml`):
 ```

--- a/src/literals.py
+++ b/src/literals.py
@@ -81,6 +81,7 @@ REPLICA_SCHEMA = {
     "user": {"type": "string"},
     "password": {"type": "string"},
     "suffix": {"type": "string", "nullable": True},
+    "params": {"type": "string", "nullable": True},
 }
 
 BIGQUERY_BACKEND_SCHEMA = {

--- a/src/sql_catalog.py
+++ b/src/sql_catalog.py
@@ -58,8 +58,9 @@ class SqlCatalog(CatalogBase):
 
             catalog_name = f"{self.name}{suffix}"
             url = self.db_url
-            if self.backend.get("params"):
-                url = f"{url}?{self.backend['params']}"
+            params = replica_info.get("params") or self.backend.get("params")
+            if params:
+                url = f"{url}?{params}"
 
             catalog_content = textwrap.dedent(
                 f"""\

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -71,9 +71,11 @@ rw:
   user: trino
   password: pwd1
   suffix: _developer
+  params: ssl=true&sslmode=require&sslrootcert={SSL_PATH}&sslrootcertpassword={SSL_PWD}&targetServerType=primary
 ro:
   user: trino_ro
   password: pwd2
+  params: ssl=true&sslmode=require&sslrootcert={SSL_PATH}&sslrootcertpassword={SSL_PWD}&targetServerType=preferSecondary
 """  # nosec
 
 MYSQL_REPLICA_SECRET = """\

--- a/tests/integration/trino_catalog_requirer_charm/lib/charms/trino_k8s/v0/trino_catalog.py
+++ b/tests/integration/trino_catalog_requirer_charm/lib/charms/trino_k8s/v0/trino_catalog.py
@@ -26,7 +26,6 @@ LIBAPI = 0
 LIBPATCH = 5
 
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -48,6 +48,18 @@ ro:
   user: trino_ro
   password: pwd2
 """  # nosec
+
+POSTGRESQL_REPLICA_SECRET_WITH_PARAMS = """\
+rw:
+  user: trino
+  password: pwd1
+  suffix: _developer
+  params: ssl=true&targetServerType=primary
+ro:
+  user: trino_ro
+  password: pwd2
+  params: ssl=true&targetServerType=preferSecondary
+"""  # nosec
 MYSQL_REPLICA_SECRET = """\
 ro:
   user: trino_ro
@@ -67,6 +79,9 @@ cert: |
 
 POSTGRESQL_1_CATALOG_PATH = (
     "/usr/lib/trino/etc/catalog/postgresql-1.properties"
+)
+POSTGRESQL_1_DEVELOPER_CATALOG_PATH = (
+    "/usr/lib/trino/etc/catalog/postgresql-1_developer.properties"
 )
 POSTGRESQL_2_CATALOG_PATH = (
     "/usr/lib/trino/etc/catalog/postgresql-2.properties"
@@ -449,4 +464,33 @@ def create_added_catalog_config(
                 bigquery.case-insensitive-name-matching=true
         gsheets:
             connector: gsheets
+    """
+
+
+def create_single_catalog_config(postgresql_secret_id, backend_params=None):
+    """Create a minimal catalog-config with a single postgresql catalog.
+
+    Args:
+        postgresql_secret_id: the juju secret id for postgresql
+        backend_params: optional JDBC params string for the backend. When None,
+            the backend declares no params and replicas must provide their own.
+
+    Returns:
+        catalog configuration string.
+    """
+    params_line = (
+        f"\n            params: {backend_params}" if backend_params else ""
+    )
+    return f"""\
+    catalogs:
+        postgresql-1:
+            backend: dwh
+            database: example
+            secret-id: {postgresql_secret_id}
+    backends:
+        dwh:
+            connector: postgresql
+            url: jdbc:postgresql://example.com:5432{params_line}
+            config: |
+                case-insensitive-name-matching=true
     """

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -25,8 +25,12 @@ from tests.unit.helpers import (
     BIGQUERY_CATALOG_PATH,
     DEFAULT_JVM_STRING,
     POSTGRESQL_1_CATALOG_PATH,
+    POSTGRESQL_1_DEVELOPER_CATALOG_PATH,
+    POSTGRESQL_REPLICA_SECRET,
+    POSTGRESQL_REPLICA_SECRET_WITH_PARAMS,
     SERVER_PORT,
     create_catalog_config,
+    create_single_catalog_config,
     make_relation_event,
     simulate_lifecycle_coordinator,
     simulate_lifecycle_worker,
@@ -515,3 +519,87 @@ class TestCharm(TestCase):
 
         self.assertFalse(container.exists(properties_path))
         self.assertFalse(container.exists(json_path))
+
+    def test_per_replica_params_override_backend_params(self):
+        """Per-replica params override backend params in rendered catalog files.
+
+        The rw replica and ro replica must get the targetServerType declared
+        in their respective replica params, not a shared value from the backend.
+        """
+        harness = self.harness
+        simulate_lifecycle_coordinator(harness)
+
+        postgresql_secret_id = harness.add_model_secret(
+            "trino-k8s",
+            {"replicas": POSTGRESQL_REPLICA_SECRET_WITH_PARAMS},
+        )
+        catalog_config = create_single_catalog_config(postgresql_secret_id)
+        harness.update_config({"catalog-config": catalog_config})
+
+        container = harness.model.unit.get_container("trino")
+
+        ro_props = container.pull(POSTGRESQL_1_CATALOG_PATH).read()
+        rw_props = container.pull(POSTGRESQL_1_DEVELOPER_CATALOG_PATH).read()
+
+        self.assertIn("targetServerType=preferSecondary", ro_props)
+        self.assertIn("targetServerType=primary", rw_props)
+        self.assertNotIn("targetServerType=preferSecondary", rw_props)
+
+    def test_backend_params_applied_when_replica_params_absent(self):
+        """Backend params are used for all replicas when no per-replica params are set.
+
+        Verifies the fallback path: replicas without their own params inherit
+        the backend-level params unchanged.
+        """
+        harness = self.harness
+        simulate_lifecycle_coordinator(harness)
+
+        postgresql_secret_id = harness.add_model_secret(
+            "trino-k8s",
+            {"replicas": POSTGRESQL_REPLICA_SECRET},
+        )
+        catalog_config = create_single_catalog_config(
+            postgresql_secret_id,
+            backend_params="ssl=false&targetServerType=primary",
+        )
+        harness.update_config({"catalog-config": catalog_config})
+
+        container = harness.model.unit.get_container("trino")
+
+        ro_props = container.pull(POSTGRESQL_1_CATALOG_PATH).read()
+        rw_props = container.pull(POSTGRESQL_1_DEVELOPER_CATALOG_PATH).read()
+
+        # Both replicas should carry the backend's params unchanged
+        self.assertIn("targetServerType=primary", ro_props)
+        self.assertIn("targetServerType=primary", rw_props)
+
+    def test_replica_params_override_backend_params_when_both_present(self):
+        """Replica params take precedence over backend params when both are declared.
+
+        Verifies the override path: even when the backend has params, each
+        replica's own params replace them entirely for that catalog file.
+        """
+        harness = self.harness
+        simulate_lifecycle_coordinator(harness)
+
+        postgresql_secret_id = harness.add_model_secret(
+            "trino-k8s",
+            {"replicas": POSTGRESQL_REPLICA_SECRET_WITH_PARAMS},
+        )
+        catalog_config = create_single_catalog_config(
+            postgresql_secret_id,
+            backend_params="ssl=false&targetServerType=primary",
+        )
+        harness.update_config({"catalog-config": catalog_config})
+
+        container = harness.model.unit.get_container("trino")
+
+        ro_props = container.pull(POSTGRESQL_1_CATALOG_PATH).read()
+        rw_props = container.pull(POSTGRESQL_1_DEVELOPER_CATALOG_PATH).read()
+
+        # Replica params should win, backend has targetServerType=primary for both,
+        # but replica declares preferSecondary for ro and primary for rw
+        self.assertIn("targetServerType=preferSecondary", ro_props)
+        self.assertNotIn("targetServerType=primary", ro_props)
+        self.assertIn("targetServerType=primary", rw_props)
+        self.assertNotIn("targetServerType=preferSecondary", rw_props)


### PR DESCRIPTION
This PR adds an optional params field to each replica in the secrets referenced in catalog-config. When set, the replica's params override the backend-level params for that catalog file, allowing rw and ro replicas to declare different JDBC routing settings independently.

This is needed because backends with multiple replicas (rw + ro) shared a single params string from the backend config, so both catalogs inherited the same targetServerType leading to ro catalogs always routing to primaries if a corresponding rw catalog existed alongside them.