### PR TITLE
fix: rework tls-secret-name

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The load balancer or proxy server accepts TLS connections and forwards them to t
 ![trino-communication](trino-tls.svg)
 
 ### Ingress
-The Trino operator exposes its ports using the Nginx Ingress Integrator operator. You must first make sure to have an Nginx Ingress Controller deployed. To enable TLS connections, you must have a TLS certificate stored as a k8s secret (default name is "trino-tls"). A self-signed certificate for development purposes can be created as follows:
+The Trino operator exposes its ports using the Nginx Ingress Integrator operator. You must first make sure to have an Nginx Ingress Controller deployed. To enable TLS connections, you can either supply the name of a pre-existing k8s TLS secret via the `tls-secret-name` config option, or leave it unset and relate `nginx-ingress-integrator` to a `lego` operator so that lego manages the certificate automatically. A self-signed certificate for development purposes can be created and supplied as follows:
 
 ```
 # Generate private key
@@ -48,6 +48,9 @@ openssl x509 -req -days 365 -in server.csr -signkey server.key -out server.crt -
 
 # Create a k8s secret
 kubectl create secret tls trino-tls --cert=server.crt --key=server.key
+
+# Configure the application
+juju config trino-k8s tls-secret-name=trino-tls
 ```
 This operator can then be deployed and connected to the Trino operator using the Juju command line as follows:
 

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -150,7 +150,9 @@ config:
     tls-secret-name:
       description: |
           Name of the k8s secret which contains the TLS certificate to be used by ingress.
-      default: "trino-tls"
+          When set, this takes precedence over any TLS secret managed externally (e.g. by lego).
+          Leave unset to let nginx-ingress-integrator obtain the TLS certificate from a related
+          lego operator instead.
       type: string
     charm-function:
       description: |

--- a/src/charm.py
+++ b/src/charm.py
@@ -231,7 +231,7 @@ class TrinoK8SCharm(TypedCharmBase[CharmConfig]):
             service_hostname=raw.get("external-hostname") or self.app.name,
             service_name=self.app.name,
             service_port=TRINO_PORTS["HTTP"],
-            tls_secret_name=raw.get("tls-secret-name") or "trino-tls",
+            tls_secret_name=raw.get("tls-secret-name"),
             backend_protocol="HTTP",
         )
 

--- a/src/config.py
+++ b/src/config.py
@@ -93,7 +93,7 @@ class CharmConfig(BaseConfigModel):
     web_proxy: Optional[str] = None
     ranger_service_name: Optional[str] = None
     external_hostname: Optional[str] = None
-    tls_secret_name: str = "trino-tls"
+    tls_secret_name: Optional[str] = None
     charm_function: str = "all"
     discovery_uri: Optional[str] = None
     catalog_config: Optional[str] = None
@@ -168,13 +168,13 @@ class CharmConfig(BaseConfigModel):
 
     @validator("tls_secret_name")
     def validate_tls_secret_name(cls, v):
-        """Validate tls_secret_name is a legal Kubernetes resource name."""
-        if not _K8S_NAME_RE.match(v):
+        """Validate tls_secret_name is a legal Kubernetes resource name when provided."""
+        if v and not _K8S_NAME_RE.match(v):
             raise ValueError(
                 f"tls-secret-name must be a valid Kubernetes resource name "
                 f"(lowercase alphanumeric and hyphens), got {v!r}"
             )
-        return v
+        return v or None
 
     # ── Regex validators ───────────────────────────────────────────────────
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -196,8 +196,52 @@ class TestCharm(TestCase):
             "service-name": harness.charm.app.name,
             "service-port": SERVER_PORT,
             "backend-protocol": "HTTP",
-            "tls-secret-name": "trino-tls",
         }
+
+    @mock.patch("charm.KubernetesStatefulsetPatch")
+    def test_ingress_tls_secret_name_set(self, _):
+        """An explicit tls-secret-name is forwarded to the nginx-route relation."""
+        harness = Harness(TrinoK8SCharm)
+        self.addCleanup(harness.cleanup)
+        harness.set_can_connect("trino", True)
+        harness.set_leader(True)
+        harness.set_model_name("trino-model")
+        harness.add_network("10.0.0.10", endpoint="peer")
+        harness.update_config({"tls-secret-name": "my-tls-secret"})
+        harness.begin()
+
+        simulate_lifecycle_coordinator(harness)
+        nginx_route_relation_id = harness.add_relation("nginx-route", "ingress")
+        harness.charm._require_nginx_route()
+
+        assert (
+            harness.get_relation_data(nginx_route_relation_id, harness.charm.app).get(
+                "tls-secret-name"
+            )
+            == "my-tls-secret"
+        )
+
+    @mock.patch("charm.KubernetesStatefulsetPatch")
+    def test_ingress_tls_secret_name_unset(self, _):
+        """When tls-secret-name is not set, the key is absent from the nginx-route relation.
+
+        This allows an external operator (e.g. lego) to provide the TLS secret instead.
+        """
+        harness = Harness(TrinoK8SCharm)
+        self.addCleanup(harness.cleanup)
+        harness.set_can_connect("trino", True)
+        harness.set_leader(True)
+        harness.set_model_name("trino-model")
+        harness.add_network("10.0.0.10", endpoint="peer")
+        harness.begin()
+
+        simulate_lifecycle_coordinator(harness)
+        nginx_route_relation_id = harness.add_relation("nginx-route", "ingress")
+        harness.charm._require_nginx_route()
+
+        assert "tls-secret-name" not in harness.get_relation_data(
+            nginx_route_relation_id, harness.charm.app
+        )
 
     def test_invalid_config_value(self):
         """The charm blocks if an invalid config value is provided."""


### PR DESCRIPTION
Changes:
* Lets `tls-secret-name` be empty.
* Removes redundant default for `tls-secret-name`.