### PR TITLE
Migrate testing frameworks

### DIFF
--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -433,6 +433,11 @@ from typing import (
     overload,
 )
 
+try:
+    from cryptography.fernet import Fernet, InvalidToken
+except ImportError:
+    Fernet = None
+    InvalidToken = None
 from ops import JujuVersion, Model, Secret, SecretInfo, SecretNotFoundError
 from ops.charm import (
     CharmBase,
@@ -453,7 +458,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 58
+LIBPATCH = 59
 
 PYDEPS = ["ops>=2.0.0"]
 
@@ -488,6 +493,10 @@ MODEL_ERRORS = {
     "no_label_and_uri": "ERROR either URI or label should be used for getting an owned secret but not both",
     "owner_no_refresh": "ERROR secret owner cannot use --refresh",
 }
+
+CROSS_MODEL_RELATION_CONSUMER_SECRETS = [
+    "mtls-cert",
+]
 
 
 ##############################################################################
@@ -1227,6 +1236,15 @@ class Data(ABC):
         """Load secrets from the databag."""
         raise NotImplementedError
 
+    def _get_encryption_key(self, relation: Relation) -> Optional[str]:
+        """Fetch the encryption key from the encryption secret if available."""
+        if not (encryption_secret := relation.data[relation.app].get("encryption-secret")):
+            return None
+
+        # get the encryption secret created on provider side
+        secret = self._model.get_secret(id=encryption_secret)
+        return secret.get_content().get("encryption-key")
+
     def _fetch_specific_relation_data(
         self, relation: Relation, fields: Optional[List[str]]
     ) -> Dict[str, str]:
@@ -1586,11 +1604,48 @@ class Data(ABC):
             return {}
 
         if fields:
-            return {
+            relation_data = {
                 k: relation.data[component][k] for k in fields if k in relation.data[component]
             }
         else:
-            return dict(relation.data[component])
+            relation_data = dict(relation.data[component])
+
+        try:
+            remote_model_uuid = relation.remote_model.uuid
+        except (FileNotFoundError, ModelError, RuntimeError) as e:
+            # access to remote model added in Juju 3.6.2, fails with 2.9
+            logger.warning("Access to remote model failed: %s", e)
+            remote_model_uuid = ""
+
+        # if not a cross-model relation we can return data as-is
+        if remote_model_uuid == "" or self._model.uuid == remote_model_uuid:
+            return relation_data
+
+        if not (encryption_key := self._get_encryption_key(relation)):
+            return relation_data
+
+        if not Fernet:
+            logger.warning(
+                "Cryptography module not installed. Could not decrypt sensitive field in cross-model relation"
+            )
+            return relation_data
+
+        # still here means sensitive data needs to be decrypted
+        for key, value in relation_data.items():
+            if key in CROSS_MODEL_RELATION_CONSUMER_SECRETS:
+                try:
+                    f = Fernet(encryption_key)
+                    decrypted_value = f.decrypt(value.encode()).decode()
+                    relation_data[key] = decrypted_value
+                except (
+                    AttributeError,
+                    InvalidToken,
+                    TypeError,
+                    ValueError,
+                ):  # pyright: ignore [reportGeneralTypeIssues]
+                    logger.warning("Could not decrypt sensitive field in cross-model relation")
+
+        return relation_data
 
     def _fetch_relation_data_with_secrets(
         self,
@@ -1637,8 +1692,40 @@ class Data(ABC):
         if component not in relation.data or relation.data[component] is None:
             return
 
-        if relation:
-            relation.data[component].update(data)
+        if not relation:
+            return
+
+        # ensure no sensitive information is stored in relation data
+        encryption_key = self._get_encryption_key(relation)
+
+        try:
+            remote_model_uuid = relation.remote_model.uuid
+        except (FileNotFoundError, ModelError, RuntimeError):
+            # access to remote model added in Juju 3.6.2, fails with 2.9
+            remote_model_uuid = ""
+
+        if encryption_key and remote_model_uuid != "" and self._model.uuid != remote_model_uuid:
+            for key, value in data.items():
+                try:
+                    f = Fernet(encryption_key)  # pyright: ignore [reportOptionalCall]
+                    if key in CROSS_MODEL_RELATION_CONSUMER_SECRETS:
+                        encrypted_value = f.encrypt(value.encode()).decode()
+                        data[key] = encrypted_value
+                except (
+                    AttributeError,
+                    InvalidToken,
+                    ValueError,
+                ):  # pyright: ignore [reportGeneralTypeIssues]
+                    logger.warning("Could not encrypt sensitive field in cross-model relation")
+                    data[key] = ""
+                except TypeError:
+                    # "TypeError: 'NoneType' object is not callable" raised when Fernet is `None`
+                    logger.warning(
+                        "Cryptography module not installed. Could not decrypt sensitive field in cross-model relation"
+                    )
+                    data[key] = ""
+
+        relation.data[component].update(data)
 
     def _delete_relation_data_without_secrets(
         self, component: Union[Application, Unit], relation: Relation, fields: List[str]
@@ -1899,7 +1986,7 @@ class ProviderData(Data):
         """Set values for fields not caring whether it's a secret or not."""
         keys = set(data.keys())
         if self.fetch_relation_field(relation.id, self.RESOURCE_FIELD) is None and (
-            keys - {"endpoints", "read-only-endpoints", "replset"}
+            keys - {"endpoints", "read-only-endpoints", "replset", "encryption-secret"}
         ):
             raise PrematureDataAccessError(
                 "Premature access to relation data, update is forbidden before the connection is initialized."
@@ -2112,12 +2199,31 @@ class RequirerData(Data):
             field
             for field in self.SECRET_LABEL_MAP.keys()
             if field not in self._remote_secret_fields
+            and not (
+                field in CROSS_MODEL_RELATION_CONSUMER_SECRETS and self.is_cross_model_relation
+            )
         ]
         if additional_secret_fields:
             self._remote_secret_fields += additional_secret_fields
         self.data_component = self.local_unit
 
     # Internal functions
+    @property
+    def is_cross_model_relation(self) -> bool:
+        """Determines whether the relation is a cross-model relation or not."""
+        if len(self.relations) == 0:
+            return False
+
+        try:
+            remote_model_uuid = self.relations[0].remote_model.uuid
+        except (FileNotFoundError, ModelError, RuntimeError):
+            # access to remote model added in Juju 3.6.2, fails with 2.9
+            return False
+
+        if self._model.uuid != remote_model_uuid:
+            return True
+
+        return False
 
     def _is_resource_created_for_relation(self, relation: Relation) -> bool:
         if not relation.app:
@@ -2389,6 +2495,44 @@ class ProviderEventHandlers(EventHandlers):
                 raise ValueError(f"Cannot change {key} after relation has already been created")
 
     # Event handlers
+    def _on_relation_created_event(self, event: RelationCreatedEvent) -> None:
+        """Event emitted when a relation is created."""
+        if not self.relation_data.local_unit.is_leader():
+            return
+
+        try:
+            remote_model_uuid = event.relation.remote_model.uuid
+        except (FileNotFoundError, ModelError, RuntimeError):
+            # access to remote model added in Juju 3.6.2, fails with 2.9
+            return
+
+        if self.model.uuid == remote_model_uuid:
+            return
+
+        if not Fernet:
+            logger.warning(
+                "Cryptography module not installed. Could not decrypt sensitive field in cross-model relation"
+            )
+            return
+
+        # in cross-model relations, generate an encryption key and share it with the requirer as a secret
+        event_data = {}
+        secret_label = f"{self.model.uuid}-{event.relation.id}-encryption-secret"
+
+        try:
+            # check if secret was already created to avoid duplicates
+            secret = self.charm.model.get_secret(label=secret_label)
+        except SecretNotFoundError:
+            encryption_key = Fernet.generate_key()  # pyright: ignore [reportOptionalMemberAccess]
+            content = {"encryption-key": encryption_key.decode()}
+            secret = self.charm.app.add_secret(content, label=secret_label)
+
+        secret.grant(event.relation)
+        if not secret.id:
+            raise SecretError("Encryption secret is missing secred id")
+        event_data["encryption-secret"] = secret.id
+
+        self.relation_data.update_relation_data(event.relation.id, event_data)
 
     def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
         """Event emitted when the relation data has changed."""
@@ -4412,6 +4556,33 @@ class KafkaRequirerEventHandlers(RequirerEventHandlers):
         # Check which data has changed to emit customs events.
         diff = self._diff(event)
 
+        # send request again if encryption secret was added from provider side
+        if "encryption-secret" in diff.added and self.relation_data.local_unit.is_leader():
+            relation_data = {
+                "topic": self.relation_data.topic,
+                "encryption-secret": event.relation.data[event.relation.app].get(
+                    "encryption-secret"
+                ),
+            }
+
+            if self.relation_data.mtls_cert:
+                relation_data["mtls-cert"] = self.relation_data.mtls_cert
+
+            if self.relation_data.consumer_group_prefix:
+                relation_data["consumer-group-prefix"] = self.relation_data.consumer_group_prefix
+
+            if self.relation_data.extra_user_roles:
+                relation_data["extra-user-roles"] = self.relation_data.extra_user_roles
+            if self.relation_data.extra_group_roles:
+                relation_data["extra-group-roles"] = self.relation_data.extra_group_roles
+            if self.relation_data.entity_type:
+                relation_data["entity-type"] = self.relation_data.entity_type
+            if self.relation_data.entity_permissions:
+                relation_data["entity-permissions"] = self.relation_data.entity_permissions
+
+            self.relation_data.update_relation_data(event.relation.id, relation_data)
+            return
+
         # Check if the topic is created
         # (the Kafka charm shared the credentials).
 
@@ -5689,6 +5860,24 @@ class EtcdRequirerEventHandlers(RequirerEventHandlers):
 
         # Check which data has changed to emit customs events.
         diff = self._diff(event)
+
+        # send request again if encryption secret was added from provider side
+        if "encryption-secret" in diff.added and self.relation_data.local_unit.is_leader():
+            payload = {
+                "prefix": self.relation_data.prefix,
+                "encryption-secret": event.relation.data[event.relation.app].get(
+                    "encryption-secret"
+                ),
+            }
+            if self.relation_data.mtls_cert:
+                payload["mtls-cert"] = self.relation_data.mtls_cert
+
+            self.relation_data.update_relation_data(
+                event.relation.id,
+                payload,
+            )
+            return
+
         # Register all new secrets with their labels
         if any(newval for newval in diff.added if self.relation_data._is_secret_field(newval)):
             self.relation_data._register_secrets_to_relation(event.relation, diff.added)

--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -217,7 +217,7 @@ LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 49
+LIBPATCH = 50
 
 PYDEPS = ["cosl >= 0.0.50"]
 
@@ -1349,10 +1349,26 @@ class GrafanaDashboardProvider(Object):
 
     def _upset_dashboards_on_relation(self, relation: Relation) -> None:
         """Update the dashboards in the relation data bucket."""
+        new_templates = type_convert_stored(self._stored.dashboard_templates)  # pyright: ignore
+
+        # Check if the templates have actually changed before updating.
+        # This avoids generating a new UUID on every event, which would cause
+        # unnecessary relation-changed events on the consumer side.
+        # See: https://github.com/canonical/opentelemetry-collector-operator/issues/331
+        existing_data_str = relation.data[self._charm.app].get("dashboards", "{}")
+        try:
+            existing_data = json.loads(existing_data_str)
+            existing_templates = existing_data.get("templates", {})
+        except json.JSONDecodeError:
+            existing_templates = {}
+
+        if new_templates == existing_templates:
+            return  # No change in templates, don't update the databag
+
         # It's completely ridiculous to add a UUID, but if we don't have some
         # pseudo-random value, this never makes it across 'juju set-state'
         stored_data = {
-            "templates": type_convert_stored(self._stored.dashboard_templates),  # pyright: ignore
+            "templates": new_templates,
             "uuid": str(uuid.uuid4()),
         }
 
@@ -1831,14 +1847,28 @@ class GrafanaDashboardAggregator(Object):
 
     def _update_remote_grafana(self, _: Optional[RelationEvent] = None) -> None:
         """Push dashboards to the downstream Grafana relation."""
-        # It's still ridiculous to add a UUID here, but needed
-        stored_data = {
-            "templates": type_convert_stored(self._stored.dashboard_templates),  # pyright: ignore
-            "uuid": str(uuid.uuid4()),
-        }
+        new_templates = type_convert_stored(self._stored.dashboard_templates)  # pyright: ignore
 
         if self._charm.unit.is_leader():
             for grafana_relation in self.model.relations[self._grafana_relation]:
+                # Check if the templates have actually changed before updating.
+                # This avoids generating a new UUID on every event, which would cause
+                # unnecessary relation-changed events on the consumer side.
+                existing_data_str = grafana_relation.data[self._charm.app].get("dashboards", "{}")
+                try:
+                    existing_data = json.loads(existing_data_str)
+                    existing_templates = existing_data.get("templates", {})
+                except json.JSONDecodeError:
+                    existing_templates = {}
+
+                if new_templates == existing_templates:
+                    continue  # No change in templates, don't update the databag
+
+                # It's still ridiculous to add a UUID here, but needed
+                stored_data = {
+                    "templates": new_templates,
+                    "uuid": str(uuid.uuid4()),
+                }
                 grafana_relation.data[self._charm.app]["dashboards"] = json.dumps(stored_data)
 
     def remove_dashboards(self, event: RelationBrokenEvent) -> None:

--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -544,7 +544,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 26
+LIBPATCH = 30
 
 PYDEPS = ["cosl"]
 
@@ -1188,7 +1188,10 @@ class LokiPushApiProvider(Object):
                 )
                 continue
 
-            alerts[identifier] = self._tool.apply_label_matchers(alert_rules)  # type: ignore
+            # Topology labels are already injected by _inject_alert_expr_labels using
+            # alert_expression_dict, which intentionally excludes juju_charm and juju_unit.
+            # Don't call apply_label_matchers here as it would re-inject juju_charm.
+            alerts[identifier] = alert_rules
 
             _, errmsg = self._tool.validate_alert_rules(cast(OfficialRuleFileFormat, alert_rules))
             if errmsg:
@@ -1198,6 +1201,10 @@ class LokiPushApiProvider(Object):
                 if self._charm.unit.is_leader():
                     relation.data[self._charm.app]["event"] = json.dumps({"errors": errmsg})
                 continue
+            if self._charm.unit.is_leader():
+                event_data = json.loads(relation.data[self._charm.app].get("event", "{}"))
+                event_data.pop("errors", None)
+                relation.data[self._charm.app]["event"] = json.dumps(event_data)
 
             alerts[identifier] = alert_rules
 
@@ -1279,10 +1286,13 @@ class LokiPushApiProvider(Object):
                             charm_name=labels.get("juju_charm", ""),
                         )
 
-                        # Inject topology and put it back in the list
+                        # Inject topology and put it back in the list.
+                        # Use alert_expression_dict (excludes juju_charm) instead of
+                        # label_matcher_dict because subordinate charms (e.g. otelcol)
+                        # label logs with their own charm name, not the principal's.
                         rule["expr"] = self._tool.inject_label_matchers(
                             re.sub(r"%%juju_topology%%,?", "", rule["expr"]),
-                            topology.label_matcher_dict,
+                            topology.alert_expression_dict,
                         )
                     except KeyError:
                         # Some required JujuTopology key is missing. Just move on.
@@ -1405,7 +1415,6 @@ class ConsumerBase(Object):
                 endpoints.append(deserialized_endpoint)
 
         return endpoints
-
 
 
 class LokiPushApiConsumer(ConsumerBase):
@@ -1700,7 +1709,7 @@ class LogProxyConsumer(ConsumerBase):
         self._promtails_ports = self._generate_promtails_ports(logs_scheme)
 
         # architecture used for promtail binary
-        arch = platform.processor()
+        arch = platform.machine()
         if arch in ["x86_64", "amd64"]:
             self._arch = "amd64"
         elif arch in ["aarch64", "arm64", "armv8b", "armv8l"]:
@@ -2294,6 +2303,7 @@ class _PebbleLogClient:
                         "juju_model_uuid": topology._model_uuid,
                         "juju_application": topology._application,
                         "juju_unit": topology._unit,
+                        "job": f"juju_{topology.identifier}",
                     },
                 }
             )

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -361,7 +361,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 59
+LIBPATCH = 61
 
 # Version 0.0.53 needed for cosl.rules.generic_alert_groups
 PYDEPS = ["cosl>=0.0.53"]
@@ -999,6 +999,10 @@ class MetricsEndpointConsumer(Object):
         self.framework.observe(
             events.relation_departed, self._on_metrics_provider_relation_departed
         )
+        self.framework.observe(
+            events.relation_broken, self._on_metrics_provider_relation_departed
+        )
+
 
     def _on_metrics_provider_relation_changed(self, event):
         """Handle changes with related metrics providers.
@@ -1141,6 +1145,7 @@ class MetricsEndpointConsumer(Object):
 
             _, errmsg = self._tool.validate_alert_rules(alert_rules)
             if errmsg:
+                logger.error(f"Invalid alert rule file: {errmsg}")
                 if alerts[identifier]:
                     del alerts[identifier]
                 if self._charm.unit.is_leader():
@@ -1148,6 +1153,10 @@ class MetricsEndpointConsumer(Object):
                     data["errors"] = errmsg
                     relation.data[self._charm.app]["event"] = json.dumps(data)
                 continue
+            if self._charm.unit.is_leader():
+                data = json.loads(relation.data[self._charm.app].get("event", "{}"))
+                data.pop("errors", None)
+                relation.data[self._charm.app]["event"] = json.dumps(data)
 
         return alerts
 
@@ -1634,8 +1643,7 @@ class MetricsEndpointProvider(Object):
     def _on_relation_changed(self, event):
         """Check for alert rule messages in the relation data before moving on."""
         # Refresh the unit address on every `relation_changed`. This reacts faster than waiting for
-        # the next `update_status` when the pod IP changes, and is a no-op when the address is
-        # unchanged. See https://github.com/canonical/opentelemetry-collector-k8s-operator/issues/270
+        # the next `update_status` when the pod IP changes, and is safe to call repeatedly.
         self._set_unit_ip()
 
         if self._charm.unit.is_leader():
@@ -1814,6 +1822,7 @@ class PrometheusRulesProvider(Object):
             events.relation_changed,
             self._charm.on.leader_elected,
             self._charm.on.upgrade_charm,
+            self._charm.on.config_changed,
         ]
 
         for event_source in event_sources:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,10 +57,9 @@ unit = [
 
 # Dependencies for integration tests
 integration = [
-    "juju>=3.6.1.3,<4",
     "pytest>=9.0.3,<10",
-    "pytest-operator>=0.43.2,<0.44",
-    "pytest-asyncio>=0.21.2,<0.22",
+    "jubilant>=1.10.0,<2",
+    "pytest-jubilant>=2.1.1,<3",
     "trino>=0.337.0,<0.338",
     "apache-ranger>=0.0.12,<0.1",
 ]

--- a/src/charm.py
+++ b/src/charm.py
@@ -291,6 +291,7 @@ class TrinoK8SCharm(TypedCharmBase[CharmConfig]):
             return
         self.trino_coordinator._update_coordinator_relation_data(event)
         self._update(event)
+        self.postgresql_catalog_handler.reconcile_postgresql_catalogs(event)
         self.trino_catalog.reconcile_trino_catalog_relations()
 
     @log_event_handler(logger)

--- a/src/relations/postgresql_catalog.py
+++ b/src/relations/postgresql_catalog.py
@@ -304,7 +304,7 @@ class PostgresqlCatalogRelationHandler(framework.Object):
         catalog_dir = str(self.charm.catalog_abs_path)
         try:
             files = container.list_files(catalog_dir)
-        except (pebble.PathError, pebble.APIError):
+        except pebble.PathError:
             logger.debug("Catalog directory %s does not exist yet", catalog_dir)
             return {}
         except pebble.Error:

--- a/src/relations/postgresql_catalog.py
+++ b/src/relations/postgresql_catalog.py
@@ -6,6 +6,7 @@
 import hashlib
 import json
 import logging
+import time
 from typing import Callable, Optional
 
 import pydantic
@@ -32,7 +33,7 @@ def _env_var_name(database: str) -> str:
         database: The database name.
 
     Returns:
-        Environment variable name, e.g. ``PG_PASS_MYDB``.
+        Environment variable name, e.g. `PG_PASS_MYDB`.
     """
     return PASS_ENV_VAR_PREFIX + database.upper().replace("-", "_")
 
@@ -194,8 +195,8 @@ class PostgresqlCatalogRelationHandler(framework.Object):
         discrepancies.
 
         Before issuing SQL statements, ensures pebble env vars carry the
-        current passwords so that ``${ENV:…}`` references in CREATE CATALOG
-        resolve correctly.  Delegates replanning to ``self.charm._update()``.
+        current passwords so that `${ENV:…}` references in CREATE CATALOG
+        resolve correctly.  Delegates replanning to `self.charm._update()`.
 
         Args:
             event: The Juju event that triggered reconciliation (optional).
@@ -237,8 +238,8 @@ class PostgresqlCatalogRelationHandler(framework.Object):
 
         self._current_wanted_envs = None
 
-        if not self._is_trino_reachable():
-            logger.warning("Trino not reachable after replan, skipping catalog creates")
+        if not self._wait_for_trino_ready():
+            logger.warning("Trino not ready after replan, skipping catalog creates")
             return
 
         # CREATE new catalogs and UPDATE changed ones (drop + re-create)
@@ -273,7 +274,7 @@ class PostgresqlCatalogRelationHandler(framework.Object):
     def get_postgresql_env_vars(self) -> dict:
         """Return password env vars derived from PG relations.
 
-        If called during a ``reconcile_postgresql_catalogs()`` run, returns the cached value
+        If called during a `reconcile_postgresql_catalogs()` run, returns the cached value
         to avoid recomputing.  Otherwise computes fresh from relations.
 
         Returns:
@@ -290,7 +291,7 @@ class PostgresqlCatalogRelationHandler(framework.Object):
         """Read dynamic catalogs from `.properties` files on disk.
 
         Scans the catalog directory for `.properties` files that contain
-        the ``query.comment-format=dynamic catalog`` marker and returns
+        the `query.comment-format=dynamic catalog` marker and returns
         a dict of catalog names to property hashes.
 
         Returns:
@@ -607,16 +608,43 @@ class PostgresqlCatalogRelationHandler(framework.Object):
             logger.error("Failed to import TLS cert for relation %s: %s", relation_id, e)
 
     def _is_trino_reachable(self) -> bool:
-        """Check if Trino is reachable via HTTP.
+        """Check if Trino is reachable and finished initializing.
 
         Returns:
-            True if Trino responds to a health check.
+            True if Trino responds to a health check and is no longer starting.
         """
         try:
             resp = requests.get("http://localhost:8080/v1/info", timeout=5.0)
-            return resp.status_code == 200
+            if resp.status_code != 200:
+                return False
+            # /v1/info returns 200 while the server is still initializing, so
+            # also require the "starting" flag to be false before treating
+            # Trino as ready to accept CREATE/DROP CATALOG statements.
+            return resp.json().get("starting") is False
         except Exception:
             return False
+
+    def _wait_for_trino_ready(self, timeout: float = 300.0, interval: float = 5.0) -> bool:
+        """Poll Trino until it has finished initializing or the timeout elapses.
+
+        After an env-var replan Trino is restarted and briefly reports
+        `SERVER_STARTING_UP` for any query. Wait until it is ready before
+        issuing catalog statements.
+
+        Args:
+            timeout: Maximum total seconds to wait for readiness.
+            interval: Seconds to wait between checks.
+
+        Returns:
+            True if Trino became ready within the timeout, False otherwise.
+        """
+        deadline = time.time() + timeout
+        while True:
+            if self._is_trino_reachable():
+                return True
+            if time.time() >= deadline:
+                return False
+            time.sleep(interval)
 
     def _get_trino_user(self) -> str:
         """Get the Trino user for HTTP API calls.

--- a/src/relations/postgresql_catalog.py
+++ b/src/relations/postgresql_catalog.py
@@ -200,7 +200,15 @@ class PostgresqlCatalogRelationHandler(framework.Object):
         Args:
             event: The Juju event that triggered reconciliation (optional).
         """
-        if self.charm.config.charm_function not in ("coordinator", "all"):
+        # While invalid configuration is caught during config changes
+        # other hooks can still fire afterwards even if the charm is blocked.
+        try:
+            charm_function = self.charm.config.charm_function
+        except pydantic.ValidationError:
+            logger.warning("Skipping PG catalog reconciliation: charm config is invalid")
+            return
+
+        if charm_function not in ("coordinator", "all"):
             return
 
         self._write_databag()

--- a/src/relations/postgresql_catalog.py
+++ b/src/relations/postgresql_catalog.py
@@ -304,7 +304,7 @@ class PostgresqlCatalogRelationHandler(framework.Object):
         catalog_dir = str(self.charm.catalog_abs_path)
         try:
             files = container.list_files(catalog_dir)
-        except pebble.PathError:
+        except (pebble.PathError, pebble.APIError):
             logger.debug("Catalog directory %s does not exist yet", catalog_dir)
             return {}
         except pebble.Error:

--- a/src/relations/trino_catalog.py
+++ b/src/relations/trino_catalog.py
@@ -18,6 +18,7 @@ from charms.trino_k8s.v0.trino_catalog import (
 from ops.charm import CharmBase
 from ops.framework import Object
 from ops.model import SecretNotFoundError
+from pydantic import ValidationError
 
 from literals import (
     POSTGRESQL_RELATION_NAME,
@@ -333,6 +334,12 @@ class TrinoCatalogRelationHandler(Object):
             return
 
         if not self.charm.unit.is_leader():
+            return
+
+        try:
+            _ = self.charm.config
+        except ValidationError:
+            logger.warning("Skipping trino catalog reconciliation: charm config is invalid")
             return
 
         # Get Trino URL

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,14 @@
 import pytest
 
 
+def pytest_configure(config: pytest.Config):
+    """Register custom markers used by the test suite."""
+    config.addinivalue_line(
+        "markers",
+        "abort_on_fail: xfail the remaining tests in the same module after a failure",
+    )
+
+
 def pytest_addoption(parser: pytest.Parser):
     """Parse additional pytest options.
 
@@ -16,3 +24,26 @@ def pytest_addoption(parser: pytest.Parser):
     parser.addoption("--charm-file", action="append", default=[])
     # The charm image name:tag.
     parser.addoption("--trino-image", action="store", default="")
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo[None]):
+    """Expose per-phase reports on each collected test item."""
+    outcome = yield
+    report = outcome.get_result()
+    setattr(item, f"rep_{report.when}", report)
+
+
+@pytest.fixture(autouse=True)
+def abort_on_fail(request: pytest.FixtureRequest):
+    """Preserve pytest-operator abort-on-fail semantics at module scope."""
+    module = request.module
+    if module is not None and getattr(module, "_abort_on_fail_triggered", False):
+        pytest.xfail("aborted")
+
+    yield
+
+    marker = request.node.get_closest_marker("abort_on_fail")
+    report = getattr(request.node, "rep_call", None)
+    if module is not None and marker and report and report.failed:
+        setattr(module, "_abort_on_fail_triggered", True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,8 @@ def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo[None]):
     setattr(item, f"rep_{report.when}", report)
 
 
+# TODO (mertalpt): Retire this fixture in favor of `pytest -x`
+# and clean up tests and `pytest_configure`.
 @pytest.fixture(autouse=True)
 def abort_on_fail(request: pytest.FixtureRequest):
     """Preserve pytest-operator abort-on-fail semantics at module scope."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,15 @@ def pytest_addoption(parser: pytest.Parser):
     parser.addoption("--charm-file", action="append", default=[])
     # The charm image name:tag.
     parser.addoption("--trino-image", action="store", default="")
+    parser.addoption(
+        "--keep-models",
+        action="store_true",
+        default=False,
+    )
+    parser.addoption(
+        "--model",
+        action="store",
+    )
 
 
 @pytest.hookimpl(hookwrapper=True)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -113,6 +113,6 @@ def deploy(juju: jubilant.Juju, charm: str, charm_image: str):
         juju,
         [APP_NAME, WORKER_NAME],
         status="active",
-        timeout=600,
+        timeout=900,
     )
     assert get_unit(juju, APP_NAME).workload_status.current == "active"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -72,6 +72,8 @@ def charm_fixture(request: FixtureRequest) -> str | Path:
 @pytest.fixture(name="deploy", scope="module")
 def deploy(juju: jubilant.Juju, charm: str, charm_image: str):
     """Deploy the app."""
+    juju.model_config({"update-status-hook-interval": "10s"})
+
     # Deploy trino and nginx charms
     juju.deploy(
         charm,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,21 +4,41 @@
 """Trino charm integration test config."""
 
 import logging
+import subprocess  # nosec B404
 from pathlib import Path
 
+import jubilant
 import pytest
-import pytest_asyncio
 from helpers import (
     APP_NAME,
     COORDINATOR_CONFIG,
     NGINX_NAME,
     WORKER_CONFIG,
     WORKER_NAME,
+    get_unit,
+    wait_for_apps,
 )
 from pytest import FixtureRequest
-from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
+
+
+def pack_charm(source_dir: Path) -> Path:
+    """Build a charm and return the newest resulting artifact path."""
+    existing = {path.resolve() for path in source_dir.glob("*.charm")}
+    subprocess.run(
+        ["/snap/bin/charmcraft", "pack", "--verbose"],
+        cwd=source_dir,
+        check=True,
+        text=True,
+    )  # nosec B603
+    artifacts = sorted(source_dir.glob("*.charm"), key=lambda path: path.stat().st_mtime)
+    assert artifacts, f"No charm artifact found in {source_dir} after packing"
+
+    for artifact in reversed(artifacts):
+        if artifact.resolve() not in existing:
+            return artifact
+    return artifacts[-1]
 
 
 @pytest.fixture(scope="module", name="charm_image")
@@ -31,64 +51,66 @@ def charm_image_fixture(request: FixtureRequest) -> str:
     return charm_image
 
 
-@pytest_asyncio.fixture(scope="module", name="charm")
-async def charm_fixture(request: FixtureRequest, ops_test: OpsTest) -> str | Path:
+@pytest.fixture(scope="module", name="charm")
+def charm_fixture(request: FixtureRequest) -> str | Path:
     """Fetch the path to charm."""
     charms = request.config.getoption("--charm-file")
-    if not charms:
-        charm = await ops_test.build_charm(".")
-        assert charm, "Charm not built"
-        return charm
-    return charms[0]
+    if charms:
+        charm = charms[0]
+    else:
+        charm_dir = Path(__file__).resolve().parents[2]
+        charms = list(charm_dir.glob("*.charm"))
+        assert charms, f"No charms were found in {charm_dir.resolve()}"
+        assert len(charms) == 1, f"Found more than one charm {charms}"
+        charm = charms[0]
+
+    path = Path(charm).resolve()
+    assert path.is_file(), f"{path} is not a file"
+    return path
 
 
-@pytest_asyncio.fixture(name="deploy", scope="module")
-async def deploy(ops_test: OpsTest, charm: str, charm_image: str):
+@pytest.fixture(name="deploy", scope="module")
+def deploy(juju: jubilant.Juju, charm: str, charm_image: str):
     """Deploy the app."""
     # Deploy trino and nginx charms
-    async with ops_test.fast_forward():
-        await ops_test.model.deploy(
-            charm,
-            resources={"trino-image": charm_image},
-            application_name=APP_NAME,
-            config=COORDINATOR_CONFIG,
-            num_units=1,
-            trust=True,
-        )
-        await ops_test.model.deploy(
-            charm,
-            resources={"trino-image": charm_image},
-            application_name=WORKER_NAME,
-            config=WORKER_CONFIG,
-            num_units=1,
-            trust=True,
-        )
+    juju.deploy(
+        charm,
+        APP_NAME,
+        resources={"trino-image": charm_image},
+        config=COORDINATOR_CONFIG,
+        num_units=1,
+        trust=True,
+    )
+    juju.deploy(
+        charm,
+        WORKER_NAME,
+        resources={"trino-image": charm_image},
+        config=WORKER_CONFIG,
+        num_units=1,
+        trust=True,
+    )
+    juju.deploy(NGINX_NAME, trust=True)
 
-        await ops_test.model.deploy(NGINX_NAME, trust=True)
+    wait_for_apps(
+        juju,
+        [APP_NAME, WORKER_NAME],
+        status="blocked",
+        timeout=600,
+    )
+    wait_for_apps(
+        juju,
+        [NGINX_NAME],
+        status="waiting",
+        timeout=600,
+    )
 
-        await ops_test.model.wait_for_idle(
-            apps=[APP_NAME, WORKER_NAME],
-            status="blocked",
-            raise_on_blocked=False,
-            timeout=600,
-        )
-        await ops_test.model.wait_for_idle(
-            apps=[NGINX_NAME],
-            status="waiting",
-            raise_on_blocked=False,
-            timeout=600,
-        )
+    juju.integrate(f"{APP_NAME}:trino-coordinator", f"{WORKER_NAME}:trino-worker")
+    juju.integrate(APP_NAME, NGINX_NAME)
 
-        await ops_test.model.integrate(
-            f"{APP_NAME}:trino-coordinator", f"{WORKER_NAME}:trino-worker"
-        )
-
-        await ops_test.model.integrate(APP_NAME, NGINX_NAME)
-
-        await ops_test.model.wait_for_idle(
-            apps=[APP_NAME, WORKER_NAME],
-            status="active",
-            raise_on_blocked=False,
-            timeout=300,
-        )
-    assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
+    wait_for_apps(
+        juju,
+        [APP_NAME, WORKER_NAME],
+        status="active",
+        timeout=300,
+    )
+    assert get_unit(juju, APP_NAME).workload_status.current == "active"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -111,6 +111,6 @@ def deploy(juju: jubilant.Juju, charm: str, charm_image: str):
         juju,
         [APP_NAME, WORKER_NAME],
         status="active",
-        timeout=300,
+        timeout=600,
     )
     assert get_unit(juju, APP_NAME).workload_status.current == "active"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -72,8 +72,6 @@ def charm_fixture(request: FixtureRequest) -> str | Path:
 @pytest.fixture(name="deploy", scope="module")
 def deploy(juju: jubilant.Juju, charm: str, charm_image: str):
     """Deploy the app."""
-    juju.model_config({"update-status-hook-interval": "10s"})
-
     # Deploy trino and nginx charms
     juju.deploy(
         charm,

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -7,7 +7,9 @@
 import logging
 import os
 import time
+from contextlib import contextmanager
 from pathlib import Path
+from typing import Generator
 
 import jubilant
 import requests
@@ -118,6 +120,17 @@ def get_unit(
     return juju.status().apps[application].units[unit_name]
 
 
+@contextmanager
+def fast_forward_ctx(juju: jubilant.Juju, interval: str) -> Generator[None, None, None]:
+    """Simulate OpsTest fast forward semantics."""
+    old_interval = juju.model_config()["update-status-hook-interval"]
+    try:
+        juju.model_config({"update-status-hook-interval": interval})
+        yield
+    finally:
+        juju.model_config({"update-status-hook-interval": old_interval})
+
+
 def _apps_ready(
     model_status: jubilant.Status, apps: list[str], status: str, exact_units: dict[str, int]
 ) -> bool:
@@ -172,6 +185,7 @@ def wait_for_apps(
     wait_for_exact_units: int | dict[str, int] | None = None,
     idle_period: int | None = None,
     delay: float = 2.0,
+    fast_forward: str | None = "10s",
 ):
     """Approximate OpsTest wait_for_idle semantics with Jubilant waits."""
     exact_units: dict[str, int] = {}
@@ -188,7 +202,11 @@ def wait_for_apps(
     def error(model_status):
         return _apps_in_error(model_status, apps, status, raise_on_blocked)
 
-    return juju.wait(ready, error=error, delay=delay, timeout=timeout, successes=successes)
+    if not fast_forward:
+        return juju.wait(ready, error=error, delay=delay, timeout=timeout, successes=successes)
+
+    with fast_forward_ctx(juju, fast_forward):
+        return juju.wait(ready, error=error, delay=delay, timeout=timeout, successes=successes)
 
 
 def wait_for_app_gone(juju: jubilant.Juju, app: str, timeout: float = 600, delay: float = 2.0):

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -6,6 +6,7 @@
 
 import logging
 import os
+import textwrap
 import time
 from contextlib import contextmanager
 from pathlib import Path
@@ -476,102 +477,70 @@ def create_catalog_config(
     Returns:
         the catalog configuration.
     """
+    catalogs = textwrap.dedent(f"""\
+        postgresql-1:
+            backend: dwh
+            database: example
+            secret-id: {postgresql_secret_id}
+        mysql:
+            backend: mysql
+            secret-id: {mysql_secret_id}
+        redshift:
+            backend: redshift
+            secret-id: {redshift_secret_id}
+        gsheets-1:
+            backend: gsheets
+            metasheet-id: 1Es4HhWALUQjoa-bQh4a8B5HROz7dpGMfq_HbfoaW5LM
+            secret-id: {gsheets_secret_id}
+    """)
+
+    backends = textwrap.dedent("""\
+        dwh:
+            connector: postgresql
+            url: jdbc:postgresql://example.com:5432
+            params: ssl=true&sslmode=require&sslrootcert={SSL_PATH}&sslrootcertpassword={SSL_PWD}
+            config: |
+                case-insensitive-name-matching=true
+                decimal-mapping=allow_overflow
+                decimal-rounding-mode=HALF_UP
+        mysql:
+            connector: mysql
+            url: jdbc:mysql://mysql.com:3306
+            params: sslMode=REQUIRED
+            config: |
+                case-insensitive-name-matching=true
+                decimal-mapping=allow_overflow
+                decimal-rounding-mode=HALF_UP
+        redshift:
+            connector: redshift
+            url: jdbc:redshift://redshift.com:5439/example
+            params: SSL=TRUE
+            config: |
+                case-insensitive-name-matching=true
+        gsheets:
+            connector: gsheets
+    """)
     if include_bigquery:
-        catalog_config = f"""\
-        catalogs:
-            postgresql-1:
-                backend: dwh
-                database: example
-                secret-id: {postgresql_secret_id}
-            mysql:
-                backend: mysql
-                secret-id: {mysql_secret_id}
-            redshift:
-                backend: redshift
-                secret-id: {redshift_secret_id}
+        catalogs += textwrap.dedent(f"""\
             bigquery:
                 backend: bigquery
                 project: project-12345
                 secret-id: {bigquery_secret_id}
-            gsheets-1:
-                backend: gsheets
-                metasheet-id: 1Es4HhWALUQjoa-bQh4a8B5HROz7dpGMfq_HbfoaW5LM
-                secret-id: {gsheets_secret_id}
-        backends:
-            dwh:
-                connector: postgresql
-                url: jdbc:postgresql://example.com:5432
-                params: ssl=true&sslmode=require&sslrootcert={{SSL_PATH}}&sslrootcertpassword={{SSL_PWD}}
-                config: |
-                    case-insensitive-name-matching=true
-                    decimal-mapping=allow_overflow
-                    decimal-rounding-mode=HALF_UP
-            mysql:
-                connector: mysql
-                url: jdbc:mysql://mysql.com:3306
-                params: sslMode=REQUIRED
-                config: |
-                    case-insensitive-name-matching=true
-                    decimal-mapping=allow_overflow
-                    decimal-rounding-mode=HALF_UP
-            redshift:
-                connector: redshift
-                url: jdbc:redshift://redshift.com:5439/example
-                params: SSL=TRUE
-                config: |
-                    case-insensitive-name-matching=true
+        """)
+
+        backends += textwrap.dedent("""\
             bigquery:
                 connector: bigquery
                 config: |
                     bigquery.case-insensitive-name-matching=true
                     bigquery.arrow-serialization.enabled=false
-            gsheets:
-                connector: gsheets
-        """  # noqa: E501
-    else:
-        catalog_config = f"""\
-        catalogs:
-            postgresql-1:
-                backend: dwh
-                database: example
-                secret-id: {postgresql_secret_id}
-            mysql:
-                backend: mysql
-                secret-id: {mysql_secret_id}
-            redshift:
-                backend: redshift
-                secret-id: {redshift_secret_id}
-            gsheets-1:
-                backend: gsheets
-                metasheet-id: 1Es4HhWALUQjoa-bQh4a8B5HROz7dpGMfq_HbfoaW5LM
-                secret-id: {gsheets_secret_id}
-        backends:
-            dwh:
-                connector: postgresql
-                url: jdbc:postgresql://example.com:5432
-                params: ssl=true&sslmode=require&sslrootcert={{SSL_PATH}}&sslrootcertpassword={{SSL_PWD}}
-                config: |
-                    case-insensitive-name-matching=true
-                    decimal-mapping=allow_overflow
-                    decimal-rounding-mode=HALF_UP
-            mysql:
-                connector: mysql
-                url: jdbc:mysql://mysql.com:3306
-                params: sslMode=REQUIRED
-                config: |
-                    case-insensitive-name-matching=true
-                    decimal-mapping=allow_overflow
-                    decimal-rounding-mode=HALF_UP
-            redshift:
-                connector: redshift
-                url: jdbc:redshift://redshift.com:5439/example
-                params: SSL=TRUE
-                config: |
-                    case-insensitive-name-matching=true
-            gsheets:
-                connector: gsheets
-        """  # noqa: E501
-    return catalog_config
+        """)
+
+    ret = (
+        f"catalogs:\n{textwrap.indent(catalogs, '    ')}\n"
+        f"backends:\n{textwrap.indent(backends, '    ')}"
+    )
+    return ret
 
 
 def get_secret_id_by_label(juju: jubilant.Juju, label: str):

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -6,15 +6,16 @@
 
 import logging
 import os
+import time
 from pathlib import Path
 
+import jubilant
 import requests
 import trino.exceptions
 import yaml
 from apache_ranger.client.ranger_client import RangerClient
 from apache_ranger.client.ranger_user_mgmt_client import RangerUserMgmtClient
 from apache_ranger.model.ranger_user_mgmt import RangerUser
-from pytest_operator.plugin import OpsTest
 from trino_client.trino_client import query_trino
 
 logger = logging.getLogger(__name__)
@@ -109,11 +110,108 @@ COORDINATOR_CONFIG = {
 }
 
 
-async def get_unit_url(ops_test: OpsTest, application, unit, port, protocol="http"):
+def unit_name(application: str, unit: int = 0) -> str:
+    """Build a Juju unit name from an application name and index."""
+    return f"{application}/{unit}"
+
+
+def get_status(juju: jubilant.Juju):
+    """Fetch the current model status."""
+    return juju.status()
+
+
+def get_unit(juju: jubilant.Juju, application: str, unit: int = 0):
+    """Return a single unit status from the current model status."""
+    return get_status(juju).apps[application].units[unit_name(application, unit)]
+
+
+def _exact_unit_counts(apps: list[str], wait_for_exact_units: int | dict[str, int] | None):
+    """Return expected unit counts for apps when exact counts are requested."""
+    if isinstance(wait_for_exact_units, int):
+        return dict.fromkeys(apps, wait_for_exact_units)
+    return wait_for_exact_units or {}
+
+
+def _apps_ready(model_status, apps: list[str], status: str, exact_units: dict[str, int]):
+    """Return whether all selected applications match the expected state."""
+    for app in apps:
+        if app not in model_status.apps:
+            return False
+
+        app_status = model_status.apps[app]
+        if app_status.app_status.current != status:
+            return False
+        if app in exact_units and len(app_status.units) != exact_units[app]:
+            return False
+        if any(unit.workload_status.current != status for unit in app_status.units.values()):
+            return False
+
+    return True
+
+
+def _apps_in_error(model_status, apps: list[str], status: str, raise_on_blocked: bool):
+    """Return whether any selected application is in a terminal wait state."""
+    for app in apps:
+        app_status = model_status.apps.get(app)
+        if app_status is None:
+            continue
+        if app_status.app_status.current == "error":
+            return True
+        if raise_on_blocked and app_status.app_status.current == "blocked" and status != "blocked":
+            return True
+        for unit_status in app_status.units.values():
+            if unit_status.workload_status.current == "error":
+                return True
+            if (
+                raise_on_blocked
+                and unit_status.workload_status.current == "blocked"
+                and status != "blocked"
+            ):
+                return True
+
+    return False
+
+
+def wait_for_apps(
+    juju: jubilant.Juju,
+    apps: list[str],
+    *,
+    status: str,
+    timeout: float,
+    raise_on_blocked: bool = False,
+    wait_for_exact_units: int | dict[str, int] | None = None,
+    idle_period: int | None = None,
+    delay: float = 2.0,
+):
+    """Approximate OpsTest wait_for_idle semantics with Jubilant waits."""
+    exact_units = _exact_unit_counts(apps, wait_for_exact_units)
+
+    successes = max(3, int(idle_period / delay)) if idle_period else 3
+
+    def ready(model_status):
+        return _apps_ready(model_status, apps, status, exact_units)
+
+    def error(model_status):
+        return _apps_in_error(model_status, apps, status, raise_on_blocked)
+
+    return juju.wait(ready, error=error, delay=delay, timeout=timeout, successes=successes)
+
+
+def wait_for_app_gone(juju: jubilant.Juju, app: str, timeout: float = 600, delay: float = 2.0):
+    """Wait until an application no longer appears in model status."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if app not in get_status(juju).apps:
+            return
+        time.sleep(delay)
+    raise TimeoutError(f"Application {app!r} still present after {timeout}s")
+
+
+def get_unit_url(juju: jubilant.Juju, application, unit, port, protocol="http"):
     """Return unit URL from the model.
 
     Args:
-        ops_test: PyTest object.
+        juju: Jubilant Juju object.
         application: Name of the application.
         unit: Number of the unit.
         port: Port number of the URL.
@@ -122,16 +220,15 @@ async def get_unit_url(ops_test: OpsTest, application, unit, port, protocol="htt
     Returns:
         Unit URL of the form {protocol}://{address}:{port}
     """
-    status = await ops_test.model.get_status()  # noqa: F821
-    address = status["applications"][application]["units"][f"{application}/{unit}"]["address"]
+    address = get_unit(juju, application, unit).address
     return f"{protocol}://{address}:{port}"
 
 
-async def get_catalogs(ops_test: OpsTest, user, app_name):
+def get_catalogs(juju: jubilant.Juju, user, app_name):
     """Return a list of catalogs from Trino charm.
 
     Args:
-        ops_test: PyTest object
+        juju: Jubilant Juju object.
         user: the user to access Trino with
         app_name: name of the application
 
@@ -139,17 +236,17 @@ async def get_catalogs(ops_test: OpsTest, user, app_name):
         catalogs: list of catalogs connected to trino
     """
     try:
-        catalogs = await run_query(ops_test, user, CATALOG_QUERY, app_name)
+        catalogs = run_query(juju, user, CATALOG_QUERY, app_name)
     except trino.exceptions.TrinoUserError:
         catalogs = []
     return catalogs
 
 
-async def run_query(ops_test: OpsTest, user, query, app_name=APP_NAME):
+def run_query(juju: jubilant.Juju, user, query, app_name=APP_NAME):
     """Run a SQL query against the Trino coordinator.
 
     Args:
-        ops_test: PyTest object.
+        juju: Jubilant Juju object.
         user: the user to access Trino with.
         query: SQL query to execute.
         app_name: name of the application.
@@ -157,34 +254,30 @@ async def run_query(ops_test: OpsTest, user, query, app_name=APP_NAME):
     Returns:
         Query result rows.
     """
-    status = await ops_test.model.get_status()  # noqa: F821
-    address = status["applications"][app_name]["units"][f"{app_name}/{0}"]["address"]
+    address = get_unit(juju, app_name).address
     logger.info("executing query on app address: %s", address)
-    return await query_trino(address, user, query)
+    return query_trino(address, user, query)
 
 
-async def update_catalog_config(ops_test, catalog_config, user):
+def update_catalog_config(juju: jubilant.Juju, catalog_config, user):
     """Run connection action.
 
     Args:
-        ops_test: PyTest object.
+        juju: Jubilant Juju object.
         catalog_config: The catalogs configuration value.
         user: the user to access Trino with.
 
     Returns:
         A string of trino catalogs.
     """
-    await ops_test.model.applications[APP_NAME].set_config({"catalog-config": catalog_config})
-    async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(
-            apps=[APP_NAME, WORKER_NAME], status="active", timeout=600
-        )
-    catalogs = await get_catalogs(ops_test, user, APP_NAME)
+    juju.config(APP_NAME, {"catalog-config": catalog_config})
+    wait_for_apps(juju, [APP_NAME, WORKER_NAME], status="active", timeout=600)
+    catalogs = get_catalogs(juju, user, APP_NAME)
     logging.info(f"Catalogs: {catalogs}")
     return catalogs
 
 
-async def create_user(ranger_url):
+def create_user(ranger_url):
     """Create Ranger user.
 
     Args:
@@ -202,7 +295,7 @@ async def create_user(ranger_url):
     logger.info(res)
 
 
-async def update_policies(ranger_url):
+def update_policies(ranger_url):
     """Update Ranger user policy.
 
     Allow user `USER_WITH_ACCESS` to access `system` catalog.
@@ -218,41 +311,43 @@ async def update_policies(ranger_url):
         ranger.update_policy(TRINO_SERVICE, policy_name, policy)
 
 
-async def scale(ops_test: OpsTest, app, units):
+def scale(juju: jubilant.Juju, app, units):
     """Scale the application to the provided number and wait for idle.
 
     Args:
-        ops_test: PyTest object.
+        juju: Jubilant Juju object.
         app: Application to be scaled.
         units: Number of units required.
     """
-    async with ops_test.fast_forward():
-        await ops_test.model.applications[app].scale(scale=units)
+    current_units = len(get_status(juju).apps[app].units)
+    if units > current_units:
+        juju.add_unit(app, num_units=units - current_units)
+    elif units < current_units:
+        juju.remove_unit(app, num_units=current_units - units)
 
-        # Wait for model to settle
-        await ops_test.model.wait_for_idle(
-            apps=[app],
-            status="active",
-            idle_period=30,
-            raise_on_blocked=True,
-            timeout=600,
-            wait_for_exact_units=units,
-        )
+    wait_for_apps(
+        juju,
+        [app],
+        status="active",
+        idle_period=30,
+        raise_on_blocked=True,
+        timeout=600,
+        wait_for_exact_units=units,
+    )
 
 
-async def get_active_workers(ops_test: OpsTest):
+def get_active_workers(juju: jubilant.Juju):
     """Get active trino workers.
 
     Args:
-        ops_test: PyTest object.
+        juju: Jubilant Juju object.
 
     Returns:
         active_workers: list of active workers.
     """
-    status = await ops_test.model.get_status()  # noqa: F821
-    address = status["applications"][APP_NAME]["units"][f"{APP_NAME}/{0}"]["address"]
+    address = get_unit(juju, APP_NAME).address
     logger.info("executing query on app address: %s", address)
-    result = await query_trino(address, USER_WITH_ACCESS, WORKER_QUERY)
+    result = query_trino(address, USER_WITH_ACCESS, WORKER_QUERY)
     active_workers = [
         x
         for x in result
@@ -263,68 +358,65 @@ async def get_active_workers(ops_test: OpsTest):
     return active_workers
 
 
-async def simulate_crash_and_restart(ops_test, charm, charm_image):
+def simulate_crash_and_restart(juju: jubilant.Juju, charm, charm_image):
     """Simulate the crash of the Trino coordinator.
 
     Args:
-        ops_test: PyTest object.
+        juju: Jubilant Juju object.
         charm: charm path.
         charm_image: path to rock image to be used.
     """
     # Destroy charm
-    await ops_test.model.applications[APP_NAME].destroy()
-    await ops_test.model.block_until(lambda: APP_NAME not in ops_test.model.applications)
+    juju.remove_application(APP_NAME)
+    wait_for_app_gone(juju, APP_NAME)
 
     # Deploy charm again
-    async with ops_test.fast_forward():
-        await ops_test.model.deploy(
-            charm,
-            resources={"trino-image": charm_image},
-            application_name=APP_NAME,
-            config=COORDINATOR_CONFIG,
-            num_units=1,
-            trust=True,
-        )
+    juju.deploy(
+        charm,
+        APP_NAME,
+        resources={"trino-image": charm_image},
+        config=COORDINATOR_CONFIG,
+        num_units=1,
+        trust=True,
+    )
 
-        await ops_test.model.wait_for_idle(
-            apps=[APP_NAME],
-            status="blocked",
-            raise_on_blocked=False,
-            timeout=1000,
-        )
+    wait_for_apps(
+        juju,
+        [APP_NAME],
+        status="blocked",
+        timeout=1000,
+    )
 
-        await ops_test.model.integrate(
-            f"{APP_NAME}:trino-coordinator", f"{WORKER_NAME}:trino-worker"
-        )
-        await ops_test.model.wait_for_idle(
-            apps=[APP_NAME, WORKER_NAME],
-            status="active",
-            raise_on_blocked=False,
-            timeout=1000,
-        )
+    juju.integrate(f"{APP_NAME}:trino-coordinator", f"{WORKER_NAME}:trino-worker")
+    wait_for_apps(
+        juju,
+        [APP_NAME, WORKER_NAME],
+        status="active",
+        timeout=1000,
+    )
 
 
-async def curl_unit_ip(ops_test):
+def curl_unit_ip(juju: jubilant.Juju):
     """Curl the coordinator unit IP.
 
     Args:
-        ops_test: PyTest object.
+        juju: Jubilant Juju object.
 
     Returns:
         response: Request response.
     """
-    url = await get_unit_url(ops_test, application=APP_NAME, unit=0, port=8080)
+    url = get_unit_url(juju, application=APP_NAME, unit=0, port=8080)
     logger.info("curling app address: %s", url)
 
     response = requests.get(url, timeout=300, verify=False)  # nosec
     return response
 
 
-async def add_juju_secret(ops_test: OpsTest, connector_type: str):
+def add_juju_secret(juju: jubilant.Juju, connector_type: str):
     """Add Juju user secret to model.
 
     Args:
-        ops_test: PyTest object.
+        juju: Jubilant Juju object.
         connector_type: Type of connector secret to add.
 
     Returns:
@@ -334,27 +426,24 @@ async def add_juju_secret(ops_test: OpsTest, connector_type: str):
         ValueError: in case connector is not supported.
     """
     if connector_type == "postgresql":
-        data_args = [f"replicas={POSTGRESQL_REPLICA_SECRET}"]  # nosec
+        content = {"replicas": POSTGRESQL_REPLICA_SECRET}  # nosec
     elif connector_type == "mysql":
-        data_args = [f"replicas=={MYSQL_REPLICA_SECRET}"]  # nosec
+        content = {"replicas": MYSQL_REPLICA_SECRET}  # nosec
     elif connector_type == "redshift":
-        data_args = [f"replicas=={REDSHIFT_REPLICA_SECRET}"]  # nosec
+        content = {"replicas": REDSHIFT_REPLICA_SECRET}  # nosec
     elif connector_type == "bigquery":
-        data_args = [f"service-accounts={BIGQUERY_SECRET}"]  # nosec
+        content = {"service-accounts": BIGQUERY_SECRET}  # nosec
     elif connector_type == "gsheets":
-        data_args = [f"service-accounts={GSHEETS_SECRET}"]  # nosec
+        content = {"service-accounts": GSHEETS_SECRET}  # nosec
     else:
         raise ValueError(f"Unsupported secret type: {connector_type}")
 
-    juju_secret = await ops_test.model.add_secret(
-        name=f"{connector_type}-secret", data_args=data_args
-    )
-
-    secret_id = juju_secret.split(":")[-1]
+    juju_secret = juju.add_secret(name=f"{connector_type}-secret", content=content)
+    secret_id = str(juju_secret).split(":")[-1]
     return secret_id
 
 
-async def create_catalog_config(
+def create_catalog_config(
     postgresql_secret_id,
     mysql_secret_id,
     redshift_secret_id,
@@ -473,21 +562,17 @@ async def create_catalog_config(
     return catalog_config
 
 
-async def get_secret_id_by_label(ops_test: OpsTest, label: str):
+def get_secret_id_by_label(juju: jubilant.Juju, label: str):
     """Get the secret ID by label.
 
     Args:
-        ops_test: PyTest object.
+        juju: Jubilant Juju object.
         label: Label of the secret to find.
 
     Returns:
         Secret ID string if found, None otherwise.
     """
-    result = await ops_test.juju("secrets", "--format=yaml")
-    if result[0] != 0:
-        return None
-
-    secrets = yaml.safe_load(result[1])
+    secrets = yaml.safe_load(juju.cli("secrets", "--format=yaml"))
 
     for secret_id, info in secrets.items():
         if info and info.get("name") == label:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -118,14 +118,9 @@ def get_unit(
     return juju.status().apps[application].units[unit_name]
 
 
-def _exact_unit_counts(apps: list[str], wait_for_exact_units: int | dict[str, int] | None):
-    """Return expected unit counts for apps when exact counts are requested."""
-    if isinstance(wait_for_exact_units, int):
-        return dict.fromkeys(apps, wait_for_exact_units)
-    return wait_for_exact_units or {}
-
-
-def _apps_ready(model_status, apps: list[str], status: str, exact_units: dict[str, int]):
+def _apps_ready(
+    model_status: jubilant.Status, apps: list[str], status: str, exact_units: dict[str, int]
+) -> bool:
     """Return whether all selected applications match the expected state."""
     for app in apps:
         if app not in model_status.apps:
@@ -142,7 +137,9 @@ def _apps_ready(model_status, apps: list[str], status: str, exact_units: dict[st
     return True
 
 
-def _apps_in_error(model_status, apps: list[str], status: str, raise_on_blocked: bool):
+def _apps_in_error(
+    model_status: jubilant.Status, apps: list[str], status: str, raise_on_blocked: bool
+) -> bool:
     """Return whether any selected application is in a terminal wait state."""
     for app in apps:
         app_status = model_status.apps.get(app)
@@ -177,7 +174,11 @@ def wait_for_apps(
     delay: float = 2.0,
 ):
     """Approximate OpsTest wait_for_idle semantics with Jubilant waits."""
-    exact_units = _exact_unit_counts(apps, wait_for_exact_units)
+    exact_units: dict[str, int] = {}
+    if isinstance(wait_for_exact_units, dict):
+        exact_units = wait_for_exact_units
+    elif isinstance(wait_for_exact_units, int):
+        exact_units = dict.fromkeys(apps, wait_for_exact_units)
 
     successes = max(3, int(idle_period / delay)) if idle_period else 3
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -110,19 +110,12 @@ COORDINATOR_CONFIG = {
 }
 
 
-def unit_name(application: str, unit: int = 0) -> str:
-    """Build a Juju unit name from an application name and index."""
-    return f"{application}/{unit}"
-
-
-def get_status(juju: jubilant.Juju):
-    """Fetch the current model status."""
-    return juju.status()
-
-
-def get_unit(juju: jubilant.Juju, application: str, unit: int = 0):
+def get_unit(
+    juju: jubilant.Juju, application: str, unit: int = 0
+) -> jubilant.statustypes.UnitStatus:
     """Return a single unit status from the current model status."""
-    return get_status(juju).apps[application].units[unit_name(application, unit)]
+    unit_name = f"{application}/{unit}"
+    return juju.status().apps[application].units[unit_name]
 
 
 def _exact_unit_counts(apps: list[str], wait_for_exact_units: int | dict[str, int] | None):
@@ -201,7 +194,7 @@ def wait_for_app_gone(juju: jubilant.Juju, app: str, timeout: float = 600, delay
     """Wait until an application no longer appears in model status."""
     deadline = time.time() + timeout
     while time.time() < deadline:
-        if app not in get_status(juju).apps:
+        if app not in juju.status().apps:
             return
         time.sleep(delay)
     raise TimeoutError(f"Application {app!r} still present after {timeout}s")
@@ -319,7 +312,7 @@ def scale(juju: jubilant.Juju, app, units):
         app: Application to be scaled.
         units: Number of units required.
     """
-    current_units = len(get_status(juju).apps[app].units)
+    current_units = len(juju.status().apps[app].units)
     if units > current_units:
         juju.add_unit(app, num_units=units - current_units)
     elif units < current_units:

--- a/tests/integration/test_catalog_updates.py
+++ b/tests/integration/test_catalog_updates.py
@@ -6,6 +6,7 @@
 
 import logging
 
+import jubilant
 import pytest
 from conftest import deploy  # noqa: F401, pylint: disable=W0611
 from helpers import (
@@ -16,8 +17,8 @@ from helpers import (
     create_catalog_config,
     get_catalogs,
     update_catalog_config,
+    wait_for_apps,
 )
-from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
 
@@ -27,23 +28,23 @@ logger = logging.getLogger(__name__)
 class TestCatalogUpdates:
     """Integration tests for catalog changes in Trino charm."""
 
-    async def test_catalog_config_updates_after_relation_break(self, ops_test: OpsTest):
+    def test_catalog_config_updates_after_relation_break(self, juju: jubilant.Juju):
         """Test that the worker picks up updated catalog-config after relation re-establishment."""
         # Step 1: create and apply catalog config with BigQuery
-        postgresql_secret_id = await add_juju_secret(ops_test, "postgresql")
-        mysql_secret_id = await add_juju_secret(ops_test, "mysql")
-        redshift_secret_id = await add_juju_secret(ops_test, "redshift")
-        bigquery_secret_id = await add_juju_secret(ops_test, "bigquery")
-        gsheet_secret_id = await add_juju_secret(ops_test, "gsheets")
+        postgresql_secret_id = add_juju_secret(juju, "postgresql")
+        mysql_secret_id = add_juju_secret(juju, "mysql")
+        redshift_secret_id = add_juju_secret(juju, "redshift")
+        bigquery_secret_id = add_juju_secret(juju, "bigquery")
+        gsheet_secret_id = add_juju_secret(juju, "gsheets")
 
         for app in ["trino-k8s", "trino-k8s-worker"]:
-            await ops_test.model.grant_secret("postgresql-secret", app)
-            await ops_test.model.grant_secret("mysql-secret", app)
-            await ops_test.model.grant_secret("redshift-secret", app)
-            await ops_test.model.grant_secret("bigquery-secret", app)
-            await ops_test.model.grant_secret("gsheets-secret", app)
+            juju.grant_secret("postgresql-secret", app)
+            juju.grant_secret("mysql-secret", app)
+            juju.grant_secret("redshift-secret", app)
+            juju.grant_secret("bigquery-secret", app)
+            juju.grant_secret("gsheets-secret", app)
 
-        catalog_config = await create_catalog_config(
+        catalog_config = create_catalog_config(
             postgresql_secret_id,
             mysql_secret_id,
             redshift_secret_id,
@@ -51,20 +52,18 @@ class TestCatalogUpdates:
             gsheet_secret_id,
             True,  # include_bigquery
         )
-        await update_catalog_config(ops_test, catalog_config, TRINO_USER)
+        update_catalog_config(juju, catalog_config, TRINO_USER)
 
         # Assert that bigquery is present
-        catalogs = await get_catalogs(ops_test, TRINO_USER, APP_NAME)
+        catalogs = get_catalogs(juju, TRINO_USER, APP_NAME)
         assert "bigquery" in str(catalogs)
 
         # Step 2: Remove relation between coordinator and worker
-        await ops_test.model.applications[APP_NAME].remove_relation(
-            f"{APP_NAME}:trino-coordinator", f"{WORKER_NAME}:trino-worker"
-        )
-        await ops_test.model.wait_for_idle(apps=[APP_NAME, WORKER_NAME], timeout=600)
+        juju.remove_relation(f"{APP_NAME}:trino-coordinator", f"{WORKER_NAME}:trino-worker")
+        wait_for_apps(juju, [APP_NAME, WORKER_NAME], status="blocked", timeout=600)
 
         # Step 3: Update catalog config to remove bigquery (DO NOT use config-changed after this)
-        updated_catalog_config = await create_catalog_config(
+        updated_catalog_config = create_catalog_config(
             postgresql_secret_id,
             mysql_secret_id,
             redshift_secret_id,
@@ -73,25 +72,15 @@ class TestCatalogUpdates:
             False,  # now exclude bigquery
         )
 
-        await ops_test.model.applications[APP_NAME].set_config(
-            {"catalog-config": updated_catalog_config}
-        )
-        async with ops_test.fast_forward():
-            await ops_test.model.wait_for_idle(
-                apps=[APP_NAME], timeout=300, raise_on_blocked=False
-            )
+        juju.config(APP_NAME, {"catalog-config": updated_catalog_config})
+        wait_for_apps(juju, [APP_NAME], status="blocked", timeout=300)
 
         # Step 4: Re-establish relation
-        await ops_test.model.integrate(
-            f"{APP_NAME}:trino-coordinator", f"{WORKER_NAME}:trino-worker"
-        )
-        async with ops_test.fast_forward():
-            await ops_test.model.wait_for_idle(
-                apps=[APP_NAME, WORKER_NAME], status="active", timeout=900
-            )
+        juju.integrate(f"{APP_NAME}:trino-coordinator", f"{WORKER_NAME}:trino-worker")
+        wait_for_apps(juju, [APP_NAME, WORKER_NAME], status="active", timeout=900)
 
         # Step 5: Check the catalogs (expect bigquery to be removed)
-        catalogs = await get_catalogs(ops_test, TRINO_USER, APP_NAME)
+        catalogs = get_catalogs(juju, TRINO_USER, APP_NAME)
         assert "bigquery" not in str(catalogs), (
             "BigQuery should be removed after relation re-establishment"
         )

--- a/tests/integration/test_catalog_updates.py
+++ b/tests/integration/test_catalog_updates.py
@@ -37,12 +37,12 @@ class TestCatalogUpdates:
         bigquery_secret_id = add_juju_secret(juju, "bigquery")
         gsheet_secret_id = add_juju_secret(juju, "gsheets")
 
-        for app in ["trino-k8s", "trino-k8s-worker"]:
-            juju.grant_secret("postgresql-secret", app)
-            juju.grant_secret("mysql-secret", app)
-            juju.grant_secret("redshift-secret", app)
-            juju.grant_secret("bigquery-secret", app)
-            juju.grant_secret("gsheets-secret", app)
+        apps = ["trino-k8s", "trino-k8s-worker"]
+        juju.grant_secret("postgresql-secret", apps)
+        juju.grant_secret("mysql-secret", apps)
+        juju.grant_secret("redshift-secret", apps)
+        juju.grant_secret("bigquery-secret", apps)
+        juju.grant_secret("gsheets-secret", apps)
 
         catalog_config = create_catalog_config(
             postgresql_secret_id,

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -6,6 +6,7 @@
 
 import logging
 
+import jubilant
 import pytest
 from conftest import deploy  # noqa: F401, pylint: disable=W0611
 from helpers import (
@@ -17,8 +18,8 @@ from helpers import (
     get_catalogs,
     simulate_crash_and_restart,
     update_catalog_config,
+    wait_for_apps,
 )
-from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
 
@@ -28,33 +29,33 @@ logger = logging.getLogger(__name__)
 class TestDeployment:
     """Integration tests for Trino charm."""
 
-    async def test_trino_ui(self, ops_test: OpsTest):
+    def test_trino_ui(self, juju: jubilant.Juju):
         """Perform GET request on the Trino UI host."""
-        response = await curl_unit_ip(ops_test)
+        response = curl_unit_ip(juju)
         assert response.status_code == 200
 
-    async def test_basic_client(self, ops_test: OpsTest):
+    def test_basic_client(self, juju: jubilant.Juju):
         """Connects a client and executes a basic SQL query."""
-        catalogs = await get_catalogs(ops_test, TRINO_USER, APP_NAME)
+        catalogs = get_catalogs(juju, TRINO_USER, APP_NAME)
         logging.info(f"Found catalogs: {catalogs}")
         assert catalogs
 
-    async def test_catalog_config(self, ops_test: OpsTest):
+    def test_catalog_config(self, juju: jubilant.Juju):
         """Adds a PostgreSQL and BigQuery connector and asserts catalogs added."""
-        postgresql_secret_id = await add_juju_secret(ops_test, "postgresql")
-        mysql_secret_id = await add_juju_secret(ops_test, "mysql")
-        redshift_secret_id = await add_juju_secret(ops_test, "redshift")
-        bigquery_secret_id = await add_juju_secret(ops_test, "bigquery")
-        gsheet_secret_id = await add_juju_secret(ops_test, "gsheets")
+        postgresql_secret_id = add_juju_secret(juju, "postgresql")
+        mysql_secret_id = add_juju_secret(juju, "mysql")
+        redshift_secret_id = add_juju_secret(juju, "redshift")
+        bigquery_secret_id = add_juju_secret(juju, "bigquery")
+        gsheet_secret_id = add_juju_secret(juju, "gsheets")
 
         for app in ["trino-k8s", "trino-k8s-worker"]:
-            await ops_test.model.grant_secret("postgresql-secret", app)
-            await ops_test.model.grant_secret("mysql-secret", app)
-            await ops_test.model.grant_secret("redshift-secret", app)
-            await ops_test.model.grant_secret("bigquery-secret", app)
-            await ops_test.model.grant_secret("gsheets-secret", app)
+            juju.grant_secret("postgresql-secret", app)
+            juju.grant_secret("mysql-secret", app)
+            juju.grant_secret("redshift-secret", app)
+            juju.grant_secret("bigquery-secret", app)
+            juju.grant_secret("gsheets-secret", app)
 
-        catalog_config = await create_catalog_config(
+        catalog_config = create_catalog_config(
             postgresql_secret_id,
             mysql_secret_id,
             redshift_secret_id,
@@ -62,7 +63,7 @@ class TestDeployment:
             gsheet_secret_id,
             True,
         )
-        catalogs = await update_catalog_config(ops_test, catalog_config, TRINO_USER)
+        catalogs = update_catalog_config(juju, catalog_config, TRINO_USER)
 
         # Verify that both catalogs have been added.
         assert "postgresql-1" in str(catalogs)
@@ -71,7 +72,7 @@ class TestDeployment:
         assert "bigquery" in str(catalogs)
         assert "gsheets-1" in str(catalogs)
 
-        updated_catalog_config = await create_catalog_config(
+        updated_catalog_config = create_catalog_config(
             postgresql_secret_id,
             mysql_secret_id,
             redshift_secret_id,
@@ -80,7 +81,7 @@ class TestDeployment:
             False,
         )
 
-        catalogs = await update_catalog_config(ops_test, updated_catalog_config, TRINO_USER)
+        catalogs = update_catalog_config(juju, updated_catalog_config, TRINO_USER)
 
         # Verify that only the bigquery catalog has been removed.
         assert "postgresql-1" in str(catalogs)
@@ -89,27 +90,26 @@ class TestDeployment:
         assert "bigquery" not in str(catalogs)
         assert "gsheets-1" in str(catalogs)
 
-    async def test_simulate_crash(self, ops_test: OpsTest, charm: str, charm_image: str):
+    def test_simulate_crash(self, juju: jubilant.Juju, charm: str, charm_image: str):
         """Simulate the crash of the Trino coordinator charm.
 
         Args:
-            ops_test: PyTest object.
+            juju: Jubilant Juju object.
             charm: charm path.
             charm_image: path to rock image to be used.
         """
-        await simulate_crash_and_restart(ops_test, charm, charm_image)
-        response = await curl_unit_ip(ops_test)
+        simulate_crash_and_restart(juju, charm, charm_image)
+        response = curl_unit_ip(juju)
         assert response.status_code == 200
 
-        catalogs = await get_catalogs(ops_test, TRINO_USER, APP_NAME)
+        catalogs = get_catalogs(juju, TRINO_USER, APP_NAME)
         assert catalogs
 
-    async def test_trino_default_policy(self, ops_test: OpsTest):
+    def test_trino_default_policy(self, juju: jubilant.Juju):
         """Update the config and verify no catalog access."""
-        await ops_test.model.applications[APP_NAME].set_config({"acl-mode-default": "none"})
+        juju.config(APP_NAME, {"acl-mode-default": "none"})
 
-        async with ops_test.fast_forward():
-            await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=600)
-        catalogs = await get_catalogs(ops_test, TRINO_USER, APP_NAME)
+        wait_for_apps(juju, [APP_NAME], status="active", timeout=600)
+        catalogs = get_catalogs(juju, TRINO_USER, APP_NAME)
         logging.info(f"Found catalogs: {catalogs}")
         assert not catalogs

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -48,12 +48,12 @@ class TestDeployment:
         bigquery_secret_id = add_juju_secret(juju, "bigquery")
         gsheet_secret_id = add_juju_secret(juju, "gsheets")
 
-        for app in ["trino-k8s", "trino-k8s-worker"]:
-            juju.grant_secret("postgresql-secret", app)
-            juju.grant_secret("mysql-secret", app)
-            juju.grant_secret("redshift-secret", app)
-            juju.grant_secret("bigquery-secret", app)
-            juju.grant_secret("gsheets-secret", app)
+        apps = ["trino-k8s", "trino-k8s-worker"]
+        juju.grant_secret("postgresql-secret", apps)
+        juju.grant_secret("mysql-secret", apps)
+        juju.grant_secret("redshift-secret", apps)
+        juju.grant_secret("bigquery-secret", apps)
+        juju.grant_secret("gsheets-secret", apps)
 
         catalog_config = create_catalog_config(
             postgresql_secret_id,

--- a/tests/integration/test_managers.py
+++ b/tests/integration/test_managers.py
@@ -6,11 +6,11 @@
 
 import json
 
+import jubilant
 import pytest
 import trino.exceptions
 from conftest import deploy  # noqa: F401, pylint: disable=W0611
-from helpers import APP_NAME, TRINO_USER, WORKER_NAME, run_query
-from pytest_operator.plugin import OpsTest
+from helpers import APP_NAME, TRINO_USER, WORKER_NAME, run_query, wait_for_apps
 
 
 def _resource_groups_config(user: str) -> str:
@@ -48,25 +48,25 @@ SESSION_PROPERTY_MANAGER_CONFIG = json.dumps(
 )
 
 
-async def _set_manager_config(
-    ops_test: OpsTest,
+def _set_manager_config(
+    juju: jubilant.Juju,
     resource_groups_config: str = "",
     session_property_manager_config: str = "",
 ):
     """Apply manager configuration and wait for Trino to settle."""
-    await ops_test.model.applications[APP_NAME].set_config(
+    juju.config(
+        APP_NAME,
         {
             "resource-groups-config": resource_groups_config,
             "session-property-manager-config": session_property_manager_config,
-        }
+        },
     )
-    async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(
-            apps=[APP_NAME, WORKER_NAME],
-            status="active",
-            raise_on_blocked=False,
-            timeout=600,
-        )
+    wait_for_apps(
+        juju,
+        [APP_NAME, WORKER_NAME],
+        status="active",
+        timeout=600,
+    )
 
 
 @pytest.mark.abort_on_fail
@@ -74,32 +74,32 @@ async def _set_manager_config(
 class TestManagers:
     """Integration tests for Trino managers."""
 
-    async def test_resource_group_and_session_property_managers(self, ops_test: OpsTest):
+    def test_resource_group_and_session_property_managers(self, juju: jubilant.Juju):
         """Verify both managers affect query execution at runtime."""
         try:
-            await _set_manager_config(
-                ops_test,
+            _set_manager_config(
+                juju,
                 resource_groups_config=_resource_groups_config("nobody"),
                 session_property_manager_config=(SESSION_PROPERTY_MANAGER_CONFIG),
             )
 
             with pytest.raises(trino.exceptions.TrinoUserError) as exc_info:
-                await run_query(
-                    ops_test,
+                run_query(
+                    juju,
                     TRINO_USER,
                     "SHOW SESSION LIKE 'query_max_execution_time'",
                 )
 
             assert "No matching resource group found" in str(exc_info.value)
 
-            await _set_manager_config(
-                ops_test,
+            _set_manager_config(
+                juju,
                 resource_groups_config=_resource_groups_config(TRINO_USER),
                 session_property_manager_config=(SESSION_PROPERTY_MANAGER_CONFIG),
             )
 
-            session_rows = await run_query(
-                ops_test,
+            session_rows = run_query(
+                juju,
                 TRINO_USER,
                 "SHOW SESSION LIKE 'query_max_execution_time'",
             )
@@ -107,4 +107,4 @@ class TestManagers:
             assert session_rows[0][0] == "query_max_execution_time"
             assert session_rows[0][1] == "7m"
         finally:
-            await _set_manager_config(ops_test)
+            _set_manager_config(juju)

--- a/tests/integration/test_pg_catalog_relation.py
+++ b/tests/integration/test_pg_catalog_relation.py
@@ -3,10 +3,10 @@
 
 """Integration tests for the Trino-PostgreSQL catalog relation."""
 
-import asyncio
 import logging
 import time
 
+import jubilant
 import pytest
 import yaml
 from conftest import deploy  # noqa: F401, pylint: disable=W0611
@@ -18,9 +18,14 @@ from helpers import (
     add_juju_secret,
     create_catalog_config,
     get_catalogs,
+    get_status,
+    get_unit,
+    scale,
+    unit_name,
     update_catalog_config,
+    wait_for_app_gone,
+    wait_for_apps,
 )
-from pytest_operator.plugin import OpsTest
 from trino_client.trino_client import query_trino
 
 logger = logging.getLogger(__name__)
@@ -60,130 +65,98 @@ def pg_catalog_config(
     return yaml.dump({app_name: entry})
 
 
-async def deploy_pg(ops_test, pg_name=POSTGRES_NAME, db_name="testdb", units=1):
+def deploy_pg(juju: jubilant.Juju, pg_name=POSTGRES_NAME, db_name="testdb", units=1):
     """Deploy PostgreSQL and a data-integrator to create a database.
 
     The DI is needed because PG's prefix matching only discovers existing
     databases, it does not create them from a prefix request.
 
     Args:
-        ops_test: PyTest object.
+        juju: Jubilant Juju object.
         pg_name: Application name for PG.
         db_name: Database name for the data-integrator to create.
         units: Number of PG units.
     """
     di_name = f"di-{pg_name}"
-    await ops_test.model.deploy(
-        "postgresql-k8s",
-        application_name=pg_name,
-        channel=PG_CHANNEL,
-        num_units=units,
-        trust=True,
-    )
-    await ops_test.model.deploy(
+    juju.deploy("postgresql-k8s", pg_name, channel=PG_CHANNEL, num_units=units, trust=True)
+    juju.deploy(
         "data-integrator",
-        application_name=di_name,
+        di_name,
         channel="latest/edge",
         config={"database-name": db_name},
     )
-    await ops_test.model.integrate(f"{pg_name}:database", di_name)
-    async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(
-            apps=[pg_name],
-            status="active",
-            timeout=900,
-            wait_for_exact_units=units,
-        )
-        await ops_test.model.wait_for_idle(
-            apps=[di_name],
-            status="active",
-            timeout=900,
-        )
+    juju.integrate(f"{pg_name}:database", di_name)
+    wait_for_apps(juju, [pg_name], status="active", timeout=900, wait_for_exact_units=units)
+    wait_for_apps(juju, [di_name], status="active", timeout=900)
 
 
-async def wait_for_idle_pg(ops_test, pg_name=POSTGRES_NAME):
+def wait_for_idle_pg(juju: jubilant.Juju, pg_name=POSTGRES_NAME):
     """Wait for PG and Trino to be idle and active.
 
     Args:
-        ops_test: PyTest object.
+        juju: Jubilant Juju object.
         pg_name: PG application name.
     """
-    async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(
-            apps=[APP_NAME, WORKER_NAME, pg_name],
-            status="active",
-            raise_on_blocked=False,
-            timeout=900,
-        )
+    wait_for_apps(juju, [APP_NAME, WORKER_NAME, pg_name], status="active", timeout=900)
 
 
-async def destroy_pg(ops_test, pg_name):
+def destroy_pg(juju: jubilant.Juju, pg_name):
     """Destroy a PG app and its associated data-integrator.
 
     Args:
-        ops_test: PyTest object.
+        juju: Jubilant Juju object.
         pg_name: Application name for PG.
     """
     di_name = f"di-{pg_name}"
-    await ops_test.model.applications[di_name].destroy()
-    await ops_test.model.applications[pg_name].destroy()
-    await ops_test.model.block_until(lambda: pg_name not in ops_test.model.applications)
+    juju.remove_application(di_name)
+    juju.remove_application(pg_name)
+    wait_for_app_gone(juju, di_name)
+    wait_for_app_gone(juju, pg_name)
 
 
-async def relate_pg(ops_test, pg_name=POSTGRES_NAME):
+def relate_pg(juju: jubilant.Juju, pg_name=POSTGRES_NAME):
     """Integrate Trino with PG and wait for idle.
 
     Args:
-        ops_test: PyTest object.
+        juju: Jubilant Juju object.
         pg_name: PG application name.
     """
-    await ops_test.model.integrate(APP_NAME, pg_name)
-    await wait_for_idle_pg(ops_test, pg_name)
+    juju.integrate(APP_NAME, pg_name)
+    wait_for_idle_pg(juju, pg_name)
 
 
-async def remove_pg_relation(ops_test, pg_name=POSTGRES_NAME):
+def remove_pg_relation(juju: jubilant.Juju, pg_name=POSTGRES_NAME):
     """Remove the Trino-PG relation and wait for idle.
 
     Args:
-        ops_test: PyTest object.
+        juju: Jubilant Juju object.
         pg_name: PG application name.
     """
-    await ops_test.juju("remove-relation", APP_NAME, pg_name)
-    async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=600)
+    juju.remove_relation(APP_NAME, pg_name)
+    wait_for_apps(juju, [APP_NAME], status="active", timeout=600)
 
 
-async def set_pg_config(ops_test, config_str, expect_blocked=False):
+def set_pg_config(juju: jubilant.Juju, config_str, expect_blocked=False):
     """Set postgresql-catalog-config and wait for idle.
 
     Args:
-        ops_test: PyTest object.
+        juju: Jubilant Juju object.
         config_str: YAML config string.
         expect_blocked: When True, wait for APP_NAME to reach blocked status
             instead of active. Used when the config is intentionally invalid.
     """
-    await ops_test.model.applications[APP_NAME].set_config({PG_CONFIG_KEY: config_str})
-    async with ops_test.fast_forward():
-        if expect_blocked:
-            await ops_test.model.wait_for_idle(
-                apps=[APP_NAME],
-                status="blocked",
-                raise_on_blocked=False,
-                timeout=900,
-            )
-        else:
-            await ops_test.model.wait_for_idle(
-                apps=[APP_NAME, WORKER_NAME, POSTGRES_NAME],
-                status="active",
-                timeout=900,
-            )
+    juju.config(APP_NAME, {PG_CONFIG_KEY: config_str})
+    if expect_blocked:
+        wait_for_apps(juju, [APP_NAME], status="blocked", timeout=900)
+    else:
+        wait_for_apps(juju, [APP_NAME, WORKER_NAME, POSTGRES_NAME], status="active", timeout=900)
 
 
-async def wait_for_catalog(ops_test, catalog_name, present=True, timeout=120):
+def wait_for_catalog(juju: jubilant.Juju, catalog_name, present=True, timeout=120):
     """Poll SHOW CATALOGS until catalog appears/disappears or timeout.
 
     Args:
-        ops_test: PyTest object.
+        juju: Jubilant Juju object.
         catalog_name: Catalog name to check.
         present: True to wait for appearance, False for disappearance.
         timeout: Seconds before giving up.
@@ -197,54 +170,50 @@ async def wait_for_catalog(ops_test, catalog_name, present=True, timeout=120):
     deadline = time.time() + timeout
     while time.time() < deadline:
         try:
-            catalogs = await get_catalogs(ops_test, TRINO_USER, APP_NAME)
+            catalogs = get_catalogs(juju, TRINO_USER, APP_NAME)
             found = catalog_name in str(catalogs)
             if found == present:
                 return catalogs
         except Exception:  # nosec
             pass  # nosec
-        await asyncio.sleep(5)
+        time.sleep(5)
     state = "not found" if present else "still present"
     raise TimeoutError(f"Catalog {catalog_name!r} {state} after {timeout}s")
 
 
-async def query_pg_catalog(ops_test, catalog_name):
+def query_pg_catalog(juju: jubilant.Juju, catalog_name):
     """Run SHOW SCHEMAS against a catalog to verify connectivity.
 
     Args:
-        ops_test: PyTest object.
+        juju: Jubilant Juju object.
         catalog_name: Name of the Trino catalog.
 
     Returns:
         List of schemas
     """
-    status = await ops_test.model.get_status()
-    address = status["applications"][APP_NAME]["units"][f"{APP_NAME}/0"]["address"]
-    return await query_trino(address, TRINO_USER, f'SHOW SCHEMAS FROM "{catalog_name}"')
+    address = get_status(juju).apps[APP_NAME].units[f"{APP_NAME}/0"].address
+    return query_trino(address, TRINO_USER, f'SHOW SCHEMAS FROM "{catalog_name}"')
 
 
-async def get_properties_file(ops_test, catalog_name):
+def get_properties_file(juju: jubilant.Juju, catalog_name):
     """Read a catalog .properties file from the Trino container.
 
     Args:
-        ops_test: PyTest object.
+        juju: Jubilant Juju object.
         catalog_name: Name of the catalog.
 
     Returns:
         File contents as string, or None if not found.
     """
-    unit = ops_test.model.applications[APP_NAME].units[0]
-    rc, stdout, _ = await ops_test.juju(
-        "ssh",
-        "--container",
-        "trino",
-        unit.name,
-        "cat",
-        f"{CATALOG_DIR}/{catalog_name}.properties",
-    )
-    if rc != 0:
+    try:
+        return juju.ssh(
+            unit_name(APP_NAME),
+            "cat",
+            f"{CATALOG_DIR}/{catalog_name}.properties",
+            container="trino",
+        )
+    except Exception:  # nosec
         return None
-    return stdout
 
 
 @pytest.mark.abort_on_fail
@@ -252,164 +221,156 @@ async def get_properties_file(ops_test, catalog_name):
 class TestPostgresqlCatalogRelation:
     """Integration tests for PostgreSQL catalog relation."""
 
-    async def test_01_missing_database_prefix(self, ops_test: OpsTest):
+    def test_01_missing_database_prefix(self, juju: jubilant.Juju):
         """Config without database_prefix: charm goes blocked with validation error."""
         config = yaml.dump({POSTGRES_NAME: {"ro_catalog_name": "test_ro"}})
-        await deploy_pg(ops_test)
-        await relate_pg(ops_test)
-        await set_pg_config(ops_test, config, expect_blocked=True)
+        deploy_pg(juju)
+        relate_pg(juju)
+        set_pg_config(juju, config, expect_blocked=True)
 
-        unit = ops_test.model.applications[APP_NAME].units[0]
-        assert unit.workload_status == "blocked"
-        assert "database_prefix" in unit.workload_status_message
+        unit = get_unit(juju, APP_NAME)
+        assert unit.workload_status.current == "blocked"
+        assert "database_prefix" in unit.workload_status.message
 
-    async def test_02_prefix_without_asterisk(self, ops_test: OpsTest):
+    def test_02_prefix_without_asterisk(self, juju: jubilant.Juju):
         """Config with database_prefix missing *: charm goes blocked with validation error."""
         config = pg_catalog_config(POSTGRES_NAME, "mydb", "test_ro")
-        await set_pg_config(ops_test, config, expect_blocked=True)
+        set_pg_config(juju, config, expect_blocked=True)
 
-        unit = ops_test.model.applications[APP_NAME].units[0]
-        assert unit.workload_status == "blocked"
-        assert "database_prefix" in unit.workload_status_message
+        unit = get_unit(juju, APP_NAME)
+        assert unit.workload_status.current == "blocked"
+        assert "database_prefix" in unit.workload_status.message
 
-    async def test_03_missing_catalog_names(self, ops_test: OpsTest):
+    def test_03_missing_catalog_names(self, juju: jubilant.Juju):
         """Config with database_prefix but no catalog names: charm goes blocked."""
         config = yaml.dump({POSTGRES_NAME: {"database_prefix": "testdb*"}})
-        await set_pg_config(ops_test, config, expect_blocked=True)
+        set_pg_config(juju, config, expect_blocked=True)
 
-        unit = ops_test.model.applications[APP_NAME].units[0]
-        assert unit.workload_status == "blocked"
-        assert "ro_catalog_name" in unit.workload_status_message
+        unit = get_unit(juju, APP_NAME)
+        assert unit.workload_status.current == "blocked"
+        assert "ro_catalog_name" in unit.workload_status.message
 
-    async def test_04_fix_invalid_config(self, ops_test: OpsTest):
+    def test_04_fix_invalid_config(self, juju: jubilant.Juju):
         """After fixing the invalid config from test_03, charm recovers and catalog is created."""
         config = pg_catalog_config(POSTGRES_NAME, "testdb*", "test_catalog")
-        await set_pg_config(ops_test, config)
+        set_pg_config(juju, config)
 
-        await wait_for_catalog(ops_test, "test_catalog")
+        wait_for_catalog(juju, "test_catalog")
 
-        schemas = await query_pg_catalog(ops_test, "test_catalog")
+        schemas = query_pg_catalog(juju, "test_catalog")
         schema_names = [s[0] for s in schemas]
         assert "public" in schema_names
 
-    async def test_05_both_ro_and_rw(self, ops_test: OpsTest):
+    def test_05_both_ro_and_rw(self, juju: jubilant.Juju):
         """Config with both ro and rw: two catalogs created."""
         config = pg_catalog_config(POSTGRES_NAME, "testdb*", "mydb_ro", rw_name="mydb_rw")
-        await set_pg_config(ops_test, config)
+        set_pg_config(juju, config)
 
-        await wait_for_catalog(ops_test, "mydb_ro")
-        await wait_for_catalog(ops_test, "mydb_rw")
+        wait_for_catalog(juju, "mydb_ro")
+        wait_for_catalog(juju, "mydb_rw")
 
-        ro_props = await get_properties_file(ops_test, "mydb_ro")
-        rw_props = await get_properties_file(ops_test, "mydb_rw")
+        ro_props = get_properties_file(juju, "mydb_ro")
+        rw_props = get_properties_file(juju, "mydb_rw")
         assert ro_props is not None
         assert rw_props is not None
         assert "preferSecondary" in ro_props
         assert "primary" in rw_props
 
-        ro_schemas = await query_pg_catalog(ops_test, "mydb_ro")
-        rw_schemas = await query_pg_catalog(ops_test, "mydb_rw")
+        ro_schemas = query_pg_catalog(juju, "mydb_ro")
+        rw_schemas = query_pg_catalog(juju, "mydb_rw")
         assert any("public" in s for s in ro_schemas)
         assert any("public" in s for s in rw_schemas)
 
-    async def test_06_remove_rw(self, ops_test: OpsTest):
+    def test_06_remove_rw(self, juju: jubilant.Juju):
         """Remove rw_catalog_name: RW catalog dropped, RO remains."""
         config = pg_catalog_config(POSTGRES_NAME, "testdb*", "mydb_ro")
-        await set_pg_config(ops_test, config)
+        set_pg_config(juju, config)
 
-        await wait_for_catalog(ops_test, "mydb_ro")
-        await wait_for_catalog(ops_test, "mydb_rw", present=False)
+        wait_for_catalog(juju, "mydb_ro")
+        wait_for_catalog(juju, "mydb_rw", present=False)
 
-    async def test_07_add_rw(self, ops_test: OpsTest):
+    def test_07_add_rw(self, juju: jubilant.Juju):
         """Add rw_catalog_name: RW catalog appears alongside RO."""
         config = pg_catalog_config(POSTGRES_NAME, "testdb*", "mydb_ro", rw_name="mydb_rw")
-        await set_pg_config(ops_test, config)
+        set_pg_config(juju, config)
 
-        await wait_for_catalog(ops_test, "mydb_ro")
-        await wait_for_catalog(ops_test, "mydb_rw")
+        wait_for_catalog(juju, "mydb_ro")
+        wait_for_catalog(juju, "mydb_rw")
 
-    async def test_08_pg_scaling(self, ops_test: OpsTest):
+    def test_08_pg_scaling(self, juju: jubilant.Juju):
         """Catalog URL gains replicas service address after PG scales up."""
         config = pg_catalog_config(POSTGRES_NAME, "testdb*", "multihost_ro")
-        await set_pg_config(ops_test, config)
-        await wait_for_catalog(ops_test, "multihost_ro")
+        set_pg_config(juju, config)
+        wait_for_catalog(juju, "multihost_ro")
 
         # With 1 PG unit there are no replicas, URL has only the primary
-        props = await get_properties_file(ops_test, "multihost_ro")
+        props = get_properties_file(juju, "multihost_ro")
         assert props is not None
         assert f"{POSTGRES_NAME}-primary" in props
         assert f"{POSTGRES_NAME}-replicas" not in props
 
         # Scale PG to 3, replicas service should appear in the URL
-        async with ops_test.fast_forward():
-            await ops_test.model.applications[POSTGRES_NAME].scale(scale=3)
-            await ops_test.model.wait_for_idle(
-                apps=[POSTGRES_NAME],
-                status="active",
-                timeout=900,
-                wait_for_exact_units=3,
-            )
-            await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=600)
+        scale(juju, POSTGRES_NAME, 3)
+        wait_for_apps(juju, [APP_NAME], status="active", timeout=600)
 
-        await wait_for_catalog(ops_test, "multihost_ro")
-        props = await get_properties_file(ops_test, "multihost_ro")
+        wait_for_catalog(juju, "multihost_ro")
+        props = get_properties_file(juju, "multihost_ro")
         assert props is not None
         assert f"{POSTGRES_NAME}-primary" in props
         assert f"{POSTGRES_NAME}-replicas" in props
 
-    async def test_09_both_config_types(self, ops_test: OpsTest):
+    def test_09_both_config_types(self, juju: jubilant.Juju):
         """Both catalog-config and postgresql-catalog-config active."""
-        postgresql_secret_id = await add_juju_secret(ops_test, "postgresql")
+        postgresql_secret_id = add_juju_secret(juju, "postgresql")
         for app in [APP_NAME, WORKER_NAME]:
-            await ops_test.model.grant_secret("postgresql-secret", app)
+            juju.grant_secret("postgresql-secret", app)
 
-        catalog_config = await create_catalog_config(
+        catalog_config = create_catalog_config(
             postgresql_secret_id,
-            await add_juju_secret(ops_test, "mysql"),
-            await add_juju_secret(ops_test, "redshift"),
-            await add_juju_secret(ops_test, "bigquery"),
-            await add_juju_secret(ops_test, "gsheets"),
+            add_juju_secret(juju, "mysql"),
+            add_juju_secret(juju, "redshift"),
+            add_juju_secret(juju, "bigquery"),
+            add_juju_secret(juju, "gsheets"),
         )
         for app in [APP_NAME, WORKER_NAME]:
-            await ops_test.model.grant_secret("mysql-secret", app)
-            await ops_test.model.grant_secret("redshift-secret", app)
-            await ops_test.model.grant_secret("bigquery-secret", app)
-            await ops_test.model.grant_secret("gsheets-secret", app)
+            juju.grant_secret("mysql-secret", app)
+            juju.grant_secret("redshift-secret", app)
+            juju.grant_secret("bigquery-secret", app)
+            juju.grant_secret("gsheets-secret", app)
 
-        await update_catalog_config(ops_test, catalog_config, TRINO_USER)
+        update_catalog_config(juju, catalog_config, TRINO_USER)
 
         pg_config = pg_catalog_config(POSTGRES_NAME, "testdb*", "dynamic_pg")
-        await set_pg_config(ops_test, pg_config)
+        set_pg_config(juju, pg_config)
 
-        await wait_for_catalog(ops_test, "dynamic_pg")
-        await wait_for_catalog(ops_test, "postgresql-1")
+        wait_for_catalog(juju, "dynamic_pg")
+        wait_for_catalog(juju, "postgresql-1")
 
-    async def test_10_remove_relation_keeps_static(self, ops_test: OpsTest):
+    def test_10_remove_relation_keeps_static(self, juju: jubilant.Juju):
         """Removing PG relation does not affect static catalogs."""
-        await remove_pg_relation(ops_test)
+        remove_pg_relation(juju)
 
-        await wait_for_catalog(ops_test, "dynamic_pg", present=False)
-        await wait_for_catalog(ops_test, "postgresql-1")
+        wait_for_catalog(juju, "dynamic_pg", present=False)
+        wait_for_catalog(juju, "postgresql-1")
 
         # Re-relate for next test
-        await relate_pg(ops_test)
+        relate_pg(juju)
 
-    async def test_11_remove_static_keeps_dynamic(self, ops_test: OpsTest):
+    def test_11_remove_static_keeps_dynamic(self, juju: jubilant.Juju):
         """Removing static catalog does not affect dynamic catalog."""
-        await wait_for_catalog(ops_test, "dynamic_pg")
+        wait_for_catalog(juju, "dynamic_pg")
 
-        await ops_test.model.applications[APP_NAME].reset_config(["catalog-config"])
-        async with ops_test.fast_forward():
-            await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=600)
+        juju.config(APP_NAME, reset=["catalog-config"])
+        wait_for_apps(juju, [APP_NAME], status="active", timeout=600)
 
-        await wait_for_catalog(ops_test, "postgresql-1", present=False)
-        await wait_for_catalog(ops_test, "dynamic_pg")
+        wait_for_catalog(juju, "postgresql-1", present=False)
+        wait_for_catalog(juju, "dynamic_pg")
 
-        await remove_pg_relation(ops_test)
+        remove_pg_relation(juju)
 
-    async def test_12_two_pg_apps(self, ops_test: OpsTest):
+    def test_12_two_pg_apps(self, juju: jubilant.Juju):
         """Two PG apps with separate configs: both catalogs created."""
-        await deploy_pg(ops_test, pg_name="pg-second", db_name="seconddb")
+        deploy_pg(juju, pg_name="pg-second", db_name="seconddb")
 
         config = yaml.dump(
             {
@@ -423,126 +384,106 @@ class TestPostgresqlCatalogRelation:
                 },
             }
         )
-        await ops_test.model.applications[APP_NAME].set_config({PG_CONFIG_KEY: config})
+        juju.config(APP_NAME, {PG_CONFIG_KEY: config})
 
-        await ops_test.model.integrate(APP_NAME, POSTGRES_NAME)
-        await ops_test.model.integrate(APP_NAME, "pg-second")
+        juju.integrate(APP_NAME, POSTGRES_NAME)
+        juju.integrate(APP_NAME, "pg-second")
 
-        async with ops_test.fast_forward():
-            await ops_test.model.wait_for_idle(
-                apps=[APP_NAME, WORKER_NAME, POSTGRES_NAME, "pg-second"],
-                status="active",
-                timeout=900,
-            )
-
-        await wait_for_catalog(ops_test, "pg1_catalog")
-        await wait_for_catalog(ops_test, "pg2_catalog")
-
-    async def test_13_remove_one_relation(self, ops_test: OpsTest):
-        """Remove one PG relation: its catalog dropped, other unaffected."""
-        await remove_pg_relation(ops_test)
-
-        await wait_for_catalog(ops_test, "pg1_catalog", present=False)
-        await wait_for_catalog(ops_test, "pg2_catalog")
-
-    async def test_14_re_add_relation(self, ops_test: OpsTest):
-        """Re-add first PG relation: catalog re-created."""
-        await relate_pg(ops_test)
-
-        await wait_for_catalog(ops_test, "pg1_catalog")
-        await wait_for_catalog(ops_test, "pg2_catalog")
-
-        # Cleanup
-        await remove_pg_relation(ops_test)
-        await remove_pg_relation(ops_test, "pg-second")
-        await destroy_pg(ops_test, "pg-second")
-
-    async def test_15_wrong_app_name_in_config(self, ops_test: OpsTest):
-        """Config key doesn't match PG app name: no catalog, charm active."""
-        config = pg_catalog_config("wrong-name", "testdb*", "missing_catalog")
-        await ops_test.model.applications[APP_NAME].set_config({PG_CONFIG_KEY: config})
-        await relate_pg(ops_test)
-
-        await wait_for_catalog(ops_test, "missing_catalog", present=False)
-        assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
-
-        await remove_pg_relation(ops_test)
-
-    async def test_16_container_restart(self, ops_test: OpsTest):
-        """Trino container restart: catalog persists."""
-        config = pg_catalog_config(POSTGRES_NAME, "testdb*", "persist_catalog")
-        await ops_test.model.applications[APP_NAME].set_config({PG_CONFIG_KEY: config})
-        await relate_pg(ops_test)
-
-        await wait_for_catalog(ops_test, "persist_catalog")
-
-        schemas = await query_pg_catalog(ops_test, "persist_catalog")
-        assert any("public" in s for s in schemas)
-
-        unit = ops_test.model.applications[APP_NAME].units[0]
-        await ops_test.juju(
-            "ssh",
-            "--container",
-            "trino",
-            unit.name,
-            "/charm/bin/pebble",
-            "restart",
-            "trino",
+        wait_for_apps(
+            juju,
+            [APP_NAME, WORKER_NAME, POSTGRES_NAME, "pg-second"],
+            status="active",
+            timeout=900,
         )
 
-        async with ops_test.fast_forward():
-            await ops_test.model.wait_for_idle(
-                apps=[APP_NAME, WORKER_NAME],
-                status="active",
-                timeout=600,
-            )
+        wait_for_catalog(juju, "pg1_catalog")
+        wait_for_catalog(juju, "pg2_catalog")
 
-        await wait_for_catalog(ops_test, "persist_catalog")
+    def test_13_remove_one_relation(self, juju: jubilant.Juju):
+        """Remove one PG relation: its catalog dropped, other unaffected."""
+        remove_pg_relation(juju)
 
-        schemas = await query_pg_catalog(ops_test, "persist_catalog")
+        wait_for_catalog(juju, "pg1_catalog", present=False)
+        wait_for_catalog(juju, "pg2_catalog")
+
+    def test_14_re_add_relation(self, juju: jubilant.Juju):
+        """Re-add first PG relation: catalog re-created."""
+        relate_pg(juju)
+
+        wait_for_catalog(juju, "pg1_catalog")
+        wait_for_catalog(juju, "pg2_catalog")
+
+        # Cleanup
+        remove_pg_relation(juju)
+        remove_pg_relation(juju, "pg-second")
+        destroy_pg(juju, "pg-second")
+
+    def test_15_wrong_app_name_in_config(self, juju: jubilant.Juju):
+        """Config key doesn't match PG app name: no catalog, charm active."""
+        config = pg_catalog_config("wrong-name", "testdb*", "missing_catalog")
+        juju.config(APP_NAME, {PG_CONFIG_KEY: config})
+        relate_pg(juju)
+
+        wait_for_catalog(juju, "missing_catalog", present=False)
+        assert get_unit(juju, APP_NAME).workload_status.current == "active"
+
+        remove_pg_relation(juju)
+
+    def test_16_container_restart(self, juju: jubilant.Juju):
+        """Trino container restart: catalog persists."""
+        config = pg_catalog_config(POSTGRES_NAME, "testdb*", "persist_catalog")
+        juju.config(APP_NAME, {PG_CONFIG_KEY: config})
+        relate_pg(juju)
+
+        wait_for_catalog(juju, "persist_catalog")
+
+        schemas = query_pg_catalog(juju, "persist_catalog")
+        assert any("public" in s for s in schemas)
+
+        juju.ssh(unit_name(APP_NAME), "/charm/bin/pebble", "restart", "trino", container="trino")
+
+        wait_for_apps(juju, [APP_NAME, WORKER_NAME], status="active", timeout=600)
+
+        wait_for_catalog(juju, "persist_catalog")
+
+        schemas = query_pg_catalog(juju, "persist_catalog")
         assert any("public" in s for s in schemas)
 
         # Final cleanup
-        await remove_pg_relation(ops_test)
-        await ops_test.model.applications[APP_NAME].reset_config([PG_CONFIG_KEY])
-        async with ops_test.fast_forward():
-            await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=600)
+        remove_pg_relation(juju)
+        juju.config(APP_NAME, reset=[PG_CONFIG_KEY])
+        wait_for_apps(juju, [APP_NAME], status="active", timeout=600)
 
-    async def test_17_tls_connection(self, ops_test: OpsTest):
+    def test_17_tls_connection(self, juju: jubilant.Juju):
         """Catalog uses TLS when PG has certificates enabled."""
-        await ops_test.model.deploy("self-signed-certificates", channel="latest/edge")
-        async with ops_test.fast_forward():
-            await ops_test.model.wait_for_idle(
-                apps=["self-signed-certificates"],
-                status="active",
-                timeout=600,
-            )
+        juju.deploy("self-signed-certificates", channel="latest/edge")
+        wait_for_apps(juju, ["self-signed-certificates"], status="active", timeout=600)
 
-        await ops_test.model.integrate(
+        juju.integrate(
             f"{POSTGRES_NAME}:client-certificates",
             "self-signed-certificates:certificates",
         )
-        async with ops_test.fast_forward():
-            await ops_test.model.wait_for_idle(
-                apps=[POSTGRES_NAME, "self-signed-certificates"],
-                status="active",
-                timeout=900,
-            )
+        wait_for_apps(
+            juju,
+            [POSTGRES_NAME, "self-signed-certificates"],
+            status="active",
+            timeout=900,
+        )
 
         config = pg_catalog_config(POSTGRES_NAME, "testdb*", "tls_catalog")
-        await ops_test.model.applications[APP_NAME].set_config({PG_CONFIG_KEY: config})
-        await relate_pg(ops_test)
+        juju.config(APP_NAME, {PG_CONFIG_KEY: config})
+        relate_pg(juju)
 
-        await wait_for_catalog(ops_test, "tls_catalog")
+        wait_for_catalog(juju, "tls_catalog")
 
-        props = await get_properties_file(ops_test, "tls_catalog")
+        props = get_properties_file(juju, "tls_catalog")
         assert props is not None
         assert "ssl=true" in props or "ssl\\=true" in props
         assert "sslmode=require" in props or "sslmode\\=require" in props
 
-        schemas = await query_pg_catalog(ops_test, "tls_catalog")
+        schemas = query_pg_catalog(juju, "tls_catalog")
         assert any("public" in s for s in schemas)
 
         # Cleanup
-        await remove_pg_relation(ops_test)
-        await ops_test.model.applications[APP_NAME].reset_config([PG_CONFIG_KEY])
+        remove_pg_relation(juju)
+        juju.config(APP_NAME, reset=[PG_CONFIG_KEY])

--- a/tests/integration/test_pg_catalog_relation.py
+++ b/tests/integration/test_pg_catalog_relation.py
@@ -18,10 +18,8 @@ from helpers import (
     add_juju_secret,
     create_catalog_config,
     get_catalogs,
-    get_status,
     get_unit,
     scale,
-    unit_name,
     update_catalog_config,
     wait_for_app_gone,
     wait_for_apps,
@@ -206,7 +204,7 @@ def query_pg_catalog(juju: jubilant.Juju, catalog_name):
     Returns:
         List of schemas
     """
-    address = get_status(juju).apps[APP_NAME].units[f"{APP_NAME}/0"].address
+    address = get_unit(juju, APP_NAME).address
     return query_trino(address, TRINO_USER, f'SHOW SCHEMAS FROM "{catalog_name}"')
 
 
@@ -222,7 +220,7 @@ def get_properties_file(juju: jubilant.Juju, catalog_name):
     """
     try:
         return juju.ssh(
-            unit_name(APP_NAME),
+            f"{APP_NAME}/0",
             "cat",
             f"{CATALOG_DIR}/{catalog_name}.properties",
             container="trino",
@@ -347,11 +345,12 @@ class TestPostgresqlCatalogRelation:
             add_juju_secret(juju, "bigquery"),
             add_juju_secret(juju, "gsheets"),
         )
-        for app in [APP_NAME, WORKER_NAME]:
-            juju.grant_secret("mysql-secret", app)
-            juju.grant_secret("redshift-secret", app)
-            juju.grant_secret("bigquery-secret", app)
-            juju.grant_secret("gsheets-secret", app)
+
+        apps = [APP_NAME, WORKER_NAME]
+        juju.grant_secret("mysql-secret", apps)
+        juju.grant_secret("redshift-secret", apps)
+        juju.grant_secret("bigquery-secret", apps)
+        juju.grant_secret("gsheets-secret", apps)
 
         update_catalog_config(juju, catalog_config, TRINO_USER)
 
@@ -455,7 +454,7 @@ class TestPostgresqlCatalogRelation:
         schemas = query_pg_catalog(juju, "persist_catalog")
         assert any("public" in s for s in schemas)
 
-        juju.ssh(unit_name(APP_NAME), "/charm/bin/pebble", "restart", "trino", container="trino")
+        juju.ssh(f"{APP_NAME}/0", "/charm/bin/pebble", "restart", "trino", container="trino")
 
         wait_for_apps(juju, [APP_NAME, WORKER_NAME], status="active", timeout=600)
 

--- a/tests/integration/test_pg_catalog_relation.py
+++ b/tests/integration/test_pg_catalog_relation.py
@@ -135,6 +135,21 @@ def remove_pg_relation(juju: jubilant.Juju, pg_name=POSTGRES_NAME):
     juju.remove_relation(APP_NAME, pg_name)
     wait_for_apps(juju, [APP_NAME], status="active", timeout=600)
 
+    # Wait for the relation to be fully removed from Juju's state
+    # to avoid "relation is dying, but not yet removed" errors on re-integrate.
+    deadline = time.time() + 300
+    while time.time() < deadline:
+        status = juju.status()
+        app_status = status.apps.get(APP_NAME)
+        if app_status is None:
+            break
+        pg_relations = app_status.relations.get("postgresql", [])
+        if not any(r.related_app == pg_name for r in pg_relations):
+            break
+        time.sleep(2)
+    else:
+        raise TimeoutError(f"Relation {APP_NAME}:postgresql {pg_name} still present after 300s")
+
 
 def set_pg_config(juju: jubilant.Juju, config_str, expect_blocked=False):
     """Set postgresql-catalog-config and wait for idle.

--- a/tests/integration/test_pg_catalog_relation.py
+++ b/tests/integration/test_pg_catalog_relation.py
@@ -165,7 +165,7 @@ def set_pg_config(juju: jubilant.Juju, config_str, expect_blocked=False):
         wait_for_apps(juju, [APP_NAME, WORKER_NAME, POSTGRES_NAME], status="active", timeout=900)
 
 
-def wait_for_catalog(juju: jubilant.Juju, catalog_name, present=True, timeout=120):
+def wait_for_catalog(juju: jubilant.Juju, catalog_name, present=True, timeout=300):
     """Poll SHOW CATALOGS until catalog appears/disappears or timeout.
 
     Args:

--- a/tests/integration/test_pg_catalog_relation.py
+++ b/tests/integration/test_pg_catalog_relation.py
@@ -17,6 +17,7 @@ from helpers import (
     WORKER_NAME,
     add_juju_secret,
     create_catalog_config,
+    fast_forward_ctx,
     get_catalogs,
     get_unit,
     scale,
@@ -181,15 +182,18 @@ def wait_for_catalog(juju: jubilant.Juju, catalog_name, present=True, timeout=30
         TimeoutError: If the expected state isn't reached.
     """
     deadline = time.time() + timeout
-    while time.time() < deadline:
-        try:
-            catalogs = get_catalogs(juju, TRINO_USER, APP_NAME)
-            found = catalog_name in str(catalogs)
-            if found == present:
-                return catalogs
-        except Exception:  # nosec
-            pass  # nosec
-        time.sleep(5)
+    # Fast-forward update-status so a failed/incomplete reconcile is retried
+    # promptly while we poll, instead of at the slow default hook interval.
+    with fast_forward_ctx(juju, "10s"):
+        while time.time() < deadline:
+            try:
+                catalogs = get_catalogs(juju, TRINO_USER, APP_NAME)
+                found = catalog_name in str(catalogs)
+                if found == present:
+                    return catalogs
+            except Exception:  # nosec
+                pass  # nosec
+            time.sleep(5)
     state = "not found" if present else "still present"
     raise TimeoutError(f"Catalog {catalog_name!r} {state} after {timeout}s")
 

--- a/tests/integration/test_policy.py
+++ b/tests/integration/test_policy.py
@@ -93,8 +93,8 @@ class TestPolicyManager:
 
         catalogs = get_catalogs(juju, USER_WITH_ACCESS, APP_NAME)
         assert catalogs == [["system"]]
-        logger.info(f"{USER_WITH_ACCESS} can access {catalogs}.")
+        logger.info("%s can access %s.", USER_WITH_ACCESS, catalogs)
 
         catalogs = get_catalogs(juju, USER_WITHOUT_ACCESS, APP_NAME)
-        logger.info(f"{USER_WITHOUT_ACCESS} can not access {catalogs}.")
+        logger.info("%s can not access %s.", USER_WITH_ACCESS, catalogs)
         assert catalogs == []

--- a/tests/integration/test_policy.py
+++ b/tests/integration/test_policy.py
@@ -7,8 +7,8 @@
 import logging
 import time
 
+import jubilant
 import pytest
-import pytest_asyncio
 from helpers import (
     APP_NAME,
     POSTGRES_NAME,
@@ -19,8 +19,8 @@ from helpers import (
     get_catalogs,
     get_unit_url,
     update_policies,
+    wait_for_apps,
 )
-from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
 
@@ -30,50 +30,32 @@ TRINO_CONFIG = {
 }
 
 
-async def resolve_ranger_errors(ops_test: OpsTest):
+def resolve_ranger_errors(juju: jubilant.Juju):
     """Resolve Ranger error state if any.
 
     Args:
-        ops_test: The OpsTest instance.
+        juju: The Jubilant Juju instance.
     """
-    for unit in ops_test.model.applications[RANGER_NAME].units:
-        if unit.workload_status == "error":
-            logger.info("Resolving error on %s", unit.name)
-            await unit.resolved(retry=True)
+    for unit_name, unit_status in juju.status().apps[RANGER_NAME].units.items():
+        if unit_status.workload_status.current == "error":
+            logger.info("Resolving error on %s", unit_name)
+            juju.cli("resolved", "--retry", unit_name)
 
 
-@pytest_asyncio.fixture(name="deploy-policy", scope="module")
-async def deploy_policy_engine(ops_test: OpsTest):
+@pytest.fixture(name="deploy-policy", scope="module")
+def deploy_policy_engine(juju: jubilant.Juju):
     """Add Ranger relation and apply group configuration."""
-    await ops_test.model.deploy(POSTGRES_NAME, channel="14", trust=True)
-    async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(
-            apps=[POSTGRES_NAME],
-            status="active",
-            raise_on_blocked=False,
-            timeout=2000,
-        )
+    juju.deploy(POSTGRES_NAME, channel="14", trust=True)
+    wait_for_apps(juju, [POSTGRES_NAME], status="active", timeout=2000)
 
-    await ops_test.model.deploy(RANGER_NAME, channel="edge", revision=39, trust=True)
-    async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(
-            apps=[RANGER_NAME],
-            status="blocked",
-            raise_on_blocked=False,
-            timeout=2000,
-        )
+    juju.deploy(RANGER_NAME, channel="edge", revision=39, trust=True)
+    wait_for_apps(juju, [RANGER_NAME], status="blocked", timeout=2000)
 
     logger.info("Integrating Ranger and PostgreSQL.")
-    await ops_test.model.integrate(RANGER_NAME, POSTGRES_NAME)
+    juju.integrate(RANGER_NAME, POSTGRES_NAME)
     time.sleep(60)
-    async with ops_test.fast_forward():
-        await resolve_ranger_errors(ops_test)
-        await ops_test.model.wait_for_idle(
-            apps=[POSTGRES_NAME, RANGER_NAME],
-            status="active",
-            raise_on_blocked=False,
-            timeout=2000,
-        )
+    resolve_ranger_errors(juju)
+    wait_for_apps(juju, [POSTGRES_NAME, RANGER_NAME], status="active", timeout=2000)
 
 
 @pytest.mark.abort_on_fail
@@ -81,50 +63,38 @@ async def deploy_policy_engine(ops_test: OpsTest):
 class TestPolicyManager:
     """Integration test for Ranger policy enforcement."""
 
-    async def test_policy_enforcement(self, ops_test, charm: str, charm_image: str):
+    def test_policy_enforcement(self, juju: jubilant.Juju, charm: str, charm_image: str):
         """Test Ranger integration."""
-        await ops_test.model.deploy(
+        juju.deploy(
             charm,
+            APP_NAME,
             resources={"trino-image": charm_image},
-            application_name=APP_NAME,
             config=TRINO_CONFIG,
             trust=True,
         )
 
-        async with ops_test.fast_forward():
-            await ops_test.model.wait_for_idle(
-                apps=[APP_NAME],
-                status="active",
-                raise_on_blocked=False,
-                timeout=2000,
-            )
+        wait_for_apps(juju, [APP_NAME], status="active", timeout=2000)
 
         logger.info("Creating test user.")
-        url = await get_unit_url(ops_test, application=RANGER_NAME, unit=0, port=6080)
-        await create_user(url)
+        url = get_unit_url(juju, application=RANGER_NAME, unit=0, port=6080)
+        create_user(url)
 
         # Integrate Trino and Ranger.
         logger.info("Integrating Trino and Ranger.")
-        await ops_test.model.integrate(RANGER_NAME, APP_NAME)
+        juju.integrate(RANGER_NAME, APP_NAME)
         time.sleep(30)
-        async with ops_test.fast_forward():
-            await resolve_ranger_errors(ops_test)
-            await ops_test.model.wait_for_idle(
-                apps=[APP_NAME, RANGER_NAME],
-                status="active",
-                raise_on_blocked=False,
-                timeout=2000,
-            )
+        resolve_ranger_errors(juju)
+        wait_for_apps(juju, [APP_NAME, RANGER_NAME], status="active", timeout=2000)
 
         logging.info("update default policies to authorize the new user")
-        await update_policies(url)
+        update_policies(url)
 
         time.sleep(30)  # wait 30 seconds for the policy to be synced.
 
-        catalogs = await get_catalogs(ops_test, USER_WITH_ACCESS, APP_NAME)
+        catalogs = get_catalogs(juju, USER_WITH_ACCESS, APP_NAME)
         assert catalogs == [["system"]]
         logger.info(f"{USER_WITH_ACCESS} can access {catalogs}.")
 
-        catalogs = await get_catalogs(ops_test, USER_WITHOUT_ACCESS, APP_NAME)
+        catalogs = get_catalogs(juju, USER_WITHOUT_ACCESS, APP_NAME)
         logger.info(f"{USER_WITHOUT_ACCESS} can not access {catalogs}.")
         assert catalogs == []

--- a/tests/integration/test_resources.py
+++ b/tests/integration/test_resources.py
@@ -18,6 +18,8 @@ logger = logging.getLogger(__name__)
 @pytest.fixture(name="deploy-resources", scope="module")
 def deploy(juju: jubilant.Juju, charm: str, charm_image: str):
     """Deploy the app."""
+    juju.model_config({"update-status-hook-interval": "10s"})
+
     trino_config = {
         "charm-function": "all",
     }
@@ -30,7 +32,7 @@ def deploy(juju: jubilant.Juju, charm: str, charm_image: str):
         num_units=1,
         trust=True,
     )
-    wait_for_apps(juju, [APP_NAME], status="active", timeout=300)
+    wait_for_apps(juju, [APP_NAME], status="active", timeout=600)
     assert get_unit(juju, APP_NAME).workload_status.current == "active"
 
 

--- a/tests/integration/test_resources.py
+++ b/tests/integration/test_resources.py
@@ -18,8 +18,6 @@ logger = logging.getLogger(__name__)
 @pytest.fixture(name="deploy-resources", scope="module")
 def deploy(juju: jubilant.Juju, charm: str, charm_image: str):
     """Deploy the app."""
-    juju.model_config({"update-status-hook-interval": "10s"})
-
     trino_config = {
         "charm-function": "all",
     }

--- a/tests/integration/test_resources.py
+++ b/tests/integration/test_resources.py
@@ -6,39 +6,32 @@
 import logging
 import time
 
+import jubilant
 import pytest
-import pytest_asyncio
-from helpers import APP_NAME
+from helpers import APP_NAME, get_unit, wait_for_apps
 from lightkube import Client  # pyright: ignore
 from lightkube.resources.apps_v1 import StatefulSet
-from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
 
 
-@pytest_asyncio.fixture(name="deploy-resources", scope="module")
-async def deploy(ops_test: OpsTest, charm: str, charm_image: str):
+@pytest.fixture(name="deploy-resources", scope="module")
+def deploy(juju: jubilant.Juju, charm: str, charm_image: str):
     """Deploy the app."""
     trino_config = {
         "charm-function": "all",
     }
     # Deploy trino with no resource constraints
-    async with ops_test.fast_forward():
-        await ops_test.model.deploy(
-            charm,
-            resources={"trino-image": charm_image},
-            application_name=APP_NAME,
-            config=trino_config,
-            num_units=1,
-            trust=True,
-        )
-        await ops_test.model.wait_for_idle(
-            apps=[APP_NAME],
-            status="active",
-            raise_on_blocked=False,
-            timeout=300,
-        )
-        assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
+    juju.deploy(
+        charm,
+        APP_NAME,
+        resources={"trino-image": charm_image},
+        config=trino_config,
+        num_units=1,
+        trust=True,
+    )
+    wait_for_apps(juju, [APP_NAME], status="active", timeout=300)
+    assert get_unit(juju, APP_NAME).workload_status.current == "active"
 
 
 @pytest.mark.abort_on_fail
@@ -46,22 +39,23 @@ async def deploy(ops_test: OpsTest, charm: str, charm_image: str):
 class TestResources:
     """Integration test for resource limits and requests."""
 
-    async def test_resources_set(self, ops_test):
+    def test_resources_set(self, juju: jubilant.Juju):
         """Test setting resources."""
-        await ops_test.model.applications[APP_NAME].set_config(
+        juju.config(
+            APP_NAME,
             {
                 "workload-memory-requests": "1Gi",
                 "workload-memory-limits": "2Gi",
                 "workload-cpu-requests": "1",
                 "workload-cpu-limits": "2",
-            }
+            },
         )
         time.sleep(10)
         client = Client()
         statefulset = client.get(
             StatefulSet,
             name=APP_NAME,
-            namespace=ops_test.model.name,
+            namespace=juju.model,
         )
 
         containers = statefulset.spec.template.spec.containers

--- a/tests/integration/test_resources.py
+++ b/tests/integration/test_resources.py
@@ -32,7 +32,7 @@ def deploy(juju: jubilant.Juju, charm: str, charm_image: str):
         num_units=1,
         trust=True,
     )
-    wait_for_apps(juju, [APP_NAME], status="active", timeout=600)
+    wait_for_apps(juju, [APP_NAME], status="active", timeout=900)
     assert get_unit(juju, APP_NAME).workload_status.current == "active"
 
 

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -5,9 +5,9 @@
 
 import logging
 
+import jubilant
 import pytest
-from helpers import WORKER_NAME, get_active_workers, scale
-from pytest_operator.plugin import OpsTest
+from helpers import WORKER_NAME, get_active_workers, get_status, scale
 
 logger = logging.getLogger(__name__)
 
@@ -17,18 +17,18 @@ logger = logging.getLogger(__name__)
 class TestScaling:
     """Integration tests for Trino worker scaling."""
 
-    async def test_scaling_up(self, ops_test: OpsTest):
+    def test_scaling_up(self, juju: jubilant.Juju):
         """Scale Trino worker up to 2 units."""
-        await scale(ops_test, app=WORKER_NAME, units=2)
-        assert len(ops_test.model.applications[WORKER_NAME].units) == 2
+        scale(juju, app=WORKER_NAME, units=2)
+        assert len(get_status(juju).apps[WORKER_NAME].units) == 2
 
-        active_workers = await get_active_workers(ops_test)
+        active_workers = get_active_workers(juju)
         assert len(active_workers) == 2
 
-    async def test_scaling_down(self, ops_test: OpsTest):
+    def test_scaling_down(self, juju: jubilant.Juju):
         """Scale Trino worker down to 1 unit."""
-        await scale(ops_test, app=WORKER_NAME, units=1)
-        assert len(ops_test.model.applications[WORKER_NAME].units) == 1
+        scale(juju, app=WORKER_NAME, units=1)
+        assert len(get_status(juju).apps[WORKER_NAME].units) == 1
 
-        active_workers = await get_active_workers(ops_test)
+        active_workers = get_active_workers(juju)
         assert len(active_workers) == 1

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -7,7 +7,7 @@ import logging
 
 import jubilant
 import pytest
-from helpers import WORKER_NAME, get_active_workers, get_status, scale
+from helpers import WORKER_NAME, get_active_workers, scale
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +20,7 @@ class TestScaling:
     def test_scaling_up(self, juju: jubilant.Juju):
         """Scale Trino worker up to 2 units."""
         scale(juju, app=WORKER_NAME, units=2)
-        assert len(get_status(juju).apps[WORKER_NAME].units) == 2
+        assert len(juju.status().apps[WORKER_NAME].units) == 2
 
         active_workers = get_active_workers(juju)
         assert len(active_workers) == 2
@@ -28,7 +28,7 @@ class TestScaling:
     def test_scaling_down(self, juju: jubilant.Juju):
         """Scale Trino worker down to 1 unit."""
         scale(juju, app=WORKER_NAME, units=1)
-        assert len(get_status(juju).apps[WORKER_NAME].units) == 1
+        assert len(juju.status().apps[WORKER_NAME].units) == 1
 
         active_workers = get_active_workers(juju)
         assert len(active_workers) == 1

--- a/tests/integration/test_trino_catalog_relation.py
+++ b/tests/integration/test_trino_catalog_relation.py
@@ -16,7 +16,6 @@ from helpers import (
     add_juju_secret,
     create_catalog_config,
     get_secret_id_by_label,
-    get_status,
     get_unit,
     wait_for_app_gone,
     wait_for_apps,
@@ -69,11 +68,10 @@ def test_02_trino_catalog_relation_created(juju: jubilant.Juju):
     """Test creating the trino-catalog relation."""
     # Add the relation
     juju.integrate(f"{APP_NAME}:trino-catalog", f"{REQUIRER_APP}:trino-catalog")
-    wait_for_apps(juju, [APP_NAME], status="active", timeout=1000)
-    wait_for_apps(juju, [REQUIRER_APP], status="active", timeout=1000)
+    wait_for_apps(juju, [APP_NAME, REQUIRER_APP], status="active", timeout=1000)
 
     # Verify relation exists
-    trino_catalog_relations = get_status(juju).apps[APP_NAME].relations.get("trino-catalog", [])
+    trino_catalog_relations = juju.status().apps[APP_NAME].relations.get("trino-catalog", [])
     assert len(trino_catalog_relations) > 0
 
 
@@ -140,8 +138,7 @@ def test_04_trino_catalog_relation_set_catalogs(juju: jubilant.Juju):
 
     # Update Trino with catalog config
     juju.config(APP_NAME, {"catalog-config": catalog_config})
-    wait_for_apps(juju, [APP_NAME], status="active", timeout=1000)
-    wait_for_apps(juju, [REQUIRER_APP], status="active", timeout=1000)
+    wait_for_apps(juju, [APP_NAME, REQUIRER_APP], status="active", timeout=1000)
 
     # Verify the requirer received the catalogs
     action = juju.run(f"{REQUIRER_APP}/0", "get-relation-data")
@@ -328,7 +325,7 @@ def test_08_multiple_requirers(juju: jubilant.Juju):
     wait_for_apps(juju, [requirer_app_2], status="active", timeout=1000)
 
     # Verify both requirers are connected
-    trino_catalog_relations = get_status(juju).apps[APP_NAME].relations.get("trino-catalog", [])
+    trino_catalog_relations = juju.status().apps[APP_NAME].relations.get("trino-catalog", [])
     # Should have at least 2 relations
     assert len(trino_catalog_relations) >= 2
 
@@ -365,7 +362,7 @@ def test_09_relation_broken(juju: jubilant.Juju):
     wait_for_apps(juju, [REQUIRER_APP], status="blocked", timeout=1000)
 
     # Verify relation is removed
-    trino_catalog_relations = get_status(juju).apps[APP_NAME].relations.get("trino-catalog", [])
+    trino_catalog_relations = juju.status().apps[APP_NAME].relations.get("trino-catalog", [])
     assert len(trino_catalog_relations) == 0
 
     # Requirer should be blocked

--- a/tests/integration/test_trino_catalog_relation.py
+++ b/tests/integration/test_trino_catalog_relation.py
@@ -44,6 +44,8 @@ def deploy_requirer(juju: jubilant.Juju):
 @pytest.fixture(name="deploy-trino", scope="module")
 def deploy_trino(juju: jubilant.Juju, charm: str, charm_image: str):
     """Deploy the trino charm once for all tests in this module."""
+    juju.model_config({"update-status-hook-interval": "10s"})
+
     # Deploy trino charm
     juju.deploy(
         charm,

--- a/tests/integration/test_trino_catalog_relation.py
+++ b/tests/integration/test_trino_catalog_relation.py
@@ -5,17 +5,22 @@
 
 import ast
 import logging
+from pathlib import Path
 
+import jubilant
 import pytest
-import pytest_asyncio
+from conftest import pack_charm
 from helpers import (
     APP_NAME,
     NGINX_NAME,
     add_juju_secret,
     create_catalog_config,
     get_secret_id_by_label,
+    get_status,
+    get_unit,
+    wait_for_app_gone,
+    wait_for_apps,
 )
-from pytest_operator.plugin import OpsTest
 
 from literals import TRINO_PORTS
 
@@ -25,99 +30,58 @@ REQUIRER_APP = "requirer-app"
 REQUIRER_CHARM_PATH = "tests/integration/trino_catalog_requirer_charm"
 
 
-@pytest_asyncio.fixture(name="deploy-requirer", scope="module")
-async def deploy_requirer(ops_test: OpsTest):
+@pytest.fixture(name="deploy-requirer", scope="module")
+def deploy_requirer(juju: jubilant.Juju):
     """Deploy the requirer charm once for all tests in this module."""
     # Build the requirer charm
-    requirer_charm = await ops_test.build_charm(REQUIRER_CHARM_PATH)
+    requirer_charm = pack_charm(Path(REQUIRER_CHARM_PATH))
 
     # Deploy requirer charm
-    async with ops_test.fast_forward():
-        await ops_test.model.deploy(
-            requirer_charm,
-            application_name=REQUIRER_APP,
-            num_units=1,
-        )
-
-        await ops_test.model.wait_for_idle(
-            apps=[REQUIRER_APP],
-            status="blocked",
-            raise_on_blocked=False,
-            timeout=1000,
-        )
+    juju.deploy(requirer_charm, REQUIRER_APP, num_units=1)
+    wait_for_apps(juju, [REQUIRER_APP], status="blocked", timeout=1000)
 
 
-@pytest_asyncio.fixture(name="deploy-trino", scope="module")
-async def deploy_trino(ops_test: OpsTest, charm: str, charm_image: str):
+@pytest.fixture(name="deploy-trino", scope="module")
+def deploy_trino(juju: jubilant.Juju, charm: str, charm_image: str):
     """Deploy the trino charm once for all tests in this module."""
     # Deploy trino charm
-    async with ops_test.fast_forward():
-        await ops_test.model.deploy(
-            charm,
-            resources={"trino-image": charm_image},
-            application_name=APP_NAME,
-            config={
-                "charm-function": "all",
-            },
-            trust=True,
-        )
-
-        await ops_test.model.wait_for_idle(
-            apps=[APP_NAME],
-            status="active",
-            raise_on_blocked=False,
-            timeout=1000,
-        )
+    juju.deploy(
+        charm,
+        APP_NAME,
+        resources={"trino-image": charm_image},
+        config={"charm-function": "all"},
+        trust=True,
+    )
+    wait_for_apps(juju, [APP_NAME], status="active", timeout=1000)
 
 
 @pytest.mark.abort_on_fail
 @pytest.mark.usefixtures("deploy-trino", "deploy-requirer")
-async def test_01_requirer_deployment(ops_test: OpsTest):
+def test_01_requirer_deployment(juju: jubilant.Juju):
     """Test that the requirer charm has been deployed."""
     # Verify requirer is blocked waiting for relation
-    assert ops_test.model.applications[REQUIRER_APP].units[0].workload_status == "blocked"
+    assert get_unit(juju, REQUIRER_APP).workload_status.current == "blocked"
 
 
 @pytest.mark.abort_on_fail
 @pytest.mark.usefixtures("deploy-trino", "deploy-requirer")
-async def test_02_trino_catalog_relation_created(ops_test: OpsTest):
+def test_02_trino_catalog_relation_created(juju: jubilant.Juju):
     """Test creating the trino-catalog relation."""
     # Add the relation
-    async with ops_test.fast_forward():
-        await ops_test.model.integrate(
-            f"{APP_NAME}:trino-catalog", f"{REQUIRER_APP}:trino-catalog"
-        )
-
-        # Wait for relation to settle
-        await ops_test.model.wait_for_idle(
-            apps=[APP_NAME],
-            status="active",
-            raise_on_blocked=False,
-            timeout=1000,
-        )
-
-        await ops_test.model.wait_for_idle(
-            apps=[REQUIRER_APP],
-            status="active",
-            raise_on_blocked=False,
-            timeout=1000,
-        )
+    juju.integrate(f"{APP_NAME}:trino-catalog", f"{REQUIRER_APP}:trino-catalog")
+    wait_for_apps(juju, [APP_NAME], status="active", timeout=1000)
+    wait_for_apps(juju, [REQUIRER_APP], status="active", timeout=1000)
 
     # Verify relation exists
-    trino_catalog_relations = [
-        rel
-        for rel in ops_test.model.applications[APP_NAME].relations
-        if rel.matches(f"{APP_NAME}:trino-catalog")
-    ]
+    trino_catalog_relations = get_status(juju).apps[APP_NAME].relations.get("trino-catalog", [])
     assert len(trino_catalog_relations) > 0
 
 
 @pytest.mark.abort_on_fail
 @pytest.mark.usefixtures("deploy-trino", "deploy-requirer")
-async def test_03_auto_generated_credentials(ops_test: OpsTest):
+def test_03_auto_generated_credentials(juju: jubilant.Juju):
     """Test that per-relation credentials are auto-generated."""
-    action = await ops_test.model.units.get(f"{REQUIRER_APP}/0").run_action("get-relation-data")
-    await action.wait()
+    action = juju.run(f"{REQUIRER_APP}/0", "get-relation-data")
     assert action.status == "completed"
 
     # Verify auto-generated username follows pattern app-{app_name}-{relation_id}
@@ -134,9 +98,7 @@ async def test_03_auto_generated_credentials(ops_test: OpsTest):
 
     # Verify internal URL (no nginx relation at this point)
     result_url = action.results.get("trino-url")
-    expected_internal_url = (
-        f"{APP_NAME}.{ops_test.model.name}.svc.cluster.local:{TRINO_PORTS['HTTP']}"
-    )
+    expected_internal_url = f"{APP_NAME}.{juju.model}.svc.cluster.local:{TRINO_PORTS['HTTP']}"
     assert result_url == expected_internal_url, (
         f"Expected internal URL '{expected_internal_url}', got '{result_url}'"
     )
@@ -150,24 +112,24 @@ async def test_03_auto_generated_credentials(ops_test: OpsTest):
 
 @pytest.mark.abort_on_fail
 @pytest.mark.usefixtures("deploy-trino", "deploy-requirer")
-async def test_04_trino_catalog_relation_set_catalogs(ops_test: OpsTest):
+def test_04_trino_catalog_relation_set_catalogs(juju: jubilant.Juju):
     """Test that catalog-config changes propagate to the requirer."""
     # Create catalog secrets
-    postgresql_secret_id = await add_juju_secret(ops_test, "postgresql")
-    mysql_secret_id = await add_juju_secret(ops_test, "mysql")
-    redshift_secret_id = await add_juju_secret(ops_test, "redshift")
-    bigquery_secret_id = await add_juju_secret(ops_test, "bigquery")
-    gsheets_secret_id = await add_juju_secret(ops_test, "gsheets")
+    postgresql_secret_id = add_juju_secret(juju, "postgresql")
+    mysql_secret_id = add_juju_secret(juju, "mysql")
+    redshift_secret_id = add_juju_secret(juju, "redshift")
+    bigquery_secret_id = add_juju_secret(juju, "bigquery")
+    gsheets_secret_id = add_juju_secret(juju, "gsheets")
 
     # Grant secrets to Trino
-    await ops_test.model.grant_secret("postgresql-secret", APP_NAME)
-    await ops_test.model.grant_secret("mysql-secret", APP_NAME)
-    await ops_test.model.grant_secret("redshift-secret", APP_NAME)
-    await ops_test.model.grant_secret("bigquery-secret", APP_NAME)
-    await ops_test.model.grant_secret("gsheets-secret", APP_NAME)
+    juju.grant_secret("postgresql-secret", APP_NAME)
+    juju.grant_secret("mysql-secret", APP_NAME)
+    juju.grant_secret("redshift-secret", APP_NAME)
+    juju.grant_secret("bigquery-secret", APP_NAME)
+    juju.grant_secret("gsheets-secret", APP_NAME)
 
     # Create catalog config
-    catalog_config = await create_catalog_config(
+    catalog_config = create_catalog_config(
         postgresql_secret_id,
         mysql_secret_id,
         redshift_secret_id,
@@ -177,26 +139,12 @@ async def test_04_trino_catalog_relation_set_catalogs(ops_test: OpsTest):
     )
 
     # Update Trino with catalog config
-    async with ops_test.fast_forward():
-        await ops_test.model.applications[APP_NAME].set_config({"catalog-config": catalog_config})
-
-        # Wait for Trino to be ready
-        await ops_test.model.wait_for_idle(
-            apps=[APP_NAME],
-            status="active",
-            timeout=1000,
-        )
-
-        # Requirer stays active
-        await ops_test.model.wait_for_idle(
-            apps=[REQUIRER_APP],
-            status="active",
-            timeout=1000,
-        )
+    juju.config(APP_NAME, {"catalog-config": catalog_config})
+    wait_for_apps(juju, [APP_NAME], status="active", timeout=1000)
+    wait_for_apps(juju, [REQUIRER_APP], status="active", timeout=1000)
 
     # Verify the requirer received the catalogs
-    action = await ops_test.model.units.get(f"{REQUIRER_APP}/0").run_action("get-relation-data")
-    await action.wait()
+    action = juju.run(f"{REQUIRER_APP}/0", "get-relation-data")
     assert action.status == "completed"
 
     # Parse the catalogs list from string representation
@@ -228,25 +176,16 @@ async def test_04_trino_catalog_relation_set_catalogs(ops_test: OpsTest):
 
 @pytest.mark.abort_on_fail
 @pytest.mark.usefixtures("deploy-trino", "deploy-requirer")
-async def test_05_catalog_exclusions(ops_test: OpsTest):
+def test_05_catalog_exclusions(juju: jubilant.Juju):
     """Test that catalog-exclusions filters catalogs for a specific requirer."""
     # Exclude one catalog for the requirer app
     exclusion_config = f"{REQUIRER_APP}:\n  - postgresql-1"
 
-    async with ops_test.fast_forward():
-        await ops_test.model.applications[APP_NAME].set_config(
-            {"catalog-exclusions": exclusion_config}
-        )
-
-        await ops_test.model.wait_for_idle(
-            apps=[APP_NAME],
-            status="active",
-            timeout=1000,
-        )
+    juju.config(APP_NAME, {"catalog-exclusions": exclusion_config})
+    wait_for_apps(juju, [APP_NAME], status="active", timeout=1000)
 
     # Verify the requirer receives 4 catalogs (postgresql-1 excluded)
-    action = await ops_test.model.units.get(f"{REQUIRER_APP}/0").run_action("get-relation-data")
-    await action.wait()
+    action = juju.run(f"{REQUIRER_APP}/0", "get-relation-data")
     assert action.status == "completed"
 
     catalogs_str = action.results.get("trino-catalogs", "[]")
@@ -259,17 +198,10 @@ async def test_05_catalog_exclusions(ops_test: OpsTest):
     assert len(catalogs) == 4, f"Expected 4 catalogs, got {len(catalogs)}"
 
     # Reset exclusions and verify all catalogs are restored
-    async with ops_test.fast_forward():
-        await ops_test.model.applications[APP_NAME].reset_config(["catalog-exclusions"])
+    juju.config(APP_NAME, reset=["catalog-exclusions"])
+    wait_for_apps(juju, [APP_NAME], status="active", timeout=1000)
 
-        await ops_test.model.wait_for_idle(
-            apps=[APP_NAME],
-            status="active",
-            timeout=1000,
-        )
-
-    action = await ops_test.model.units.get(f"{REQUIRER_APP}/0").run_action("get-relation-data")
-    await action.wait()
+    action = juju.run(f"{REQUIRER_APP}/0", "get-relation-data")
     assert action.status == "completed"
 
     catalogs_str = action.results.get("trino-catalogs", "[]")
@@ -286,46 +218,24 @@ async def test_05_catalog_exclusions(ops_test: OpsTest):
 
 @pytest.mark.abort_on_fail
 @pytest.mark.usefixtures("deploy-trino", "deploy-requirer")
-async def test_06_trino_catalog_external_url_with_nginx(
-    ops_test: OpsTest,
+def test_06_trino_catalog_external_url_with_nginx(
+    juju: jubilant.Juju,
 ):
     """Test that the requirer receives external URL when nginx-route relation exists."""
     # Deploy nginx-ingress-integrator
-    async with ops_test.fast_forward():
-        await ops_test.model.deploy(NGINX_NAME, trust=True)
-
-        await ops_test.model.wait_for_idle(
-            apps=[NGINX_NAME],
-            status="waiting",
-            raise_on_blocked=False,
-            timeout=1000,
-        )
+    juju.deploy(NGINX_NAME, trust=True)
+    wait_for_apps(juju, [NGINX_NAME], status="waiting", timeout=1000)
 
     # Relate Trino to nginx-ingress-integrator
-    async with ops_test.fast_forward():
-        await ops_test.model.integrate(APP_NAME, NGINX_NAME)
-
-        await ops_test.model.wait_for_idle(
-            apps=[APP_NAME],
-            status="active",
-            timeout=1000,
-        )
+    juju.integrate(APP_NAME, NGINX_NAME)
+    wait_for_apps(juju, [APP_NAME], status="active", timeout=1000)
 
     # Set external-hostname config
-    async with ops_test.fast_forward():
-        await ops_test.model.applications[APP_NAME].set_config(
-            {"external-hostname": "trino.test.com"}
-        )
-
-        await ops_test.model.wait_for_idle(
-            apps=[APP_NAME],
-            status="active",
-            timeout=1000,
-        )
+    juju.config(APP_NAME, {"external-hostname": "trino.test.com"})
+    wait_for_apps(juju, [APP_NAME], status="active", timeout=1000)
 
     # Verify the requirer received the external URL
-    action = await ops_test.model.units.get(f"{REQUIRER_APP}/0").run_action("get-relation-data")
-    await action.wait()
+    action = juju.run(f"{REQUIRER_APP}/0", "get-relation-data")
     assert action.status == "completed"
 
     result_url = action.results.get("trino-url")
@@ -336,39 +246,22 @@ async def test_06_trino_catalog_external_url_with_nginx(
     logger.info("Verified requirer received external Trino URL: %s", result_url)
 
     # Clean up: remove nginx relation and reset external-hostname
-    async with ops_test.fast_forward():
-        await ops_test.juju(
-            "remove-relation",
-            APP_NAME,
-            NGINX_NAME,
-        )
-
-        await ops_test.model.wait_for_idle(
-            apps=[APP_NAME],
-            status="active",
-            timeout=1000,
-        )
-
-    async with ops_test.fast_forward():
-        await ops_test.model.applications[APP_NAME].reset_config(["external-hostname"])
-
-        await ops_test.model.wait_for_idle(
-            apps=[APP_NAME],
-            status="active",
-            timeout=1000,
-        )
+    juju.remove_relation(APP_NAME, NGINX_NAME)
+    wait_for_apps(juju, [APP_NAME], status="active", timeout=1000)
+    juju.config(APP_NAME, reset=["external-hostname"])
+    wait_for_apps(juju, [APP_NAME], status="active", timeout=1000)
 
 
 @pytest.mark.abort_on_fail
 @pytest.mark.usefixtures("deploy-trino", "deploy-requirer")
-async def test_07_catalog_config_propagation(ops_test: OpsTest):
+def test_07_catalog_config_propagation(juju: jubilant.Juju):
     """Test that catalog-config changes propagate to the requirer."""
     # Get catalog secrets
-    postgresql_secret_id = await get_secret_id_by_label(ops_test, "postgresql-secret")
-    mysql_secret_id = await get_secret_id_by_label(ops_test, "mysql-secret")
-    redshift_secret_id = await get_secret_id_by_label(ops_test, "redshift-secret")
-    bigquery_secret_id = await get_secret_id_by_label(ops_test, "bigquery-secret")
-    gsheets_secret_id = await get_secret_id_by_label(ops_test, "gsheets-secret")
+    postgresql_secret_id = get_secret_id_by_label(juju, "postgresql-secret")
+    mysql_secret_id = get_secret_id_by_label(juju, "mysql-secret")
+    redshift_secret_id = get_secret_id_by_label(juju, "redshift-secret")
+    bigquery_secret_id = get_secret_id_by_label(juju, "bigquery-secret")
+    gsheets_secret_id = get_secret_id_by_label(juju, "gsheets-secret")
 
     logger.info("PostgreSQL secret ID: %s", postgresql_secret_id)
     logger.info("MySQL secret ID: %s", mysql_secret_id)
@@ -377,7 +270,7 @@ async def test_07_catalog_config_propagation(ops_test: OpsTest):
     logger.info("GSheets secret ID: %s", gsheets_secret_id)
 
     # Update to remove bigquery
-    catalog_config_without_bigquery = await create_catalog_config(
+    catalog_config_without_bigquery = create_catalog_config(
         postgresql_secret_id,
         mysql_secret_id,
         redshift_secret_id,
@@ -386,20 +279,11 @@ async def test_07_catalog_config_propagation(ops_test: OpsTest):
         include_bigquery=False,
     )
 
-    async with ops_test.fast_forward():
-        await ops_test.model.applications[APP_NAME].set_config(
-            {"catalog-config": catalog_config_without_bigquery}
-        )
-
-        await ops_test.model.wait_for_idle(
-            apps=[APP_NAME],
-            status="active",
-            timeout=1000,
-        )
+    juju.config(APP_NAME, {"catalog-config": catalog_config_without_bigquery})
+    wait_for_apps(juju, [APP_NAME], status="active", timeout=1000)
 
     # Verify the requirer received the updated catalogs (without bigquery)
-    action = await ops_test.model.units.get(f"{REQUIRER_APP}/0").run_action("get-relation-data")
-    await action.wait()
+    action = juju.run(f"{REQUIRER_APP}/0", "get-relation-data")
     assert action.status == "completed"
 
     # Parse the catalogs list from string representation
@@ -430,54 +314,27 @@ async def test_07_catalog_config_propagation(ops_test: OpsTest):
 
 @pytest.mark.abort_on_fail
 @pytest.mark.usefixtures("deploy-trino", "deploy-requirer")
-async def test_08_multiple_requirers(ops_test: OpsTest):
+def test_08_multiple_requirers(juju: jubilant.Juju):
     """Test that multiple requirers each get separate auto-generated credentials."""
     # Deploy a second requirer
-    requirer_charm = await ops_test.build_charm(REQUIRER_CHARM_PATH)
+    requirer_charm = pack_charm(Path(REQUIRER_CHARM_PATH))
     requirer_app_2 = "second-requirer"
 
-    async with ops_test.fast_forward():
-        await ops_test.model.deploy(
-            requirer_charm,
-            application_name=requirer_app_2,
-            num_units=1,
-        )
-
-        await ops_test.model.wait_for_idle(
-            apps=[requirer_app_2],
-            status="blocked",
-            timeout=1000,
-        )
+    juju.deploy(requirer_charm, requirer_app_2, num_units=1)
+    wait_for_apps(juju, [requirer_app_2], status="blocked", timeout=1000)
 
     # Relate second requirer to Trino
-    async with ops_test.fast_forward():
-        await ops_test.model.integrate(
-            f"{APP_NAME}:trino-catalog", f"{requirer_app_2}:trino-catalog"
-        )
-
-        await ops_test.model.wait_for_idle(
-            apps=[requirer_app_2],
-            status="active",
-            raise_on_blocked=False,
-            timeout=1000,
-        )
+    juju.integrate(f"{APP_NAME}:trino-catalog", f"{requirer_app_2}:trino-catalog")
+    wait_for_apps(juju, [requirer_app_2], status="active", timeout=1000)
 
     # Verify both requirers are connected
-    trino_catalog_relations = [
-        rel
-        for rel in ops_test.model.applications[APP_NAME].relations
-        if rel.matches(f"{APP_NAME}:trino-catalog")
-    ]
+    trino_catalog_relations = get_status(juju).apps[APP_NAME].relations.get("trino-catalog", [])
     # Should have at least 2 relations
     assert len(trino_catalog_relations) >= 2
 
     # Verify each requirer got different credentials
-    action_1 = await ops_test.model.units.get(f"{REQUIRER_APP}/0").run_action("get-relation-data")
-    await action_1.wait()
-    action_2 = await ops_test.model.units.get(f"{requirer_app_2}/0").run_action(
-        "get-relation-data"
-    )
-    await action_2.wait()
+    action_1 = juju.run(f"{REQUIRER_APP}/0", "get-relation-data")
+    action_2 = juju.run(f"{requirer_app_2}/0", "get-relation-data")
 
     username_1 = action_1.results.get("trino-username")
     username_2 = action_2.results.get("trino-username")
@@ -495,36 +352,21 @@ async def test_08_multiple_requirers(ops_test: OpsTest):
     )
 
     # Clean up second requirer
-    async with ops_test.fast_forward():
-        await ops_test.model.remove_application(requirer_app_2, block_until_done=True)
+    juju.remove_application(requirer_app_2)
+    wait_for_app_gone(juju, requirer_app_2)
 
 
 @pytest.mark.abort_on_fail
 @pytest.mark.usefixtures("deploy-trino", "deploy-requirer")
-async def test_09_relation_broken(ops_test: OpsTest):
+def test_09_relation_broken(juju: jubilant.Juju):
     """Test that relation can be broken cleanly."""
     # Remove the relation
-    async with ops_test.fast_forward():
-        await ops_test.juju(
-            "remove-relation",
-            f"{APP_NAME}:trino-catalog",
-            f"{REQUIRER_APP}:trino-catalog",
-        )
-
-        await ops_test.model.wait_for_idle(
-            apps=[REQUIRER_APP],
-            status="blocked",
-            raise_on_blocked=False,
-            timeout=1000,
-        )
+    juju.remove_relation(f"{APP_NAME}:trino-catalog", f"{REQUIRER_APP}:trino-catalog")
+    wait_for_apps(juju, [REQUIRER_APP], status="blocked", timeout=1000)
 
     # Verify relation is removed
-    trino_catalog_relations = [
-        rel
-        for rel in ops_test.model.applications[APP_NAME].relations
-        if rel.matches(f"{APP_NAME}:trino-catalog")
-    ]
+    trino_catalog_relations = get_status(juju).apps[APP_NAME].relations.get("trino-catalog", [])
     assert len(trino_catalog_relations) == 0
 
     # Requirer should be blocked
-    assert ops_test.model.applications[REQUIRER_APP].units[0].workload_status == "blocked"
+    assert get_unit(juju, REQUIRER_APP).workload_status.current == "blocked"

--- a/tests/integration/test_trino_catalog_relation.py
+++ b/tests/integration/test_trino_catalog_relation.py
@@ -44,8 +44,6 @@ def deploy_requirer(juju: jubilant.Juju):
 @pytest.fixture(name="deploy-trino", scope="module")
 def deploy_trino(juju: jubilant.Juju, charm: str, charm_image: str):
     """Deploy the trino charm once for all tests in this module."""
-    juju.model_config({"update-status-hook-interval": "10s"})
-
     # Deploy trino charm
     juju.deploy(
         charm,

--- a/tests/integration/test_upgrades.py
+++ b/tests/integration/test_upgrades.py
@@ -16,6 +16,8 @@ logger = logging.getLogger(__name__)
 @pytest.fixture(name="deploy-upgrade", scope="module")
 def deploy(juju: jubilant.Juju):
     """Deploy the app."""
+    juju.model_config({"update-status-hook-interval": "10s"})
+
     # Deploy trino and nginx charms
     trino_config = {
         "acl-mode-default": "none",

--- a/tests/integration/test_upgrades.py
+++ b/tests/integration/test_upgrades.py
@@ -5,34 +5,26 @@
 
 import logging
 
+import jubilant
 import pytest
-import pytest_asyncio
 import requests
-import yaml
-from helpers import APP_NAME, get_unit_url
-from pytest_operator.plugin import OpsTest
+from helpers import APP_NAME, get_unit, get_unit_url, wait_for_apps
 
 logger = logging.getLogger(__name__)
 
 
-@pytest_asyncio.fixture(name="deploy-upgrade", scope="module")
-async def deploy(ops_test: OpsTest):
+@pytest.fixture(name="deploy-upgrade", scope="module")
+def deploy(juju: jubilant.Juju):
     """Deploy the app."""
     # Deploy trino and nginx charms
     trino_config = {
         "acl-mode-default": "none",
         "charm-function": "all",
     }
-    await ops_test.model.deploy(APP_NAME, channel="edge", config=trino_config, trust=True)
+    juju.deploy(APP_NAME, channel="edge", config=trino_config, trust=True)
 
-    async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(
-            apps=[APP_NAME],
-            status="active",
-            raise_on_blocked=False,
-            timeout=600,
-        )
-        assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
+    wait_for_apps(juju, [APP_NAME], status="active", timeout=600)
+    assert get_unit(juju, APP_NAME).workload_status.current == "active"
 
 
 @pytest.mark.abort_on_fail
@@ -40,36 +32,23 @@ async def deploy(ops_test: OpsTest):
 class TestUpgrade:
     """Integration test for Trino charm upgrade from previous release."""
 
-    async def test_upgrade(self, ops_test: OpsTest, charm: str, charm_image: str):
+    def test_upgrade(self, juju: jubilant.Juju, charm: str, charm_image: str):
         """Builds the current charm and refreshes the current deployment."""
-        await ops_test.model.applications[APP_NAME].refresh(
-            path=str(charm), resources={"trino-image": charm_image}
-        )
+        juju.refresh(APP_NAME, path=str(charm), resources={"trino-image": charm_image})
 
-        async with ops_test.fast_forward():
-            await ops_test.model.wait_for_idle(
-                apps=[APP_NAME],
-                status="active",
-                raise_on_blocked=False,
-                timeout=600,
-            )
+        wait_for_apps(juju, [APP_NAME], status="active", timeout=600)
+        assert get_unit(juju, APP_NAME).workload_status.current == "active"
 
-            assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
-
-    async def test_ui_relation(self, ops_test: OpsTest):
+    def test_ui_relation(self, juju: jubilant.Juju):
         """Perform GET request on the Trino UI host."""
-        url = await get_unit_url(ops_test, application=APP_NAME, unit=0, port=8080)
+        url = get_unit_url(juju, application=APP_NAME, unit=0, port=8080)
         logger.info("curling app address: %s", url)
 
         response = requests.get(url, timeout=300)
         assert response.status_code == 200
 
-    async def test_config_unchanged(self, ops_test: OpsTest):
+    def test_config_unchanged(self, juju: jubilant.Juju):
         """Validate config remains unchanged."""
-        command = ["config", "trino-k8s"]
-        returncode, stdout, stderr = await ops_test.juju(*command, check=True)
-        if stderr:
-            logger.error(f"{returncode}: {stderr}")
-        config = yaml.safe_load(stdout)
-        acl_mode_default = config["settings"]["acl-mode-default"]["value"]
+        config = juju.config(APP_NAME)
+        acl_mode_default = config["acl-mode-default"]
         assert acl_mode_default == "none"

--- a/tests/integration/test_upgrades.py
+++ b/tests/integration/test_upgrades.py
@@ -16,8 +16,6 @@ logger = logging.getLogger(__name__)
 @pytest.fixture(name="deploy-upgrade", scope="module")
 def deploy(juju: jubilant.Juju):
     """Deploy the app."""
-    juju.model_config({"update-status-hook-interval": "10s"})
-
     # Deploy trino and nginx charms
     trino_config = {
         "acl-mode-default": "none",

--- a/tests/integration/test_upgrades.py
+++ b/tests/integration/test_upgrades.py
@@ -25,7 +25,7 @@ def deploy(juju: jubilant.Juju):
     }
     juju.deploy(APP_NAME, channel="edge", config=trino_config, trust=True)
 
-    wait_for_apps(juju, [APP_NAME], status="active", timeout=600)
+    wait_for_apps(juju, [APP_NAME], status="active", timeout=900)
     assert get_unit(juju, APP_NAME).workload_status.current == "active"
 
 

--- a/tests/integration/test_upgrades.py
+++ b/tests/integration/test_upgrades.py
@@ -51,4 +51,6 @@ class TestUpgrade:
         """Validate config remains unchanged."""
         config = juju.config(APP_NAME)
         acl_mode_default = config["acl-mode-default"]
+
+        # Default is `owner` but we deploy with `none`.
         assert acl_mode_default == "none"

--- a/tests/integration/trino_client/trino_client.py
+++ b/tests/integration/trino_client/trino_client.py
@@ -4,16 +4,29 @@
 
 """Trino client activity."""
 
+import logging
+import time
+
+import trino.exceptions
 from trino.dbapi import connect
 
+logger = logging.getLogger(__name__)
 
-def query_trino(host, user, query) -> str:
+
+def query_trino(host, user, query, max_wait=120, retry_interval=10) -> str:
     """Trino catalogs.
+
+    Retries transient `SERVER_STARTING_UP` errors, which occur when the Trino
+    server process is up but still initializing (e.g. shortly after a restart
+    triggered by a config change). All other errors are raised immediately.
 
     Args:
         host: trino server address.
         user: the user with which to access Trino.
         query: query to execute.
+        max_wait: maximum total seconds to keep retrying while the server is
+            still initializing.
+        retry_interval: seconds to wait between retries.
 
     Returns:
         result: list of Trino catalogs
@@ -26,6 +39,15 @@ def query_trino(host, user, query) -> str:
         verify=False,
     )
     cur = conn.cursor()
-    cur.execute(query)
-    result = cur.fetchall()
-    return result
+
+    deadline = time.time() + max_wait
+    while True:
+        try:
+            cur.execute(query)
+            result = cur.fetchall()
+            return result
+        except trino.exceptions.TrinoQueryError as err:
+            if err.error_name != "SERVER_STARTING_UP" or time.time() >= deadline:
+                raise
+            logger.info("Trino server is still initializing, retrying in %ss", retry_interval)
+            time.sleep(retry_interval)

--- a/tests/integration/trino_client/trino_client.py
+++ b/tests/integration/trino_client/trino_client.py
@@ -7,7 +7,7 @@
 from trino.dbapi import connect
 
 
-async def query_trino(host, user, query) -> str:
+def query_trino(host, user, query) -> str:
     """Trino catalogs.
 
     Args:

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -3,7 +3,3 @@
 
 
 """Unit tests config."""
-
-import ops.testing
-
-ops.testing.SIMULATE_CAN_CONNECT = True

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -15,7 +15,7 @@ from charm import TrinoK8SCharm
 _CHARM_ROOT = pathlib.Path(__file__).parents[2]
 _CHARMCRAFT = yaml.safe_load((_CHARM_ROOT / "charmcraft.yaml").read_text())
 
-# Keys from the unified ``charmcraft.yaml`` that make up the charm metadata.
+# Keys from the unified `charmcraft.yaml` that make up the charm metadata.
 _META_KEYS = (
     "name",
     "summary",
@@ -31,13 +31,13 @@ _META_KEYS = (
 
 
 def _charm_meta() -> dict:
-    """Build the charm metadata mapping from ``charmcraft.yaml``."""
+    """Build the charm metadata mapping from `charmcraft.yaml`."""
     return {key: _CHARMCRAFT[key] for key in _META_KEYS if key in _CHARMCRAFT}
 
 
 @pytest.fixture
 def ctx():
-    """Return a Scenario ``Context`` for the Trino charm.
+    """Return a Scenario `Context` for the Trino charm.
 
     The Kubernetes statefulset patch is mocked for the duration of the test so
     that charm initialisation does not reach out to a real cluster.

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,51 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Shared fixtures for the Scenario-based unit tests."""
+
+import pathlib
+from unittest import mock
+
+import pytest
+import yaml
+from ops.testing import Context
+
+from charm import TrinoK8SCharm
+
+_CHARM_ROOT = pathlib.Path(__file__).parents[2]
+_CHARMCRAFT = yaml.safe_load((_CHARM_ROOT / "charmcraft.yaml").read_text())
+
+# Keys from the unified ``charmcraft.yaml`` that make up the charm metadata.
+_META_KEYS = (
+    "name",
+    "summary",
+    "description",
+    "assumes",
+    "containers",
+    "resources",
+    "storage",
+    "requires",
+    "provides",
+    "peers",
+)
+
+
+def _charm_meta() -> dict:
+    """Build the charm metadata mapping from ``charmcraft.yaml``."""
+    return {key: _CHARMCRAFT[key] for key in _META_KEYS if key in _CHARMCRAFT}
+
+
+@pytest.fixture
+def ctx():
+    """Return a Scenario ``Context`` for the Trino charm.
+
+    The Kubernetes statefulset patch is mocked for the duration of the test so
+    that charm initialisation does not reach out to a real cluster.
+    """
+    with mock.patch("charm.KubernetesStatefulsetPatch"):
+        yield Context(
+            TrinoK8SCharm,
+            meta=_charm_meta(),
+            config=_CHARMCRAFT["config"],
+            actions=_CHARMCRAFT["actions"],
+        )

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -2,9 +2,17 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Literals used by the Trino K8s charm unit tests."""
+"""Literals and Scenario state builders for the Trino K8s charm unit tests."""
+
+import dataclasses
+import json
+from types import SimpleNamespace
+
+from ops.testing import Container, Exec, Model, PeerRelation, Relation, Secret, State
 
 SERVER_PORT = "8080"
+
+MODEL_NAME = "trino-model"
 
 GSHEET_SECRET = """\
 gsheets-1: |
@@ -126,200 +134,258 @@ UPDATED_JVM_OPTIONS = " ".join(
 )
 
 
-def simulate_lifecycle_worker(harness):
-    """Establish a relation between Trino worker and coordinator.
+def trino_container(can_connect=True, **kwargs):
+    """Build the Trino workload container with the standard mocked execs.
 
     Args:
-        harness: ops.testing.Harness object used to simulate trino relation.
+        can_connect: whether Pebble is reachable.
+        kwargs: extra keyword arguments forwarded to ``Container``.
 
     Returns:
-        container: the trino application container.
-        event: the relation event.
+        A Scenario ``Container`` for the ``trino`` workload.
     """
-    # Simulate peer relation readiness.
-    harness.add_relation("peer", "trino")
-
-    # Simulate pebble readiness.
-    harness.handle_exec("trino", ["keytool"], result=0)
-    harness.handle_exec("trino", ["htpasswd"], result=0)
-    harness.handle_exec("trino", ["/bin/sh"], result="/usr/lib/jvm/java-25-openjdk-amd64/")
-    harness.update_config({"charm-function": "worker"})
-
-    # Add catalog secrets
-    bigquery_secret_id = harness.add_model_secret(
-        "trino-k8s",
-        {"service-accounts": BIGQUERY_SECRET},
-    )
-
-    postgresql_secret_id = harness.add_model_secret(
-        "trino-k8s",
-        {
-            "replicas": POSTGRESQL_REPLICA_SECRET,
-            "cert": POSTGRESQL_REPLICA_CERT,
+    return Container(
+        "trino",
+        can_connect=can_connect,
+        execs={
+            Exec(["htpasswd"], return_code=0),
+            Exec(["keytool"], return_code=0),
+            Exec(["/bin/sh"], stdout="/usr/lib/jvm/java-25-openjdk-amd64/"),
+            Exec(["bash"], return_code=0),
         },
-    )
-    mysql_secret_id = harness.add_model_secret(
-        "trino-k8s",
-        {"replicas": MYSQL_REPLICA_SECRET},
-    )
-    redshift_secret_id = harness.add_model_secret(
-        "trino-k8s",
-        {"replicas": REDSHIFT_REPLICA_SECRET},
-    )
-    gsheets_secret_id = harness.add_model_secret(
-        "trino-k8s",
-        {"service-accounts": GSHEET_SECRET},
-    )
-    catalog_config = create_catalog_config(
-        postgresql_secret_id,
-        mysql_secret_id,
-        redshift_secret_id,
-        bigquery_secret_id,
-        gsheets_secret_id,
+        **kwargs,
     )
 
-    container = harness.model.unit.get_container("trino")
-    harness.charm.on.trino_pebble_ready.emit(container)
 
-    rel_id = harness.add_relation("trino-worker", "trino-k8s")
-    harness.add_relation_unit(rel_id, "trino-k8s-worker/0")
+def observer_secret(content):
+    """Build an observer (remotely owned, granted) Juju secret.
 
-    # Simulate coordinator publishing the int-comms secret via Juju secrets.
-    # The secret is owned by the charm under test, so no explicit grant is needed
-    # in the harness — the charm can already resolve it by ID.
-    int_comms_secret_id = harness.add_model_secret(
-        "trino-k8s",
-        {"secret": "test-int-comms-secret"},  # nosec
+    Args:
+        content: the secret content mapping.
+
+    Returns:
+        A Scenario ``Secret`` the charm can read with ``get_content(refresh=True)``.
+    """
+    return Secret(tracked_content=content, owner=None)
+
+
+def catalog_secrets():
+    """Create the standard set of catalog secrets used by the lifecycle helpers.
+
+    Returns:
+        A ``SimpleNamespace`` with the individual secret objects, a ``catalogs``
+        set of all secrets, and the rendered ``catalog_config`` string.
+    """
+    bigquery = observer_secret({"service-accounts": BIGQUERY_SECRET})
+    postgresql = observer_secret(
+        {"replicas": POSTGRESQL_REPLICA_SECRET, "cert": POSTGRESQL_REPLICA_CERT}
     )
+    mysql = observer_secret({"replicas": MYSQL_REPLICA_SECRET})
+    redshift = observer_secret({"replicas": REDSHIFT_REPLICA_SECRET})
+    gsheets = observer_secret({"service-accounts": GSHEET_SECRET})
+    ns = SimpleNamespace(
+        bigquery=bigquery,
+        postgresql=postgresql,
+        mysql=mysql,
+        redshift=redshift,
+        gsheets=gsheets,
+    )
+    ns.catalogs = {bigquery, postgresql, mysql, redshift, gsheets}
+    ns.catalog_config = create_catalog_config(
+        postgresql.id,
+        mysql.id,
+        redshift.id,
+        bigquery.id,
+        gsheets.id,
+    )
+    return ns
 
-    data = {
-        "trino-worker": {
-            "discovery-uri": "http://trino-k8s:8080",
-            "catalogs": catalog_config,
-            "int-comms-secret-id": int_comms_secret_id,
-        }
+
+def build_coordinator_state(
+    *,
+    leader=True,
+    config=None,
+    extra_relations=(),
+    extra_secrets=(),
+    container=None,
+):
+    """Build the input ``State`` for a healthy Trino coordinator.
+
+    Mirrors the end-state established by the legacy ``simulate_lifecycle_coordinator``
+    Harness helper: peer relation ready, catalog and user secrets present,
+    ``charm-function`` set to ``coordinator`` and a ``trino-coordinator`` relation.
+
+    Args:
+        leader: whether the unit is the leader.
+        config: extra config options merged over the coordinator defaults.
+        extra_relations: additional relations to include in the state.
+        extra_secrets: additional secrets to include in the state.
+        container: an explicit container to use instead of the default.
+
+    Returns:
+        A ``(State, SimpleNamespace)`` tuple. The namespace carries the catalog
+        secret IDs, the ``catalog_config`` string and the relation objects so
+        tests can inspect the output databags.
+    """
+    cats = catalog_secrets()
+    user = observer_secret({"users": TEST_USERS})
+    coordinator_relation = Relation("trino-coordinator", remote_app_name="trino-k8s-worker")
+    peer_relation = PeerRelation("peer")
+
+    base_config = {
+        "catalog-config": cats.catalog_config,
+        "charm-function": "coordinator",
+        "user-secret-id": user.id,
     }
-    event = make_relation_event("trino-worker", rel_id, data)
-    harness.charm.trino_worker._on_relation_changed(event)
-    return (
-        container,
-        event,
-        postgresql_secret_id,
-        mysql_secret_id,
-        redshift_secret_id,
-        bigquery_secret_id,
-        gsheets_secret_id,
+    if config:
+        base_config.update(config)
+
+    state = State(
+        leader=leader,
+        model=Model(name=MODEL_NAME),
+        config=base_config,
+        containers={container or trino_container()},
+        relations={peer_relation, coordinator_relation, *extra_relations},
+        secrets={user, *cats.catalogs, *extra_secrets},
     )
+    ids = SimpleNamespace(
+        postgresql=cats.postgresql.id,
+        mysql=cats.mysql.id,
+        redshift=cats.redshift.id,
+        bigquery=cats.bigquery.id,
+        gsheets=cats.gsheets.id,
+        user=user.id,
+        catalog_config=cats.catalog_config,
+        coordinator_relation=coordinator_relation,
+        peer_relation=peer_relation,
+    )
+    return state, ids
 
 
-def simulate_lifecycle_coordinator(harness):
-    """Simulate a healthy charm life-cycle.
+def build_worker_state(
+    *,
+    leader=True,
+    config=None,
+    catalogs=None,
+    include_int_comms=True,
+    extra_relations=(),
+    extra_secrets=(),
+    container=None,
+):
+    """Build the input ``State`` for a Trino worker related to a coordinator.
+
+    Mirrors the end-state established by the legacy ``simulate_lifecycle_worker``
+    Harness helper. The ``trino-worker`` relation carries the coordinator's
+    published data so a ``relation-changed`` event reproduces worker behaviour.
 
     Args:
-        harness: ops.testing.Harness object used to simulate charm lifecycle.
+        leader: whether the unit is the leader.
+        config: extra config options merged over the worker defaults.
+        catalogs: explicit catalog-config to advertise (defaults to the standard one).
+        include_int_comms: whether the coordinator has published an int-comms secret.
+        extra_relations: additional relations to include in the state.
+        extra_secrets: additional secrets to include in the state.
+        container: an explicit container to use instead of the default.
 
     Returns:
-        rel_id: the relation ID of the trino coordinator:worker relation.
+        A ``(State, SimpleNamespace)`` tuple. The namespace carries the catalog
+        secret IDs, the ``catalog_config`` string, the int-comms secret and the
+        relation objects.
     """
-    # Simulate peer relation readiness.
-    harness.add_relation("peer", "trino")
+    cats = catalog_secrets()
+    catalog_config = cats.catalog_config if catalogs is None else catalogs
+    secrets = set(cats.catalogs)
 
-    # Simulate pebble readiness.
-    container = harness.model.unit.get_container("trino")
-    harness.handle_exec("trino", ["htpasswd"], result=0)
-    harness.handle_exec("trino", ["/bin/sh"], result="/usr/lib/jvm/java-25-openjdk-amd64/")
-    harness.handle_exec("trino", ["keytool"], result=0)
-    harness.charm.on.trino_pebble_ready.emit(container)
+    remote_data = {
+        "discovery-uri": "http://trino-k8s:8080",
+        "catalogs": catalog_config,
+    }
+    int_comms = None
+    if include_int_comms:
+        int_comms = observer_secret({"secret": "test-int-comms-secret"})  # nosec B105
+        secrets.add(int_comms)
+        remote_data["int-comms-secret-id"] = int_comms.id
 
-    secret_id = harness.add_model_secret(
-        "trino-k8s",
-        {"users": TEST_USERS},
+    worker_relation = Relation(
+        "trino-worker",
+        remote_app_name="trino-k8s-coordinator",
+        remote_app_data=remote_data,
     )
+    peer_relation = PeerRelation("peer")
 
-    harness.charm.on.trino_pebble_ready.emit(container)
+    base_config = {"charm-function": "worker"}
+    if config:
+        base_config.update(config)
 
-    # Add catalog secrets
-    bigquery_secret_id = harness.add_model_secret(
-        "trino-k8s",
-        {"service-accounts": BIGQUERY_SECRET},
+    state = State(
+        leader=leader,
+        model=Model(name=MODEL_NAME),
+        config=base_config,
+        containers={container or trino_container()},
+        relations={peer_relation, worker_relation, *extra_relations},
+        secrets={*secrets, *extra_secrets},
     )
-
-    postgresql_secret_id = harness.add_model_secret(
-        "trino-k8s",
-        {
-            "replicas": POSTGRESQL_REPLICA_SECRET,
-            "cert": POSTGRESQL_REPLICA_CERT,
-        },
+    ids = SimpleNamespace(
+        postgresql=cats.postgresql.id,
+        mysql=cats.mysql.id,
+        redshift=cats.redshift.id,
+        bigquery=cats.bigquery.id,
+        gsheets=cats.gsheets.id,
+        catalog_config=catalog_config,
+        int_comms=int_comms,
+        worker_relation=worker_relation,
+        peer_relation=peer_relation,
     )
-    mysql_secret_id = harness.add_model_secret(
-        "trino-k8s",
-        {
-            "replicas": MYSQL_REPLICA_SECRET,
-        },
-    )
-    redshift_secret_id = harness.add_model_secret(
-        "trino-k8s",
-        {
-            "replicas": REDSHIFT_REPLICA_SECRET,
-        },
-    )
-    gsheets_secret_id = harness.add_model_secret(
-        "trino-k8s",
-        {"service-accounts": GSHEET_SECRET},
-    )
-
-    catalog_config = create_catalog_config(
-        postgresql_secret_id,
-        mysql_secret_id,
-        redshift_secret_id,
-        bigquery_secret_id,
-        gsheets_secret_id,
-    )
-
-    # Add worker and coordinator relation
-    harness.update_config({"catalog-config": catalog_config})
-    harness.update_config({"charm-function": "coordinator"})
-    rel_id = harness.add_relation("trino-coordinator", "trino-k8s-worker")
-
-    harness.update_config({"user-secret-id": secret_id})
-    return (
-        rel_id,
-        postgresql_secret_id,
-        mysql_secret_id,
-        redshift_secret_id,
-        bigquery_secret_id,
-        gsheets_secret_id,
-    )
+    return state, ids
 
 
-def make_relation_event(app, rel_id, data):
-    """Create and return a mock policy created event.
-
-        The event is generated by the relation with postgresql_db
+def workload_path(state, ctx, path, container="trino"):
+    """Return a filesystem ``Path`` for a file inside the workload container.
 
     Args:
-        app: name of the application.
-        rel_id: relation id.
-        data: relation data.
+        state: the output ``State`` from ``ctx.run``.
+        ctx: the Scenario ``Context``.
+        path: the absolute in-container path.
+        container: the container name.
 
     Returns:
-        Event dict.
+        A ``pathlib.Path`` pointing at the mocked container file.
     """
-    return type(
-        "Event",
-        (),
-        {
-            "app": app,
-            "relation": type(
-                "Relation",
-                (),
-                {
-                    "data": data,
-                    "id": rel_id,
-                },
-            ),
-        },
-    )
+    root = state.get_container(container).get_filesystem(ctx)
+    return root / path.lstrip("/")
+
+
+def peer_state_value(relation, name):
+    """Decode a JSON-encoded value from the peer relation app databag.
+
+    Args:
+        relation: the peer ``Relation`` taken from the output state.
+        name: the state attribute name.
+
+    Returns:
+        The decoded value, or ``None`` when absent.
+    """
+    raw = relation.local_app_data.get(name)
+    return None if raw is None else json.loads(raw)
+
+
+def carry_forward(state, container="trino"):
+    """Return ``state`` prepared for a follow-up ``ctx.run``.
+
+    Scenario auto-populates a ``CheckInfo`` for plan checks with default
+    attributes (e.g. ``threshold=3``) that do not match the layer's check
+    definition. Carrying such a container straight into another ``ctx.run``
+    trips the consistency checker, so the check statuses are cleared here.
+
+    Args:
+        state: the output ``State`` from a previous ``ctx.run``.
+        container: the container name to normalise.
+
+    Returns:
+        A new ``State`` whose container reports no check statuses.
+    """
+    cont = dataclasses.replace(state.get_container(container), check_infos=frozenset())
+    return dataclasses.replace(state, containers={cont})
 
 
 def create_catalog_config(

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -139,10 +139,10 @@ def trino_container(can_connect=True, **kwargs):
 
     Args:
         can_connect: whether Pebble is reachable.
-        kwargs: extra keyword arguments forwarded to ``Container``.
+        kwargs: extra keyword arguments forwarded to `Container`.
 
     Returns:
-        A Scenario ``Container`` for the ``trino`` workload.
+        A Scenario `Container` for the `trino` workload.
     """
     return Container(
         "trino",
@@ -164,7 +164,7 @@ def observer_secret(content):
         content: the secret content mapping.
 
     Returns:
-        A Scenario ``Secret`` the charm can read with ``get_content(refresh=True)``.
+        A Scenario `Secret` the charm can read with `get_content(refresh=True)`.
     """
     return Secret(tracked_content=content, owner=None)
 
@@ -173,8 +173,8 @@ def catalog_secrets():
     """Create the standard set of catalog secrets used by the lifecycle helpers.
 
     Returns:
-        A ``SimpleNamespace`` with the individual secret objects, a ``catalogs``
-        set of all secrets, and the rendered ``catalog_config`` string.
+        A `SimpleNamespace` with the individual secret objects, a `catalogs`
+        set of all secrets, and the rendered `catalog_config` string.
     """
     bigquery = observer_secret({"service-accounts": BIGQUERY_SECRET})
     postgresql = observer_secret(
@@ -209,11 +209,11 @@ def build_coordinator_state(
     extra_secrets=(),
     container=None,
 ):
-    """Build the input ``State`` for a healthy Trino coordinator.
+    """Build the input `State` for a healthy Trino coordinator.
 
-    Mirrors the end-state established by the legacy ``simulate_lifecycle_coordinator``
+    Mirrors the end-state established by the legacy `simulate_lifecycle_coordinator`
     Harness helper: peer relation ready, catalog and user secrets present,
-    ``charm-function`` set to ``coordinator`` and a ``trino-coordinator`` relation.
+    `charm-function` set to `coordinator` and a `trino-coordinator` relation.
 
     Args:
         leader: whether the unit is the leader.
@@ -223,8 +223,8 @@ def build_coordinator_state(
         container: an explicit container to use instead of the default.
 
     Returns:
-        A ``(State, SimpleNamespace)`` tuple. The namespace carries the catalog
-        secret IDs, the ``catalog_config`` string and the relation objects so
+        A `(State, SimpleNamespace)` tuple. The namespace carries the catalog
+        secret IDs, the `catalog_config` string and the relation objects so
         tests can inspect the output databags.
     """
     cats = catalog_secrets()
@@ -272,11 +272,11 @@ def build_worker_state(
     extra_secrets=(),
     container=None,
 ):
-    """Build the input ``State`` for a Trino worker related to a coordinator.
+    """Build the input `State` for a Trino worker related to a coordinator.
 
-    Mirrors the end-state established by the legacy ``simulate_lifecycle_worker``
-    Harness helper. The ``trino-worker`` relation carries the coordinator's
-    published data so a ``relation-changed`` event reproduces worker behaviour.
+    Mirrors the end-state established by the legacy `simulate_lifecycle_worker`
+    Harness helper. The `trino-worker` relation carries the coordinator's
+    published data so a `relation-changed` event reproduces worker behaviour.
 
     Args:
         leader: whether the unit is the leader.
@@ -288,8 +288,8 @@ def build_worker_state(
         container: an explicit container to use instead of the default.
 
     Returns:
-        A ``(State, SimpleNamespace)`` tuple. The namespace carries the catalog
-        secret IDs, the ``catalog_config`` string, the int-comms secret and the
+        A `(State, SimpleNamespace)` tuple. The namespace carries the catalog
+        secret IDs, the `catalog_config` string, the int-comms secret and the
         relation objects.
     """
     cats = catalog_secrets()
@@ -340,16 +340,16 @@ def build_worker_state(
 
 
 def workload_path(state, ctx, path, container="trino"):
-    """Return a filesystem ``Path`` for a file inside the workload container.
+    """Return a filesystem `Path` for a file inside the workload container.
 
     Args:
-        state: the output ``State`` from ``ctx.run``.
-        ctx: the Scenario ``Context``.
+        state: the output `State` from `ctx.run`.
+        ctx: the Scenario `Context`.
         path: the absolute in-container path.
         container: the container name.
 
     Returns:
-        A ``pathlib.Path`` pointing at the mocked container file.
+        A `pathlib.Path` pointing at the mocked container file.
     """
     root = state.get_container(container).get_filesystem(ctx)
     return root / path.lstrip("/")
@@ -359,30 +359,30 @@ def peer_state_value(relation, name):
     """Decode a JSON-encoded value from the peer relation app databag.
 
     Args:
-        relation: the peer ``Relation`` taken from the output state.
+        relation: the peer `Relation` taken from the output state.
         name: the state attribute name.
 
     Returns:
-        The decoded value, or ``None`` when absent.
+        The decoded value, or `None` when absent.
     """
     raw = relation.local_app_data.get(name)
     return None if raw is None else json.loads(raw)
 
 
 def carry_forward(state, container="trino"):
-    """Return ``state`` prepared for a follow-up ``ctx.run``.
+    """Return `state` prepared for a follow-up `ctx.run`.
 
-    Scenario auto-populates a ``CheckInfo`` for plan checks with default
-    attributes (e.g. ``threshold=3``) that do not match the layer's check
-    definition. Carrying such a container straight into another ``ctx.run``
+    Scenario auto-populates a `CheckInfo` for plan checks with default
+    attributes (e.g. `threshold=3`) that do not match the layer's check
+    definition. Carrying such a container straight into another `ctx.run`
     trips the consistency checker, so the check statuses are cleared here.
 
     Args:
-        state: the output ``State`` from a previous ``ctx.run``.
+        state: the output `State` from a previous `ctx.run`.
         container: the container name to normalise.
 
     Returns:
-        A new ``State`` whose container reports no check statuses.
+        A new `State` whose container reports no check statuses.
     """
     cont = dataclasses.replace(state.get_container(container), check_infos=frozenset())
     return dataclasses.replace(state, containers={cont})

--- a/tests/unit/test_catalog_freshness.py
+++ b/tests/unit/test_catalog_freshness.py
@@ -126,6 +126,7 @@ def test_catalog_added(ctx):
 
 def test_catalog_removed(ctx, tmp_path):
     """The catalog directory is updated to remove existing catalogs."""
+    # We need the mount for permanence because `ctx.run` is called twice.
     container = trino_container(
         mounts={"home": Mount(location="/usr/lib/trino/etc", source=tmp_path)}
     )

--- a/tests/unit/test_catalog_freshness.py
+++ b/tests/unit/test_catalog_freshness.py
@@ -4,221 +4,175 @@
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 
 
-"""Trino charm unit tests."""
+"""Trino charm catalog freshness unit tests."""
 
 # pylint:disable=protected-access
 
+import dataclasses
 import logging
-from unittest import TestCase, mock
 
 from ops.model import MaintenanceStatus
-from ops.testing import Harness
+from ops.testing import Mount
 
-from charm import TrinoK8SCharm
 from tests.unit.helpers import (
     BIGQUERY_CATALOG_PATH,
-    POSTGRESQL_1_CATALOG_PATH,
     POSTGRESQL_2_CATALOG_PATH,
     UPDATED_JVM_OPTIONS,
     USER_JVM_STRING,
+    build_coordinator_state,
+    build_worker_state,
+    carry_forward,
     create_added_catalog_config,
-    create_catalog_config,
-    make_relation_event,
-    simulate_lifecycle_coordinator,
-    simulate_lifecycle_worker,
+    peer_state_value,
+    trino_container,
+    workload_path,
 )
 
 logger = logging.getLogger(__name__)
 
 
-class TestCatalogConfigFreshness(TestCase):
-    """Unit tests for Trino charm catalog freshness."""
+def test_config_changed(ctx):
+    """The pebble plan changes according to config changes."""
+    state_in, ids = build_coordinator_state(
+        config={
+            "google-client-id": "test-client-id",
+            "google-client-secret": "test-client-secret",
+            "web-proxy": "proxy:port",
+            "charm-function": "all",
+            "additional-jvm-options": USER_JVM_STRING,
+        }
+    )
 
-    @mock.patch("charm.KubernetesStatefulsetPatch")
-    def setUp(self, _):
-        """Set up for the unit tests."""
-        self.harness = Harness(TrinoK8SCharm)
-        self.addCleanup(self.harness.cleanup)
-        self.harness.set_can_connect("trino", True)
-        self.harness.set_leader(True)
-        self.harness.set_model_name("trino-model")
-        self.harness.add_network("10.0.0.10", endpoint="peer")
-        self.harness.begin()
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
 
-    def test_config_changed(self):
-        """The pebble plan changes according to config changes."""
-        harness = self.harness
-        (
-            _,
-            postgresql_secret_id,
-            mysql_secret_id,
-            redshift_secret_id,
-            bigquery_secret_id,
-            gsheets_secret_id,
-        ) = simulate_lifecycle_coordinator(harness)
-
-        catalog_config = create_catalog_config(
-            postgresql_secret_id,
-            mysql_secret_id,
-            redshift_secret_id,
-            bigquery_secret_id,
-            gsheets_secret_id,
-        )
-
-        # Update the config.
-        self.harness.update_config(
-            {
-                "google-client-id": "test-client-id",
-                "google-client-secret": "test-client-secret",
-                "web-proxy": "proxy:port",
-                "charm-function": "all",
-                "additional-jvm-options": USER_JVM_STRING,
-            }
-        )
-
-        # The new plan reflects the change.
-        want_plan = {
-            "services": {
-                "trino": {
-                    "override": "replace",
-                    "summary": "trino server",
-                    "command": "./entrypoint.sh",
-                    "startup": "enabled",
-                    "on-check-failure": {"up": "ignore"},
-                    "environment": {
-                        "CATALOG_CONFIG": catalog_config,
-                        "PASSWORD_DB_PATH": "/usr/lib/trino/etc/password.db",  # nosec
-                        "LOG_LEVEL": "info",
-                        "OAUTH_CLIENT_ID": "test-client-id",
-                        "OAUTH_CLIENT_SECRET": "test-client-secret",  # nosec
-                        "WEB_PROXY": "proxy:port",
-                        "CHARM_FUNCTION": "all",
-                        "DISCOVERY_URI": "http://trino-k8s.trino-model.svc.cluster.local:8080",
-                        "APPLICATION_NAME": "trino-k8s",
-                        "TRINO_HOME": "/usr/lib/trino/etc",
-                        "JMX_PORT": 9081,
-                        "METRICS_PORT": 9090,
-                        "OAUTH_USER_MAPPING": None,
-                        "RANGER_RELATION": False,
-                        "RESOURCE_GROUPS_CONFIG": None,
-                        "SESSION_PROPERTY_MANAGER_CONFIG": None,
-                        "ACL_ACCESS_MODE": "owner",
-                        "ACL_CATALOG_PATTERN": ".*",
-                        "ACL_USER_PATTERN": ".*",
-                        "JAVA_TRUSTSTORE_PWD": "truststore_pwd",  # nosec
-                        "INT_COMMS_SECRET": "int_comms_secret",  # nosec
-                        "USER_SECRET_ID": "secret:secret-id",  # nosec
-                        "JVM_OPTIONS": UPDATED_JVM_OPTIONS,
-                        "COORDINATOR_REQUEST_TIMEOUT": "10m",
-                        "COORDINATOR_CONNECT_TIMEOUT": "30s",
-                        "WORKER_REQUEST_TIMEOUT": "30s",
-                        "MAX_CONCURRENT_QUERIES": 50,
-                        "QUERY_MAX_CPU_TIME": None,
-                        "QUERY_MAX_MEMORY_PER_NODE": None,
-                        "QUERY_MAX_MEMORY": None,
-                        "QUERY_MAX_TOTAL_MEMORY": None,
-                        "MEMORY_HEAP_HEADROOM_PER_NODE": None,
-                        "QUERY_MAX_RUN_TIME": None,
-                    },
-                }
+    want_services = {
+        "trino": {
+            "override": "replace",
+            "summary": "trino server",
+            "command": "./entrypoint.sh",
+            "startup": "enabled",
+            "on-check-failure": {"up": "ignore"},
+            "environment": {
+                "CATALOG_CONFIG": ids.catalog_config,
+                "PASSWORD_DB_PATH": "/usr/lib/trino/etc/password.db",  # nosec
+                "LOG_LEVEL": "info",
+                "OAUTH_CLIENT_ID": "test-client-id",
+                "OAUTH_CLIENT_SECRET": "test-client-secret",  # nosec
+                "WEB_PROXY": "proxy:port",
+                "CHARM_FUNCTION": "all",
+                "DISCOVERY_URI": "http://trino-k8s.trino-model.svc.cluster.local:8080",
+                "APPLICATION_NAME": "trino-k8s",
+                "TRINO_HOME": "/usr/lib/trino/etc",
+                "JMX_PORT": 9081,
+                "METRICS_PORT": 9090,
+                "OAUTH_USER_MAPPING": None,
+                "RANGER_RELATION": False,
+                "RESOURCE_GROUPS_CONFIG": None,
+                "SESSION_PROPERTY_MANAGER_CONFIG": None,
+                "ACL_ACCESS_MODE": "owner",
+                "ACL_CATALOG_PATTERN": ".*",
+                "ACL_USER_PATTERN": ".*",
+                "JAVA_TRUSTSTORE_PWD": "truststore_pwd",  # nosec
+                "INT_COMMS_SECRET": "int_comms_secret",  # nosec
+                "USER_SECRET_ID": "secret:secret-id",  # nosec
+                "JVM_OPTIONS": UPDATED_JVM_OPTIONS,
+                "COORDINATOR_REQUEST_TIMEOUT": "10m",
+                "COORDINATOR_CONNECT_TIMEOUT": "30s",
+                "WORKER_REQUEST_TIMEOUT": "30s",
+                "MAX_CONCURRENT_QUERIES": 50,
+                "QUERY_MAX_CPU_TIME": None,
+                "QUERY_MAX_MEMORY_PER_NODE": None,
+                "QUERY_MAX_MEMORY": None,
+                "QUERY_MAX_TOTAL_MEMORY": None,
+                "MEMORY_HEAP_HEADROOM_PER_NODE": None,
+                "QUERY_MAX_RUN_TIME": None,
             },
         }
-        got_plan = harness.get_container_pebble_plan("trino").to_dict()
-        environment = got_plan["services"]["trino"]["environment"]
-        environment["JAVA_TRUSTSTORE_PWD"] = "truststore_pwd"  # nosec
-        environment["INT_COMMS_SECRET"] = "int_comms_secret"  # nosec
-        environment["USER_SECRET_ID"] = "secret:secret-id"  # nosec
-        self.assertEqual(got_plan["services"], want_plan["services"])
+    }
 
-        # The MaintenanceStatus is set.
-        self.assertEqual(
-            harness.model.unit.status,
-            MaintenanceStatus("replanning application"),
-        )
+    got_services = state_out.get_container("trino").plan.to_dict()["services"]
 
-    def test_catalog_added(self):
-        """The catalog directory is updated to add the new catalog."""
-        harness = self.harness
-        (
-            _,
-            postgresql_secret_id,
-            mysql_secret_id,
-            redshift_secret_id,
-            bigquery_secret_id,
-            gsheets_secret_id,
-        ) = simulate_lifecycle_coordinator(harness)
+    # The truststore password and the internal-comms secret are randomly
+    # generated, and are normalised here to compare the rest of the plan.
+    environment = got_services["trino"]["environment"]
+    environment["JAVA_TRUSTSTORE_PWD"] = "truststore_pwd"  # nosec
+    environment["INT_COMMS_SECRET"] = "int_comms_secret"  # nosec
+    environment["USER_SECRET_ID"] = "secret:secret-id"  # nosec
 
-        catalog_config = create_added_catalog_config(
-            postgresql_secret_id,
-            mysql_secret_id,
-            redshift_secret_id,
-            bigquery_secret_id,
-            gsheets_secret_id,
-        )
+    assert got_services == want_services
+    assert state_out.unit_status == MaintenanceStatus("replanning application")
 
-        # Update the config.
-        self.harness.update_config({"catalog-config": catalog_config})
 
-        # Validate catalog.properties file created.
-        container = harness.model.unit.get_container("trino")
-        self.assertTrue(container.exists(POSTGRESQL_2_CATALOG_PATH))
-        self.assertTrue(container.exists(BIGQUERY_CATALOG_PATH))
+def test_catalog_added(ctx):
+    """The catalog directory is updated to add the new catalog."""
+    state_in, ids = build_coordinator_state()
+    extended_catalog_config = create_added_catalog_config(
+        ids.postgresql,
+        ids.mysql,
+        ids.redshift,
+        ids.bigquery,
+        ids.gsheets,
+    )
+    state_in = dataclasses.replace(
+        state_in,
+        config={**state_in.config, "catalog-config": extended_catalog_config},
+    )
 
-    def test_catalog_removed(self):
-        """The catalog directory is updated to remove existing catalogs."""
-        harness = self.harness
-        simulate_lifecycle_coordinator(harness)
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
 
-        # Update the config.
-        self.harness.update_config({"catalog-config": ""})
+    assert workload_path(state_out, ctx, POSTGRESQL_2_CATALOG_PATH).exists()
+    assert workload_path(state_out, ctx, BIGQUERY_CATALOG_PATH).exists()
 
-        # Validate catalog.properties file created.
-        container = harness.model.unit.get_container("trino")
-        self.assertFalse(container.exists(POSTGRESQL_1_CATALOG_PATH))
-        self.assertFalse(container.exists(BIGQUERY_CATALOG_PATH))
 
-    def test_worker_fetches_latest_catalog_on_relation_change(self):
-        """Test the worker catalogs change after the config and relation changes simultaneously."""
-        harness = self.harness
-        (
-            _,
-            event,
-            postgresql_secret_id,
-            mysql_secret_id,
-            redshift_secret_id,
-            bigquery_secret_id,
-            gsheets_secret_id,
-        ) = simulate_lifecycle_worker(harness)
+def test_catalog_removed(ctx, tmp_path):
+    """The catalog directory is updated to remove existing catalogs."""
+    container = trino_container(
+        mounts={"home": Mount(location="/usr/lib/trino/etc", source=tmp_path)}
+    )
+    state_in, _ = build_coordinator_state(container=container)
 
-        old_catalog = create_catalog_config(
-            postgresql_secret_id,
-            mysql_secret_id,
-            redshift_secret_id,
-            bigquery_secret_id,
-            gsheets_secret_id,
-        )
+    # Establish the catalogs on disk.
+    mid = carry_forward(ctx.run(ctx.on.config_changed(), state_in))
+    assert (tmp_path / "catalog" / "postgresql-1.properties").exists()
 
-        extended_catalog_config = create_added_catalog_config(
-            postgresql_secret_id,
-            mysql_secret_id,
-            redshift_secret_id,
-            bigquery_secret_id,
-            gsheets_secret_id,
-        )
-        new_data = dict(event.relation.data)
-        new_data["trino-worker"].update({"catalogs": extended_catalog_config})
+    # Clear the catalog configuration and reconcile.
+    mid = dataclasses.replace(mid, config={**mid.config, "catalog-config": ""})
+    ctx.run(ctx.on.config_changed(), mid)
 
-        new_event = make_relation_event("trino-worker", event.relation.id, new_data)
-        harness.charm.trino_worker._on_relation_changed(new_event)
+    assert not (tmp_path / "catalog" / "postgresql-1.properties").exists()
+    assert not (tmp_path / "catalog" / "bigquery.properties").exists()
 
-        self.assertEqual(
-            harness.charm.trino_worker.charm.state.catalog_config,
-            extended_catalog_config,
-            "Catalog should be updated to the latest version when relation is changed.",
-        )
 
-        self.assertNotEqual(
-            harness.charm.trino_worker.charm.state.catalog_config,
-            old_catalog,
-            "Stale catalog should not be used after it is updated.",
-        )
+def test_worker_fetches_latest_catalog_on_relation_change(ctx):
+    """The worker uses the latest catalog advertised on relation change."""
+    state_in, ids = build_worker_state()
+    old_catalog = ids.catalog_config
+
+    extended_catalog_config = create_added_catalog_config(
+        ids.postgresql,
+        ids.mysql,
+        ids.redshift,
+        ids.bigquery,
+        ids.gsheets,
+    )
+
+    # Advertise the extended catalog config on the worker relation.
+    worker_relation = dataclasses.replace(
+        ids.worker_relation,
+        remote_app_data={
+            **ids.worker_relation.remote_app_data,
+            "catalogs": extended_catalog_config,
+        },
+    )
+    relations = {
+        relation for relation in state_in.relations if relation.id != ids.worker_relation.id
+    }
+    relations.add(worker_relation)
+    state_in = dataclasses.replace(state_in, relations=relations)
+
+    state_out = ctx.run(ctx.on.relation_changed(worker_relation), state_in)
+
+    peer_relation = state_out.get_relation(ids.peer_relation.id)
+    catalog_config = peer_state_value(peer_relation, "catalog_config")
+    assert catalog_config == extended_catalog_config
+    assert catalog_config != old_catalog

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -8,9 +8,11 @@
 
 # pylint:disable=protected-access,too-many-public-methods
 
+import dataclasses
 import logging
-from unittest import TestCase, mock
 
+import pytest
+import yaml
 from ops.model import (
     ActiveStatus,
     BlockedStatus,
@@ -18,23 +20,24 @@ from ops.model import (
     SecretNotFoundError,
     WaitingStatus,
 )
-from ops.pebble import CheckStatus
-from ops.testing import Harness
+from ops.pebble import CheckLevel, CheckStartup, CheckStatus, Layer
+from ops.testing import CheckInfo, Mount, PeerRelation, Relation, State
 
-from charm import TrinoK8SCharm
 from tests.unit.helpers import (
     BIGQUERY_CATALOG_PATH,
     DEFAULT_JVM_STRING,
+    MODEL_NAME,
     POSTGRESQL_1_CATALOG_PATH,
     POSTGRESQL_1_DEVELOPER_CATALOG_PATH,
     POSTGRESQL_REPLICA_SECRET,
     POSTGRESQL_REPLICA_SECRET_WITH_PARAMS,
     SERVER_PORT,
-    create_catalog_config,
+    build_coordinator_state,
+    build_worker_state,
     create_single_catalog_config,
-    make_relation_event,
-    simulate_lifecycle_coordinator,
-    simulate_lifecycle_worker,
+    observer_secret,
+    trino_container,
+    workload_path,
 )
 
 mock_incomplete_pebble_plan = {"services": {"trino": {"override": "replace"}}}
@@ -42,785 +45,709 @@ mock_incomplete_pebble_plan = {"services": {"trino": {"override": "replace"}}}
 logger = logging.getLogger(__name__)
 
 
-class TestCharm(TestCase):
-    """Unit tests.
+def _services(state):
+    """Return the rendered Pebble services for the trino container."""
+    return state.get_container("trino").plan.to_dict()["services"]
 
-    Attrs:
-        maxDiff: Specifies max difference shown by failed tests.
+
+def test_initial_plan(ctx):
+    """The initial pebble plan is empty."""
+    state = State(
+        leader=True,
+        relations={PeerRelation("peer")},
+        containers={trino_container()},
+    )
+    with ctx(ctx.on.update_status(), state) as mgr:
+        initial_plan = mgr.charm.unit.get_container("trino").get_plan().to_dict()
+        assert initial_plan == {}
+
+
+def test_waiting_on_peer_relation_not_ready(ctx):
+    """The charm is blocked without a peer relation."""
+    container = trino_container()
+    state = State(leader=True, containers={container})
+
+    state_out = ctx.run(ctx.on.pebble_ready(container), state)
+
+    # No plans are set yet.
+    assert state_out.get_container("trino").plan.to_dict() == {}
+
+    # The BlockStatus is set with a message.
+    assert state_out.unit_status == BlockedStatus("peer relation not ready")
+
+
+def test_ready(ctx):
+    """The pebble plan is correctly generated when the charm is ready."""
+    state_in, ids = build_coordinator_state()
+    catalog_config = ids.catalog_config
+
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    # Asserts status is set to replanning.
+    assert state_out.unit_status == MaintenanceStatus("replanning application")
+
+    # The plan is generated after config is applied.
+    want_plan = {
+        "services": {
+            "trino": {
+                "override": "replace",
+                "summary": "trino server",
+                "command": "./entrypoint.sh",
+                "startup": "enabled",
+                "on-check-failure": {"up": "ignore"},
+                "environment": {
+                    "CATALOG_CONFIG": catalog_config,
+                    "PASSWORD_DB_PATH": "/usr/lib/trino/etc/password.db",  # nosec
+                    "LOG_LEVEL": "info",
+                    "OAUTH_CLIENT_ID": None,
+                    "OAUTH_CLIENT_SECRET": None,  # nosec
+                    "WEB_PROXY": None,
+                    "CHARM_FUNCTION": "coordinator",
+                    "DISCOVERY_URI": "http://trino-k8s.trino-model.svc.cluster.local:8080",
+                    "APPLICATION_NAME": "trino-k8s",
+                    "TRINO_HOME": "/usr/lib/trino/etc",
+                    "JMX_PORT": 9081,
+                    "METRICS_PORT": 9090,
+                    "OAUTH_USER_MAPPING": None,
+                    "RANGER_RELATION": False,
+                    "RESOURCE_GROUPS_CONFIG": None,
+                    "SESSION_PROPERTY_MANAGER_CONFIG": None,
+                    "ACL_ACCESS_MODE": "owner",
+                    "ACL_CATALOG_PATTERN": ".*",
+                    "ACL_USER_PATTERN": ".*",
+                    "JAVA_TRUSTSTORE_PWD": "truststore_pwd",  # nosec
+                    "INT_COMMS_SECRET": "int_comms_secret",  # nosec
+                    "USER_SECRET_ID": "secret:secret-id",  # nosec
+                    "JVM_OPTIONS": DEFAULT_JVM_STRING,
+                    "COORDINATOR_REQUEST_TIMEOUT": "10m",
+                    "COORDINATOR_CONNECT_TIMEOUT": "30s",
+                    "WORKER_REQUEST_TIMEOUT": "30s",
+                    "MAX_CONCURRENT_QUERIES": 50,
+                    "QUERY_MAX_CPU_TIME": None,
+                    "QUERY_MAX_MEMORY_PER_NODE": None,
+                    "QUERY_MAX_MEMORY": None,
+                    "QUERY_MAX_TOTAL_MEMORY": None,
+                    "MEMORY_HEAP_HEADROOM_PER_NODE": None,
+                    "QUERY_MAX_RUN_TIME": None,
+                },
+            }
+        },
+    }
+    got_services = _services(state_out)
+    environment = got_services["trino"]["environment"]
+    environment["JAVA_TRUSTSTORE_PWD"] = "truststore_pwd"  # nosec
+    environment["INT_COMMS_SECRET"] = "int_comms_secret"  # nosec
+    environment["USER_SECRET_ID"] = "secret:secret-id"  # nosec
+
+    assert got_services == want_plan["services"]
+
+
+def test_ingress(ctx):
+    """Test ingress relation.
+
+    The charm relates correctly to the nginx ingress charm
+    and can be configured.
     """
+    nginx_route = Relation("nginx-route", remote_app_name="ingress")
+    state_in, _ = build_coordinator_state(extra_relations=(nginx_route,))
 
-    maxDiff = None
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
 
-    @mock.patch("charm.KubernetesStatefulsetPatch")
-    def setUp(self, _):
-        """Set up for the unit tests."""
-        self.harness = Harness(TrinoK8SCharm)
-        self.addCleanup(self.harness.cleanup)
-        self.harness.set_can_connect("trino", True)
-        self.harness.set_leader(True)
-        self.harness.set_model_name("trino-model")
-        self.harness.add_network("10.0.0.10", endpoint="peer")
-        self.harness.begin()
+    relation_data = state_out.get_relation(nginx_route.id).local_app_data
+    assert relation_data == {
+        "service-namespace": MODEL_NAME,
+        "service-hostname": "trino-k8s",
+        "service-name": "trino-k8s",
+        "service-port": SERVER_PORT,
+        "backend-protocol": "HTTP",
+    }
 
-    def test_initial_plan(self):
-        """The initial pebble plan is empty."""
-        harness = self.harness
-        initial_plan = harness.get_container_pebble_plan("trino").to_dict()
-        self.assertEqual(initial_plan, {})
 
-    def test_waiting_on_peer_relation_not_ready(self):
-        """The charm is blocked without a peer relation."""
-        harness = self.harness
+def test_ingress_tls_secret_name_set(ctx):
+    """An explicit tls-secret-name is forwarded to the nginx-route relation."""
+    nginx_route = Relation("nginx-route", remote_app_name="ingress")
+    state_in, _ = build_coordinator_state(
+        config={"tls-secret-name": "my-tls-secret"},
+        extra_relations=(nginx_route,),
+    )
 
-        # Simulate pebble readiness.
-        container = harness.model.unit.get_container("trino")
-        harness.handle_exec("trino", ["htpasswd"], result=0)
-        harness.charm.on.trino_pebble_ready.emit(container)
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
 
-        # No plans are set yet.
-        got_plan = harness.get_container_pebble_plan("trino").to_dict()
-        self.assertEqual(got_plan, {})
+    relation_data = state_out.get_relation(nginx_route.id).local_app_data
+    assert relation_data.get("tls-secret-name") == "my-tls-secret"
 
-        # The BlockStatus is set with a message.
-        self.assertEqual(
-            harness.model.unit.status,
-            BlockedStatus("peer relation not ready"),
-        )
 
-    def test_ready(self):
-        """The pebble plan is correctly generated when the charm is ready."""
-        harness = self.harness
-        (
-            _,
-            postgresql_secret_id,
-            mysql_secret_id,
-            redshift_secret_id,
-            bigquery_secret_id,
-            gsheets_secret_id,
-        ) = simulate_lifecycle_coordinator(harness)
-        catalog_config = create_catalog_config(
-            postgresql_secret_id,
-            mysql_secret_id,
-            redshift_secret_id,
-            bigquery_secret_id,
-            gsheets_secret_id,
-        )
+def test_ingress_tls_secret_name_unset(ctx):
+    """When tls-secret-name is not set, the key is absent from the nginx-route relation.
 
-        # Asserts status is active
-        self.assertEqual(
-            harness.model.unit.status,
-            MaintenanceStatus("replanning application"),
-        )
+    This allows an external operator (e.g. lego) to provide the TLS secret instead.
+    """
+    nginx_route = Relation("nginx-route", remote_app_name="ingress")
+    state_in, _ = build_coordinator_state(extra_relations=(nginx_route,))
 
-        # The plan is generated after pebble is ready.
-        want_plan = {
-            "services": {
-                "trino": {
-                    "override": "replace",
-                    "summary": "trino server",
-                    "command": "./entrypoint.sh",
-                    "startup": "enabled",
-                    "on-check-failure": {"up": "ignore"},
-                    "environment": {
-                        "CATALOG_CONFIG": catalog_config,
-                        "PASSWORD_DB_PATH": "/usr/lib/trino/etc/password.db",  # nosec
-                        "LOG_LEVEL": "info",
-                        "OAUTH_CLIENT_ID": None,
-                        "OAUTH_CLIENT_SECRET": None,  # nosec
-                        "WEB_PROXY": None,
-                        "CHARM_FUNCTION": "coordinator",
-                        "DISCOVERY_URI": "http://trino-k8s.trino-model.svc.cluster.local:8080",
-                        "APPLICATION_NAME": "trino-k8s",
-                        "TRINO_HOME": "/usr/lib/trino/etc",
-                        "JMX_PORT": 9081,
-                        "METRICS_PORT": 9090,
-                        "OAUTH_USER_MAPPING": None,
-                        "RANGER_RELATION": False,
-                        "RESOURCE_GROUPS_CONFIG": None,
-                        "SESSION_PROPERTY_MANAGER_CONFIG": None,
-                        "ACL_ACCESS_MODE": "owner",
-                        "ACL_CATALOG_PATTERN": ".*",
-                        "ACL_USER_PATTERN": ".*",
-                        "JAVA_TRUSTSTORE_PWD": "truststore_pwd",  # nosec
-                        "INT_COMMS_SECRET": "int_comms_secret",  # nosec
-                        "USER_SECRET_ID": "secret:secret-id",  # nosec
-                        "JVM_OPTIONS": DEFAULT_JVM_STRING,
-                        "COORDINATOR_REQUEST_TIMEOUT": "10m",
-                        "COORDINATOR_CONNECT_TIMEOUT": "30s",
-                        "WORKER_REQUEST_TIMEOUT": "30s",
-                        "MAX_CONCURRENT_QUERIES": 50,
-                        "QUERY_MAX_CPU_TIME": None,
-                        "QUERY_MAX_MEMORY_PER_NODE": None,
-                        "QUERY_MAX_MEMORY": None,
-                        "QUERY_MAX_TOTAL_MEMORY": None,
-                        "MEMORY_HEAP_HEADROOM_PER_NODE": None,
-                        "QUERY_MAX_RUN_TIME": None,
-                    },
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    relation_data = state_out.get_relation(nginx_route.id).local_app_data
+    assert "tls-secret-name" not in relation_data
+
+
+def test_invalid_config_value(ctx):
+    """The charm blocks if an invalid config value is provided."""
+    # Seed the container with the previously-applied (valid) plan so we can
+    # assert the invalid value is not propagated to the running plan.
+    container = trino_container(
+        layers={
+            "trino": Layer(
+                {
+                    "services": {
+                        "trino": {
+                            "override": "replace",
+                            "command": "./entrypoint.sh",
+                            "environment": {"LOG_LEVEL": "info"},
+                        }
+                    }
                 }
-            },
-        }
-        got_plan = harness.get_container_pebble_plan("trino").to_dict()
-        environment = got_plan["services"]["trino"]["environment"]
-        environment["JAVA_TRUSTSTORE_PWD"] = "truststore_pwd"  # nosec
-        environment["INT_COMMS_SECRET"] = "int_comms_secret"  # nosec
-        environment["USER_SECRET_ID"] = "secret:secret-id"  # nosec
-
-        self.assertEqual(got_plan["services"], want_plan["services"])
-
-        # The service was started.
-        service = harness.model.unit.get_container("trino").get_service("trino")
-        self.assertTrue(service.is_running())
-
-        # The ActiveStatus is set with no message.
-        self.assertEqual(
-            harness.model.unit.status,
-            MaintenanceStatus("replanning application"),
-        )
-
-    def test_ingress(self):
-        """Test ingress relation.
-
-        The charm relates correctly to the nginx ingress charm
-        and can be configured.
-        """
-        harness = self.harness
-
-        simulate_lifecycle_coordinator(harness)
-
-        nginx_route_relation_id = harness.add_relation("nginx-route", "ingress")
-        harness.charm._require_nginx_route()
-
-        assert harness.get_relation_data(nginx_route_relation_id, harness.charm.app) == {
-            "service-namespace": harness.charm.model.name,
-            "service-hostname": harness.charm.app.name,
-            "service-name": harness.charm.app.name,
-            "service-port": SERVER_PORT,
-            "backend-protocol": "HTTP",
-        }
-
-    @mock.patch("charm.KubernetesStatefulsetPatch")
-    def test_ingress_tls_secret_name_set(self, _):
-        """An explicit tls-secret-name is forwarded to the nginx-route relation."""
-        harness = Harness(TrinoK8SCharm)
-        self.addCleanup(harness.cleanup)
-        harness.set_can_connect("trino", True)
-        harness.set_leader(True)
-        harness.set_model_name("trino-model")
-        harness.add_network("10.0.0.10", endpoint="peer")
-        harness.update_config({"tls-secret-name": "my-tls-secret"})
-        harness.begin()
-
-        simulate_lifecycle_coordinator(harness)
-        nginx_route_relation_id = harness.add_relation("nginx-route", "ingress")
-        harness.charm._require_nginx_route()
-
-        assert (
-            harness.get_relation_data(nginx_route_relation_id, harness.charm.app).get(
-                "tls-secret-name"
             )
-            == "my-tls-secret"
-        )
-
-    @mock.patch("charm.KubernetesStatefulsetPatch")
-    def test_ingress_tls_secret_name_unset(self, _):
-        """When tls-secret-name is not set, the key is absent from the nginx-route relation.
-
-        This allows an external operator (e.g. lego) to provide the TLS secret instead.
-        """
-        harness = Harness(TrinoK8SCharm)
-        self.addCleanup(harness.cleanup)
-        harness.set_can_connect("trino", True)
-        harness.set_leader(True)
-        harness.set_model_name("trino-model")
-        harness.add_network("10.0.0.10", endpoint="peer")
-        harness.begin()
-
-        simulate_lifecycle_coordinator(harness)
-        nginx_route_relation_id = harness.add_relation("nginx-route", "ingress")
-        harness.charm._require_nginx_route()
-
-        assert "tls-secret-name" not in harness.get_relation_data(
-            nginx_route_relation_id, harness.charm.app
-        )
-
-    def test_invalid_config_value(self):
-        """The charm blocks if an invalid config value is provided."""
-        harness = self.harness
-        simulate_lifecycle_coordinator(harness)
-
-        # Update the config with an invalid value.
-        self.harness.update_config({"log-level": "all-logs"})
-
-        # The change is not applied to the plan.
-        want_log_level = "info"
-        got_log_level = harness.get_container_pebble_plan("trino").to_dict()["services"]["trino"][
-            "environment"
-        ]["LOG_LEVEL"]
-        self.assertEqual(got_log_level, want_log_level)
-
-        # The BlockStatus is set with a message.
-        self.assertEqual(
-            harness.model.unit.status,
-            BlockedStatus("config: invalid log level 'all-logs'"),
-        )
-
-    def test_incorrect_relation(self):
-        """The charm blocks if the coordinator relation is not added.."""
-        harness = self.harness
-        simulate_lifecycle_coordinator(harness)
-
-        self.harness.update_config({"charm-function": "worker"})
-
-        # The BlockStatus is set with a message.
-        self.assertEqual(
-            harness.model.unit.status,
-            BlockedStatus("Incorrect trino relation configuration."),
-        )
-
-    def test_catalog_invalid_config(self):
-        """The charm blocks when catalog-config is missing required top-level keys."""
-        harness = self.harness
-        simulate_lifecycle_coordinator(harness)
-
-        self.harness.update_config({"catalog-config": "catalog: incorrect"})
-
-        self.assertIsInstance(harness.model.unit.status, BlockedStatus)
-        self.assertIn("catalog-config", harness.model.unit.status.message)
-
-    def test_postgresql_catalog_config_bad_prefix(self):
-        """The charm blocks when a postgresql-catalog-config entry has an invalid database_prefix."""  # noqa: E501
-        harness = self.harness
-        simulate_lifecycle_coordinator(harness)
-
-        bad_config = "pg-app:\n  database_prefix: mydb\n  ro_catalog_name: mycat\n"
-        self.harness.update_config({"postgresql-catalog-config": bad_config})
-
-        self.assertIsInstance(harness.model.unit.status, BlockedStatus)
-        self.assertIn("database_prefix", harness.model.unit.status.message)
-
-    def test_postgresql_catalog_config_no_catalog_name(self):
-        """The charm blocks when a postgresql-catalog-config entry has no catalog name."""
-        harness = self.harness
-        simulate_lifecycle_coordinator(harness)
-
-        bad_config = "pg-app:\n  database_prefix: mydb*\n"
-        self.harness.update_config({"postgresql-catalog-config": bad_config})
-
-        self.assertIsInstance(harness.model.unit.status, BlockedStatus)
-        self.assertIn("ro_catalog_name", harness.model.unit.status.message)
-
-    def test_postgresql_catalog_config_duplicate_catalog_names(self):
-        """The charm blocks when two postgresql-catalog-config entries share a catalog name."""
-        harness = self.harness
-        simulate_lifecycle_coordinator(harness)
-
-        duplicate_config = (
-            "pg-app-a:\n  database_prefix: db_a*\n  ro_catalog_name: shared_cat\n"
-            "pg-app-b:\n  database_prefix: db_b*\n  ro_catalog_name: shared_cat\n"
-        )
-        self.harness.update_config({"postgresql-catalog-config": duplicate_config})
-
-        self.assertIsInstance(harness.model.unit.status, BlockedStatus)
-        self.assertIn("Duplicate", harness.model.unit.status.message)
-        self.assertIn("shared_cat", harness.model.unit.status.message)
-
-    def test_postgresql_catalog_config_clashes_with_static(self):
-        """The charm blocks when a postgresql-catalog-config name clashes with catalog-config."""
-        harness = self.harness
-        simulate_lifecycle_coordinator(harness)
-
-        import yaml
-
-        static_config = yaml.dump(
-            {
-                "catalogs": {"my_static_cat": {"backend": "pg"}},
-                "backends": {"pg": {"connector": "postgresql"}},
-            }
-        )
-        pg_config = "pg-app:\n  database_prefix: db*\n  ro_catalog_name: my_static_cat\n"
-        self.harness.update_config(
-            {"catalog-config": static_config, "postgresql-catalog-config": pg_config}
-        )
-
-        self.assertIsInstance(harness.model.unit.status, BlockedStatus)
-        self.assertIn("clashes with catalog-config", harness.model.unit.status.message)
-
-    def test_session_property_manager_invalid_config(self):
-        """The charm blocks when the session property manager JSON is invalid."""
-        harness = self.harness
-        simulate_lifecycle_coordinator(harness)
-
-        self.harness.update_config({"session-property-manager-config": '{"group":"broken"'})
-
-        self.assertIn(
-            "Expecting ',' delimiter",
-            harness.model.unit.status.message,
-        )
-        self.assertIsInstance(harness.model.unit.status, BlockedStatus)
-
-    def test_update_status_up(self):
-        """The charm updates the unit status to active based on UP status."""
-        harness = self.harness
-
-        simulate_lifecycle_coordinator(harness)
-
-        container = harness.model.unit.get_container("trino")
-        container.get_check = mock.Mock(status="up")
-        container.get_check.return_value.status = CheckStatus.UP
-        harness.charm.on.update_status.emit()
-
-        self.assertEqual(harness.model.unit.status, ActiveStatus("Status check: UP"))
-
-    def test_update_status_down(self):
-        """The charm updates the unit status to maintenance based on DOWN status."""
-        harness = self.harness
-
-        simulate_lifecycle_coordinator(harness)
-
-        container = harness.model.unit.get_container("trino")
-        container.get_check = mock.Mock(status="up")
-        container.get_check.return_value.status = CheckStatus.DOWN
-        harness.charm.on.update_status.emit()
-
-        self.assertEqual(harness.model.unit.status, MaintenanceStatus("Status check: DOWN"))
-
-    def test_incomplete_pebble_plan(self):
-        """The charm re-applies the pebble plan if incomplete."""
-        harness = self.harness
-        simulate_lifecycle_coordinator(harness)
-
-        container = harness.model.unit.get_container("trino")
-        container.add_layer("trino", mock_incomplete_pebble_plan, combine=True)
-        harness.charm.on.update_status.emit()
-
-        self.assertEqual(
-            harness.model.unit.status,
-            MaintenanceStatus("replanning application"),
-        )
-        plan = harness.get_container_pebble_plan("trino").to_dict()
-        assert plan != mock_incomplete_pebble_plan
-
-    def test_trino_coordinator_relation(self):
-        """Test trino relation.
-
-        The coordinator and worker Trino charms relate correctly.
-        """
-        harness = self.harness
-
-        (
-            rel_id,
-            postgresql_secret_id,
-            mysql_secret_id,
-            redshift_secret_id,
-            bigquery_secret_id,
-            gsheets_secret_id,
-        ) = simulate_lifecycle_coordinator(harness)
-
-        catalog_config = create_catalog_config(
-            postgresql_secret_id,
-            mysql_secret_id,
-            redshift_secret_id,
-            bigquery_secret_id,
-            gsheets_secret_id,
-        )
-        relation_data = harness.get_relation_data(rel_id, harness.charm.app)
-
-        assert (
-            relation_data["discovery-uri"] == "http://trino-k8s.trino-model.svc.cluster.local:8080"
-        )
-        assert relation_data["catalogs"] == catalog_config
-
-    def test_trino_coordinator_relation_discovery_uri_override(self):
-        """When discovery-uri config is set, the override is published to workers.
-
-        Workers in cross-cluster or multi-network topologies need the coordinator
-        to advertise a reachable address rather than the cluster-local default.
-        """
-        harness = self.harness
-        harness.update_config({"discovery-uri": "http://trino.example.com:8080"})
-
-        (rel_id, *_) = simulate_lifecycle_coordinator(harness)
-
-        relation_data = harness.get_relation_data(rel_id, harness.charm.app)
-        assert relation_data["discovery-uri"] == "http://trino.example.com:8080"
-
-        # The override is also reflected in the coordinator's own Pebble environment.
-        got_plan = harness.get_container_pebble_plan("trino").to_dict()
-        environment = got_plan["services"]["trino"]["environment"]
-        assert environment["DISCOVERY_URI"] == "http://trino.example.com:8080"
-
-    def test_trino_coordinator_relation_broken(self):
-        """Test trino relation.
-
-        The coordinator and worker Trino charms relate correctly.
-        """
-        harness = self.harness
-
-        rel_id = simulate_lifecycle_coordinator(harness)
-
-        data = {"trino-coordinator": {}}
-        event = make_relation_event("trino-coordinator", rel_id, data)
-        with self.assertRaises(SecretNotFoundError):
-            harness.charm.trino_coordinator._on_relation_broken(event)
-            harness.model.get_secret(label="catalog-config")
-
-    def test_trino_worker_relation_created(self):
-        """Test trino relation creation.
-
-        The coordinator and worker Trino charms relate correctly.
-        """
-        harness = self.harness
-        container, _, _, _, _, _, _ = simulate_lifecycle_worker(harness)
-
-        self.assertTrue(container.exists(BIGQUERY_CATALOG_PATH))
-        self.assertTrue(container.exists(POSTGRESQL_1_CATALOG_PATH))
-
-    def test_trino_worker_relation_broken(self):
-        """Test trino relation broken.
-
-        The coordinator and worker Trino charms relation is broken.
-        """
-        harness = self.harness
-        container, event, _, _, _, _, _ = simulate_lifecycle_worker(harness)
-
-        harness.charm.trino_worker._on_relation_broken(event)
-        self.assertFalse(container.exists(POSTGRESQL_1_CATALOG_PATH))
-
-    def test_trino_single_node_deployment(self):
-        """Test pebble plan is created with single node deployment."""
-        harness = self.harness
-        harness.add_relation("peer", "trino")
-
-        harness.handle_exec("trino", ["/bin/sh"], result="/usr/lib/jvm/java-25-openjdk-amd64/")
-        harness.handle_exec("trino", ["keytool"], result=0)
-        container = harness.model.unit.get_container("trino")
-        harness.handle_exec("trino", ["htpasswd"], result=0)
-        harness.charm.on.trino_pebble_ready.emit(container)
-        harness.update_config({"charm-function": "all"})
-
-        # There is a valid pebble plan.
-        got_plan = harness.get_container_pebble_plan("trino").to_dict()
-        assert got_plan["services"]["trino"]["environment"]["CHARM_FUNCTION"] == "all"
-
-        # The MaintenanceStatus is set.
-        self.assertEqual(
-            harness.model.unit.status,
-            MaintenanceStatus("replanning application"),
-        )
-
-    def test_resource_management_config(self):
-        """Test resource management configuration variables.
-
-        The charm includes resource management variables in the environment
-        with the correct values when configured.
-        """
-        harness = self.harness
-        simulate_lifecycle_coordinator(harness)
-
-        # Update config with resource management values
-        harness.update_config(
-            {
-                "query-max-cpu-time": "1h",
-                "query-max-memory-per-node": "2GB",
-                "query-max-memory": "10GB",
-                "query-max-total-memory": "15GB",
-                "memory-heap-headroom-per-node": "1GB",
-            }
-        )
-
-        # Check that variables are present in environment with correct values
-        got_plan = harness.get_container_pebble_plan("trino").to_dict()
-        environment = got_plan["services"]["trino"]["environment"]
-
-        self.assertEqual(environment["QUERY_MAX_CPU_TIME"], "1h")
-        self.assertEqual(environment["QUERY_MAX_MEMORY_PER_NODE"], "2GB")
-        self.assertEqual(environment["QUERY_MAX_MEMORY"], "10GB")
-        self.assertEqual(environment["QUERY_MAX_TOTAL_MEMORY"], "15GB")
-        self.assertEqual(environment["MEMORY_HEAP_HEADROOM_PER_NODE"], "1GB")
-
-    def test_session_property_manager_files_created(self):
-        """The charm writes the session property manager files when configured."""
-        harness = self.harness
-        simulate_lifecycle_coordinator(harness)
-
-        session_property_config = (
-            '[{"group":"global.*","sessionProperties":{"query_max_execution_time":"8h"}}]'
-        )
-        harness.update_config({"session-property-manager-config": session_property_config})
-
-        container = harness.model.unit.get_container("trino")
-        properties_path = "/usr/lib/trino/etc/session-property-config.properties"
-        json_path = "/usr/lib/trino/etc/session-property-config.json"
-
-        self.assertTrue(container.exists(properties_path))
-        self.assertTrue(container.exists(json_path))
-        self.assertEqual(container.pull(json_path).read(), session_property_config)
-
-    def test_session_property_manager_files_removed(self):
-        """The charm removes the session property manager files when unset."""
-        harness = self.harness
-        simulate_lifecycle_coordinator(harness)
-
-        harness.update_config({"session-property-manager-config": '[{"user":"admin"}]'})
-        harness.update_config({"session-property-manager-config": ""})
-
-        container = harness.model.unit.get_container("trino")
-        properties_path = "/usr/lib/trino/etc/session-property-config.properties"
-        json_path = "/usr/lib/trino/etc/session-property-config.json"
-
-        self.assertFalse(container.exists(properties_path))
-        self.assertFalse(container.exists(json_path))
-
-    def test_resource_group_manager_files_created(self):
-        """The charm writes the resource group manager files when configured."""
-        harness = self.harness
-        simulate_lifecycle_coordinator(harness)
-
-        resource_groups_config = (
-            '{"rootGroups":[{"name":"global","softMemoryLimit":"80%",'
-            '"hardConcurrencyLimit":10,"maxQueued":10}],"selectors":'
-            '[{"user":".*","group":"global"}]}'
-        )
-        harness.update_config({"resource-groups-config": resource_groups_config})
-
-        container = harness.model.unit.get_container("trino")
-        properties_path = "/usr/lib/trino/etc/resource-groups.properties"
-        json_path = "/usr/lib/trino/etc/resource-groups.json"
-
-        self.assertTrue(container.exists(properties_path))
-        self.assertTrue(container.exists(json_path))
-        self.assertEqual(container.pull(json_path).read(), resource_groups_config)
-
-    def test_resource_group_manager_files_removed(self):
-        """The charm removes the resource group manager files when unset."""
-        harness = self.harness
-        simulate_lifecycle_coordinator(harness)
-
-        harness.update_config(
-            {
-                "resource-groups-config": (
-                    '{"rootGroups":[{"name":"global","softMemoryLimit":"80%",'
-                    '"hardConcurrencyLimit":10,"maxQueued":10}],"selectors":'
-                    '[{"user":".*","group":"global"}]}'
-                )
-            }
-        )
-        harness.update_config({"resource-groups-config": ""})
-
-        container = harness.model.unit.get_container("trino")
-        properties_path = "/usr/lib/trino/etc/resource-groups.properties"
-        json_path = "/usr/lib/trino/etc/resource-groups.json"
-
-        self.assertFalse(container.exists(properties_path))
-        self.assertFalse(container.exists(json_path))
-
-    def test_per_replica_params_override_backend_params(self):
-        """Per-replica params override backend params in rendered catalog files.
-
-        The rw replica and ro replica must get the targetServerType declared
-        in their respective replica params, not a shared value from the backend.
-        """
-        harness = self.harness
-        simulate_lifecycle_coordinator(harness)
-
-        postgresql_secret_id = harness.add_model_secret(
-            "trino-k8s",
-            {"replicas": POSTGRESQL_REPLICA_SECRET_WITH_PARAMS},
-        )
-        catalog_config = create_single_catalog_config(postgresql_secret_id)
-        harness.update_config({"catalog-config": catalog_config})
-
-        container = harness.model.unit.get_container("trino")
-
-        ro_props = container.pull(POSTGRESQL_1_CATALOG_PATH).read()
-        rw_props = container.pull(POSTGRESQL_1_DEVELOPER_CATALOG_PATH).read()
-
-        self.assertIn("targetServerType=preferSecondary", ro_props)
-        self.assertIn("targetServerType=primary", rw_props)
-        self.assertNotIn("targetServerType=preferSecondary", rw_props)
-
-    def test_backend_params_applied_when_replica_params_absent(self):
-        """Backend params are used for all replicas when no per-replica params are set.
-
-        Verifies the fallback path: replicas without their own params inherit
-        the backend-level params unchanged.
-        """
-        harness = self.harness
-        simulate_lifecycle_coordinator(harness)
-
-        postgresql_secret_id = harness.add_model_secret(
-            "trino-k8s",
-            {"replicas": POSTGRESQL_REPLICA_SECRET},
-        )
-        catalog_config = create_single_catalog_config(
-            postgresql_secret_id,
-            backend_params="ssl=false&targetServerType=primary",
-        )
-        harness.update_config({"catalog-config": catalog_config})
-
-        container = harness.model.unit.get_container("trino")
-
-        ro_props = container.pull(POSTGRESQL_1_CATALOG_PATH).read()
-        rw_props = container.pull(POSTGRESQL_1_DEVELOPER_CATALOG_PATH).read()
-
-        # Both replicas should carry the backend's params unchanged
-        self.assertIn("targetServerType=primary", ro_props)
-        self.assertIn("targetServerType=primary", rw_props)
-
-    def test_replica_params_override_backend_params_when_both_present(self):
-        """Replica params take precedence over backend params when both are declared.
-
-        Verifies the override path: even when the backend has params, each
-        replica's own params replace them entirely for that catalog file.
-        """
-        harness = self.harness
-        simulate_lifecycle_coordinator(harness)
-
-        postgresql_secret_id = harness.add_model_secret(
-            "trino-k8s",
-            {"replicas": POSTGRESQL_REPLICA_SECRET_WITH_PARAMS},
-        )
-        catalog_config = create_single_catalog_config(
-            postgresql_secret_id,
-            backend_params="ssl=false&targetServerType=primary",
-        )
-        harness.update_config({"catalog-config": catalog_config})
-
-        container = harness.model.unit.get_container("trino")
-
-        ro_props = container.pull(POSTGRESQL_1_CATALOG_PATH).read()
-        rw_props = container.pull(POSTGRESQL_1_DEVELOPER_CATALOG_PATH).read()
-
-        # Replica params should win, backend has targetServerType=primary for both,
-        # but replica declares preferSecondary for ro and primary for rw
-        self.assertIn("targetServerType=preferSecondary", ro_props)
-        self.assertNotIn("targetServerType=primary", ro_props)
-        self.assertIn("targetServerType=primary", rw_props)
-        self.assertNotIn("targetServerType=preferSecondary", rw_props)
-
-    def test_coordinator_publishes_int_comms_secret_id(self):
-        """Coordinator writes int-comms-secret-id to the relation databag instead of plaintext.
-
-        Asserts that:
-        - the coordinator relation databag contains `int-comms-secret-id`
-        - the relation databag does NOT contain any plaintext secret value
-        """
-        harness = self.harness
-        (rel_id, *_) = simulate_lifecycle_coordinator(harness)
-
-        relation_data = harness.get_relation_data(rel_id, harness.charm.app)
-
-        # The secret ID must be present.
-        assert "int-comms-secret-id" in relation_data
-        assert relation_data["int-comms-secret-id"].startswith("secret:")
-
-        # The raw int-comms value must NOT appear in the relation databag.
-        assert "int-comms-secret" not in relation_data
-        assert "int_comms_secret" not in relation_data
-
-    def test_coordinator_int_comms_secret_is_singleton(self):
-        """Calling update_coordinator_relation_data twice reuses the same secret."""
-        harness = self.harness
-        (rel_id, *_) = simulate_lifecycle_coordinator(harness)
-
-        first_id = harness.get_relation_data(rel_id, harness.charm.app).get("int-comms-secret-id")
+        }
+    )
+    state_in, _ = build_coordinator_state(config={"log-level": "all-logs"}, container=container)
+
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    # The change is not applied to the plan.
+    got_log_level = _services(state_out)["trino"]["environment"]["LOG_LEVEL"]
+    assert got_log_level == "info"
+
+    # The BlockStatus is set with a message.
+    assert state_out.unit_status == BlockedStatus("config: invalid log level 'all-logs'")
+
+
+def test_incorrect_relation(ctx):
+    """The charm blocks if the coordinator relation is not added."""
+    state_in, _ = build_coordinator_state(config={"charm-function": "worker"})
+
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    assert state_out.unit_status == BlockedStatus("Incorrect trino relation configuration.")
+
+
+def test_catalog_invalid_config(ctx):
+    """The charm blocks when catalog-config is missing required top-level keys."""
+    state_in, _ = build_coordinator_state(config={"catalog-config": "catalog: incorrect"})
+
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    assert isinstance(state_out.unit_status, BlockedStatus)
+    assert "catalog-config" in state_out.unit_status.message
+
+
+def test_postgresql_catalog_config_bad_prefix(ctx):
+    """The charm blocks when a postgresql-catalog-config entry has an invalid database_prefix."""
+    bad_config = "pg-app:\n  database_prefix: mydb\n  ro_catalog_name: mycat\n"
+    state_in, _ = build_coordinator_state(config={"postgresql-catalog-config": bad_config})
+
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    assert isinstance(state_out.unit_status, BlockedStatus)
+    assert "database_prefix" in state_out.unit_status.message
+
+
+def test_postgresql_catalog_config_no_catalog_name(ctx):
+    """The charm blocks when a postgresql-catalog-config entry has no catalog name."""
+    bad_config = "pg-app:\n  database_prefix: mydb*\n"
+    state_in, _ = build_coordinator_state(config={"postgresql-catalog-config": bad_config})
+
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    assert isinstance(state_out.unit_status, BlockedStatus)
+    assert "ro_catalog_name" in state_out.unit_status.message
+
+
+def test_postgresql_catalog_config_duplicate_catalog_names(ctx):
+    """The charm blocks when two postgresql-catalog-config entries share a catalog name."""
+    duplicate_config = (
+        "pg-app-a:\n  database_prefix: db_a*\n  ro_catalog_name: shared_cat\n"
+        "pg-app-b:\n  database_prefix: db_b*\n  ro_catalog_name: shared_cat\n"
+    )
+    state_in, _ = build_coordinator_state(config={"postgresql-catalog-config": duplicate_config})
+
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    assert isinstance(state_out.unit_status, BlockedStatus)
+    assert "Duplicate" in state_out.unit_status.message
+    assert "shared_cat" in state_out.unit_status.message
+
+
+def test_postgresql_catalog_config_clashes_with_static(ctx):
+    """The charm blocks when a postgresql-catalog-config name clashes with catalog-config."""
+    static_config = yaml.dump(
+        {
+            "catalogs": {"my_static_cat": {"backend": "pg"}},
+            "backends": {"pg": {"connector": "postgresql"}},
+        }
+    )
+    pg_config = "pg-app:\n  database_prefix: db*\n  ro_catalog_name: my_static_cat\n"
+    state_in, _ = build_coordinator_state(
+        config={"catalog-config": static_config, "postgresql-catalog-config": pg_config}
+    )
+
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    assert isinstance(state_out.unit_status, BlockedStatus)
+    assert "clashes with catalog-config" in state_out.unit_status.message
+
+
+def test_session_property_manager_invalid_config(ctx):
+    """The charm blocks when the session property manager JSON is invalid."""
+    state_in, _ = build_coordinator_state(
+        config={"session-property-manager-config": '{"group":"broken"'}
+    )
+
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    assert "Expecting ',' delimiter" in state_out.unit_status.message
+    assert isinstance(state_out.unit_status, BlockedStatus)
+
+
+def test_update_status_up(ctx):
+    """The charm updates the unit status to active based on UP status."""
+    state_in, _ = build_coordinator_state()
+    mid = ctx.run(ctx.on.config_changed(), state_in)
+
+    container = dataclasses.replace(
+        mid.get_container("trino"),
+        check_infos={
+            CheckInfo(
+                "up",
+                status=CheckStatus.UP,
+                level=CheckLevel.UNSET,
+                startup=CheckStartup.UNSET,
+                threshold=None,
+            )
+        },
+    )
+    state = dataclasses.replace(mid, containers={container})
+
+    state_out = ctx.run(ctx.on.update_status(), state)
+
+    assert state_out.unit_status == ActiveStatus("Status check: UP")
+
+
+def test_update_status_down(ctx):
+    """The charm updates the unit status to maintenance based on DOWN status."""
+    state_in, _ = build_coordinator_state()
+    mid = ctx.run(ctx.on.config_changed(), state_in)
+
+    container = dataclasses.replace(
+        mid.get_container("trino"),
+        check_infos={
+            CheckInfo(
+                "up",
+                status=CheckStatus.DOWN,
+                level=CheckLevel.UNSET,
+                startup=CheckStartup.UNSET,
+                threshold=None,
+            )
+        },
+    )
+    state = dataclasses.replace(mid, containers={container})
+
+    state_out = ctx.run(ctx.on.update_status(), state)
+
+    assert state_out.unit_status == MaintenanceStatus("Status check: DOWN")
+
+
+def test_incomplete_pebble_plan(ctx):
+    """The charm re-applies the pebble plan if incomplete."""
+    container = trino_container(layers={"trino": Layer(mock_incomplete_pebble_plan)})
+    state_in, _ = build_coordinator_state(container=container)
+
+    state_out = ctx.run(ctx.on.update_status(), state_in)
+
+    assert state_out.unit_status == MaintenanceStatus("replanning application")
+    assert state_out.get_container("trino").plan.to_dict() != mock_incomplete_pebble_plan
+
+
+def test_trino_coordinator_relation(ctx):
+    """Test trino relation.
+
+    The coordinator and worker Trino charms relate correctly.
+    """
+    state_in, ids = build_coordinator_state()
+
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    relation_data = state_out.get_relation(ids.coordinator_relation.id).local_app_data
+    assert relation_data["discovery-uri"] == "http://trino-k8s.trino-model.svc.cluster.local:8080"
+    assert relation_data["catalogs"] == ids.catalog_config
+
+
+def test_trino_coordinator_relation_discovery_uri_override(ctx):
+    """When discovery-uri config is set, the override is published to workers.
+
+    Workers in cross-cluster or multi-network topologies need the coordinator
+    to advertise a reachable address rather than the cluster-local default.
+    """
+    state_in, ids = build_coordinator_state(
+        config={"discovery-uri": "http://trino.example.com:8080"}
+    )
+
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    relation_data = state_out.get_relation(ids.coordinator_relation.id).local_app_data
+    assert relation_data["discovery-uri"] == "http://trino.example.com:8080"
+
+    # The override is also reflected in the coordinator's own Pebble environment.
+    environment = _services(state_out)["trino"]["environment"]
+    assert environment["DISCOVERY_URI"] == "http://trino.example.com:8080"
+
+
+def test_trino_coordinator_relation_broken(ctx):
+    """Test trino relation broken.
+
+    The coordinator catalog-config secret cannot be resolved.
+    """
+    state_in, ids = build_coordinator_state()
+
+    with ctx(ctx.on.relation_broken(ids.coordinator_relation), state_in) as mgr:
+        mgr.run()
+        with pytest.raises(SecretNotFoundError):
+            mgr.charm.model.get_secret(label="catalog-config")
+
+
+def test_trino_worker_relation_created(ctx):
+    """Test trino relation creation.
+
+    The coordinator and worker Trino charms relate correctly.
+    """
+    state_in, ids = build_worker_state()
+
+    state_out = ctx.run(ctx.on.relation_changed(ids.worker_relation), state_in)
+
+    assert workload_path(state_out, ctx, BIGQUERY_CATALOG_PATH).exists()
+    assert workload_path(state_out, ctx, POSTGRESQL_1_CATALOG_PATH).exists()
+
+
+def test_trino_worker_relation_broken(ctx, tmp_path):
+    """Test trino relation broken.
+
+    The coordinator and worker Trino charms relation is broken.
+    """
+    container = trino_container(
+        mounts={"home": Mount(location="/usr/lib/trino/etc", source=tmp_path)}
+    )
+    state_in, ids = build_worker_state(container=container)
+
+    # Establish the worker catalogs on disk via a relation-changed event.
+    mid = ctx.run(ctx.on.relation_changed(ids.worker_relation), state_in)
+    assert (tmp_path / "catalog" / "postgresql-1.properties").exists()
+
+    ctx.run(ctx.on.relation_broken(ids.worker_relation), mid)
+
+    assert not (tmp_path / "catalog" / "postgresql-1.properties").exists()
+
+
+def test_trino_single_node_deployment(ctx):
+    """Test pebble plan is created with single node deployment."""
+    state = State(
+        leader=True,
+        config={"charm-function": "all"},
+        relations={PeerRelation("peer")},
+        containers={trino_container()},
+    )
+
+    state_out = ctx.run(ctx.on.config_changed(), state)
+
+    # There is a valid pebble plan.
+    assert _services(state_out)["trino"]["environment"]["CHARM_FUNCTION"] == "all"
+
+    # The MaintenanceStatus is set.
+    assert state_out.unit_status == MaintenanceStatus("replanning application")
+
+
+def test_resource_management_config(ctx):
+    """Test resource management configuration variables.
+
+    The charm includes resource management variables in the environment
+    with the correct values when configured.
+    """
+    state_in, _ = build_coordinator_state(
+        config={
+            "query-max-cpu-time": "1h",
+            "query-max-memory-per-node": "2GB",
+            "query-max-memory": "10GB",
+            "query-max-total-memory": "15GB",
+            "memory-heap-headroom-per-node": "1GB",
+        }
+    )
+
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    environment = _services(state_out)["trino"]["environment"]
+    assert environment["QUERY_MAX_CPU_TIME"] == "1h"
+    assert environment["QUERY_MAX_MEMORY_PER_NODE"] == "2GB"
+    assert environment["QUERY_MAX_MEMORY"] == "10GB"
+    assert environment["QUERY_MAX_TOTAL_MEMORY"] == "15GB"
+    assert environment["MEMORY_HEAP_HEADROOM_PER_NODE"] == "1GB"
+
+
+def test_session_property_manager_files_created(ctx):
+    """The charm writes the session property manager files when configured."""
+    session_property_config = (
+        '[{"group":"global.*","sessionProperties":{"query_max_execution_time":"8h"}}]'
+    )
+    state_in, _ = build_coordinator_state(
+        config={"session-property-manager-config": session_property_config}
+    )
+
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    properties_path = "/usr/lib/trino/etc/session-property-config.properties"
+    json_path = "/usr/lib/trino/etc/session-property-config.json"
+
+    assert workload_path(state_out, ctx, properties_path).exists()
+    json_file = workload_path(state_out, ctx, json_path)
+    assert json_file.exists()
+    assert json_file.read_text() == session_property_config
+
+
+def test_session_property_manager_files_removed(ctx, tmp_path):
+    """The charm removes the session property manager files when unset."""
+    # Pre-populate the manager files so the empty config must remove them.
+    (tmp_path / "session-property-config.properties").write_text("stale")
+    (tmp_path / "session-property-config.json").write_text("[]")
+    container = trino_container(
+        mounts={"home": Mount(location="/usr/lib/trino/etc", source=tmp_path)}
+    )
+    state_in, _ = build_coordinator_state(
+        config={"session-property-manager-config": ""}, container=container
+    )
+
+    ctx.run(ctx.on.config_changed(), state_in)
+
+    assert not (tmp_path / "session-property-config.properties").exists()
+    assert not (tmp_path / "session-property-config.json").exists()
+
+
+def test_resource_group_manager_files_created(ctx):
+    """The charm writes the resource group manager files when configured."""
+    resource_groups_config = (
+        '{"rootGroups":[{"name":"global","softMemoryLimit":"80%",'
+        '"hardConcurrencyLimit":10,"maxQueued":10}],"selectors":'
+        '[{"user":".*","group":"global"}]}'
+    )
+    state_in, _ = build_coordinator_state(
+        config={"resource-groups-config": resource_groups_config}
+    )
+
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    properties_path = "/usr/lib/trino/etc/resource-groups.properties"
+    json_path = "/usr/lib/trino/etc/resource-groups.json"
+
+    assert workload_path(state_out, ctx, properties_path).exists()
+    json_file = workload_path(state_out, ctx, json_path)
+    assert json_file.exists()
+    assert json_file.read_text() == resource_groups_config
+
+
+def test_resource_group_manager_files_removed(ctx, tmp_path):
+    """The charm removes the resource group manager files when unset."""
+    (tmp_path / "resource-groups.properties").write_text("stale")
+    (tmp_path / "resource-groups.json").write_text("{}")
+    container = trino_container(
+        mounts={"home": Mount(location="/usr/lib/trino/etc", source=tmp_path)}
+    )
+    state_in, _ = build_coordinator_state(
+        config={"resource-groups-config": ""}, container=container
+    )
+
+    ctx.run(ctx.on.config_changed(), state_in)
+
+    assert not (tmp_path / "resource-groups.properties").exists()
+    assert not (tmp_path / "resource-groups.json").exists()
+
+
+def test_per_replica_params_override_backend_params(ctx):
+    """Per-replica params override backend params in rendered catalog files.
+
+    The rw replica and ro replica must get the targetServerType declared
+    in their respective replica params, not a shared value from the backend.
+    """
+    pg_secret = observer_secret({"replicas": POSTGRESQL_REPLICA_SECRET_WITH_PARAMS})
+    catalog_config = create_single_catalog_config(pg_secret.id)
+    state_in, _ = build_coordinator_state(
+        config={"catalog-config": catalog_config}, extra_secrets=(pg_secret,)
+    )
+
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    ro_props = workload_path(state_out, ctx, POSTGRESQL_1_CATALOG_PATH).read_text()
+    rw_props = workload_path(state_out, ctx, POSTGRESQL_1_DEVELOPER_CATALOG_PATH).read_text()
+
+    assert "targetServerType=preferSecondary" in ro_props
+    assert "targetServerType=primary" in rw_props
+    assert "targetServerType=preferSecondary" not in rw_props
+
+
+def test_backend_params_applied_when_replica_params_absent(ctx):
+    """Backend params are used for all replicas when no per-replica params are set.
+
+    Verifies the fallback path: replicas without their own params inherit
+    the backend-level params unchanged.
+    """
+    pg_secret = observer_secret({"replicas": POSTGRESQL_REPLICA_SECRET})
+    catalog_config = create_single_catalog_config(
+        pg_secret.id, backend_params="ssl=false&targetServerType=primary"
+    )
+    state_in, _ = build_coordinator_state(
+        config={"catalog-config": catalog_config}, extra_secrets=(pg_secret,)
+    )
+
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    ro_props = workload_path(state_out, ctx, POSTGRESQL_1_CATALOG_PATH).read_text()
+    rw_props = workload_path(state_out, ctx, POSTGRESQL_1_DEVELOPER_CATALOG_PATH).read_text()
+
+    assert "targetServerType=primary" in ro_props
+    assert "targetServerType=primary" in rw_props
+
+
+def test_replica_params_override_backend_params_when_both_present(ctx):
+    """Replica params take precedence over backend params when both are declared.
+
+    Verifies the override path: even when the backend has params, each
+    replica's own params replace them entirely for that catalog file.
+    """
+    pg_secret = observer_secret({"replicas": POSTGRESQL_REPLICA_SECRET_WITH_PARAMS})
+    catalog_config = create_single_catalog_config(
+        pg_secret.id, backend_params="ssl=false&targetServerType=primary"
+    )
+    state_in, _ = build_coordinator_state(
+        config={"catalog-config": catalog_config}, extra_secrets=(pg_secret,)
+    )
+
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    ro_props = workload_path(state_out, ctx, POSTGRESQL_1_CATALOG_PATH).read_text()
+    rw_props = workload_path(state_out, ctx, POSTGRESQL_1_DEVELOPER_CATALOG_PATH).read_text()
+
+    assert "targetServerType=preferSecondary" in ro_props
+    assert "targetServerType=primary" not in ro_props
+    assert "targetServerType=primary" in rw_props
+    assert "targetServerType=preferSecondary" not in rw_props
+
+
+def test_coordinator_publishes_int_comms_secret_id(ctx):
+    """Coordinator writes int-comms-secret-id to the relation databag instead of plaintext.
+
+    Asserts that:
+    - the coordinator relation databag contains `int-comms-secret-id`
+    - the relation databag does NOT contain any plaintext secret value
+    """
+    state_in, ids = build_coordinator_state()
+
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    relation_data = state_out.get_relation(ids.coordinator_relation.id).local_app_data
+
+    # The secret ID must be present.
+    assert "int-comms-secret-id" in relation_data
+    assert relation_data["int-comms-secret-id"].startswith("secret:")
+
+    # The raw int-comms value must NOT appear in the relation databag.
+    assert "int-comms-secret" not in relation_data
+    assert "int_comms_secret" not in relation_data
+
+
+def test_coordinator_int_comms_secret_is_singleton(ctx):
+    """Calling update_coordinator_relation_data twice reuses the same secret."""
+    state_in, ids = build_coordinator_state()
+
+    with ctx(ctx.on.config_changed(), state_in) as mgr:
+        mgr.run()
+        relation = mgr.charm.model.get_relation("trino-coordinator")
+        first_id = relation.data[mgr.charm.app].get("int-comms-secret-id")
 
         # Trigger a second update cycle (e.g. config changed).
-        harness.charm.trino_coordinator.update_coordinator_relation_data()
-        second_id = harness.get_relation_data(rel_id, harness.charm.app).get("int-comms-secret-id")
+        mgr.charm.trino_coordinator.update_coordinator_relation_data()
+        second_id = relation.data[mgr.charm.app].get("int-comms-secret-id")
 
-        assert first_id == second_id, "Singleton secret ID must not change between updates"
+    assert first_id == second_id, "Singleton secret ID must not change between updates"
 
-    def test_coordinator_int_comms_secret_preserves_existing_value(self):
-        """When peer state already carries an int-comms value, the Juju secret reuses it."""
-        harness = self.harness
-        # Add the peer relation first so state is accessible.
-        harness.add_relation("peer", "trino")
 
-        # Pre-seed the peer state with a known value.
-        harness.charm.state.int_comms_secret = "pre-existing-secret-value"  # nosec
+def test_coordinator_int_comms_secret_preserves_existing_value(ctx):
+    """When peer state already carries an int-comms value, the Juju secret reuses it."""
+    # Pre-seed the peer state with a known value (JSON-encoded as the state store does).
+    peer = PeerRelation(
+        "peer",
+        local_app_data={"int_comms_secret": '"pre-existing-secret-value"'},  # nosec
+    )
+    # can_connect False so update-status returns early without creating the secret.
+    state = State(
+        leader=True,
+        relations={peer},
+        containers={trino_container(can_connect=False)},
+    )
 
-        # Directly invoke the singleton helper — it must reuse the pre-seeded value.
-        secret = harness.charm.trino_coordinator._get_or_create_int_comms_secret()
+    with ctx(ctx.on.update_status(), state) as mgr:
+        mgr.run()
+        secret = mgr.charm.trino_coordinator._get_or_create_int_comms_secret()
         assert secret is not None
         content = secret.get_content(refresh=True)
         assert content["secret"] == "pre-existing-secret-value"  # nosec
 
         # Calling it again must return the same secret (singleton).
-        secret2 = harness.charm.trino_coordinator._get_or_create_int_comms_secret()
+        secret2 = mgr.charm.trino_coordinator._get_or_create_int_comms_secret()
         assert secret2 is not None
-        # Both invocations must carry the pre-seeded value (no rotation).
         content2 = secret2.get_content(refresh=True)
         assert content2["secret"] == "pre-existing-secret-value"  # nosec
 
-    def test_worker_resolves_int_comms_secret_from_coordinator(self):
-        """Worker reads int-comms-secret from coordinator.
 
-        Worker reads int-comms-secret-id from relation, stores the ID in state, and
-        resolves the secret value at render time via _get_int_comms_secret_value.
-        """
-        harness = self.harness
-        (container, event, *_) = simulate_lifecycle_worker(harness)
+def test_worker_resolves_int_comms_secret_from_coordinator(ctx):
+    """Worker reads int-comms-secret from coordinator.
+
+    Worker reads int-comms-secret-id from relation, stores the ID in state, and
+    resolves the secret value at render time via _get_int_comms_secret_value.
+    """
+    state_in, ids = build_worker_state()
+
+    with ctx(ctx.on.relation_changed(ids.worker_relation), state_in) as mgr:
+        mgr.run()
 
         # The worker's peer state must carry the secret *ID* (not the plaintext value).
-        secret_id = harness.charm.state.int_comms_secret_id
+        secret_id = mgr.charm.state.int_comms_secret_id
         assert secret_id is not None
         assert secret_id.startswith("secret:")
 
         # _get_int_comms_secret_value must resolve to the actual secret content.
-        assert harness.charm._get_int_comms_secret_value() == "test-int-comms-secret"  # nosec
+        assert mgr.charm._get_int_comms_secret_value() == "test-int-comms-secret"  # nosec
 
-    def test_worker_waits_when_int_comms_secret_id_absent(self):
-        """Worker goes into WaitingStatus when int-comms-secret-id is not yet in relation data."""
-        harness = self.harness
-        harness.add_relation("peer", "trino")
 
-        # Mock exec so _update does not fail.
-        harness.handle_exec("trino", ["keytool"], result=0)
-        harness.handle_exec("trino", ["htpasswd"], result=0)
-        harness.handle_exec("trino", ["/bin/sh"], result="/usr/lib/jvm/java-25-openjdk-amd64/")
-        harness.update_config({"charm-function": "worker"})
+def test_worker_waits_when_int_comms_secret_id_absent(ctx):
+    """Worker goes into WaitingStatus when int-comms-secret-id is not yet in relation data."""
+    state_in, ids = build_worker_state(include_int_comms=False)
 
-        container = harness.model.unit.get_container("trino")
-        harness.charm.on.trino_pebble_ready.emit(container)
+    state_out = ctx.run(ctx.on.relation_changed(ids.worker_relation), state_in)
 
-        rel_id = harness.add_relation("trino-worker", "trino-k8s")
-        harness.add_relation_unit(rel_id, "trino-k8s-worker/0")
+    assert state_out.unit_status == WaitingStatus(
+        "waiting for coordinator to publish internal communication secret"
+    )
 
-        # Relation data WITHOUT int-comms-secret-id.
-        data = {
-            "trino-worker": {
-                "discovery-uri": "http://trino-k8s:8080",
-                "catalogs": "",
-            }
-        }
-        event = make_relation_event("trino-worker", rel_id, data)
-        harness.charm.trino_worker._on_relation_changed(event)
 
-        self.assertEqual(
-            harness.model.unit.status,
-            WaitingStatus("waiting for coordinator to publish internal communication secret"),
-        )
+def test_worker_no_plaintext_secret_in_relation_databag(ctx):
+    """Worker never writes a plaintext internal communication secret to relation data.
 
-    def test_worker_no_plaintext_secret_in_relation_databag(self):
-        """Worker never writes a plaintext internal communication secret to relation data.
+    This is the cross-model / cross-controller safety invariant: the databag
+    carries only the Juju secret ID, not the raw value.
+    """
+    state_in, ids = build_worker_state()
 
-        This is the cross-model / cross-controller safety invariant: the databag
-        carries only the Juju secret ID, not the raw value.
-        """
-        harness = self.harness
-        simulate_lifecycle_worker(harness)
+    state_out = ctx.run(ctx.on.relation_changed(ids.worker_relation), state_in)
 
-        relation = harness.charm.model.get_relation("trino-worker")
-        assert relation is not None
-
-        # Only inspect the worker app's own databag — the coordinator's bag is
-        # populated via make_relation_event (a fake dict) and is not accessible
-        # through the real relation in the worker harness.
-        app_data = dict(relation.data[harness.charm.app])
-        for key, value in app_data.items():
-            if "int-comms" in key.lower() and not key.endswith("-id"):
-                raise AssertionError(
-                    f"Plaintext int-comms field {key!r} "
-                    f"found in worker app relation data: {value!r}"
-                )
+    app_data = dict(state_out.get_relation(ids.worker_relation.id).local_app_data)
+    for key, value in app_data.items():
+        if "int-comms" in key.lower() and not key.endswith("-id"):
+            raise AssertionError(
+                f"Plaintext int-comms field {key!r} found in worker app relation data: {value!r}"
+            )

--- a/tests/unit/test_pg_catalog_handler.py
+++ b/tests/unit/test_pg_catalog_handler.py
@@ -185,6 +185,76 @@ class TestBuildJdbcUrl(TestCase):
         handler._import_tls_cert.assert_called_once_with(1, "BEGIN CERT...")
 
 
+class TestTrinoReadiness(TestCase):
+    """Tests for _is_trino_reachable and _wait_for_trino_ready."""
+
+    def _make_handler(self):
+        """Create a mock handler bound to the real readiness methods."""
+        handler = mock.MagicMock()
+        handler._is_trino_reachable = PostgresqlCatalogRelationHandler._is_trino_reachable.__get__(
+            handler
+        )
+        handler._wait_for_trino_ready = (
+            PostgresqlCatalogRelationHandler._wait_for_trino_ready.__get__(handler)
+        )
+        return handler
+
+    @mock.patch("relations.postgresql_catalog.requests.get")
+    def test_reachable_when_started(self, mock_get):
+        """Verify reachable when HTTP 200 and starting is False."""
+        mock_get.return_value = mock.MagicMock(
+            status_code=200, json=mock.MagicMock(return_value={"starting": False})
+        )
+        handler = self._make_handler()
+        self.assertTrue(handler._is_trino_reachable())
+
+    @mock.patch("relations.postgresql_catalog.requests.get")
+    def test_not_reachable_while_starting(self, mock_get):
+        """Verify not reachable when server is still initializing."""
+        mock_get.return_value = mock.MagicMock(
+            status_code=200, json=mock.MagicMock(return_value={"starting": True})
+        )
+        handler = self._make_handler()
+        self.assertFalse(handler._is_trino_reachable())
+
+    @mock.patch("relations.postgresql_catalog.requests.get")
+    def test_not_reachable_on_non_200(self, mock_get):
+        """Verify not reachable when the health endpoint returns non-200."""
+        mock_get.return_value = mock.MagicMock(status_code=503)
+        handler = self._make_handler()
+        self.assertFalse(handler._is_trino_reachable())
+
+    @mock.patch("relations.postgresql_catalog.requests.get", side_effect=Exception("boom"))
+    def test_not_reachable_on_exception(self, _mock_get):
+        """Verify not reachable when the request raises."""
+        handler = self._make_handler()
+        self.assertFalse(handler._is_trino_reachable())
+
+    def test_wait_returns_true_when_ready(self):
+        """Verify wait returns True immediately when Trino is ready."""
+        handler = self._make_handler()
+        handler._is_trino_reachable = mock.MagicMock(return_value=True)
+        self.assertTrue(handler._wait_for_trino_ready(timeout=10, interval=0))
+
+    @mock.patch("relations.postgresql_catalog.time.sleep")
+    @mock.patch("relations.postgresql_catalog.time.time")
+    def test_wait_returns_true_after_retry(self, mock_time, _mock_sleep):
+        """Verify wait retries until Trino becomes ready."""
+        mock_time.side_effect = [0.0, 0.0, 5.0]
+        handler = self._make_handler()
+        handler._is_trino_reachable = mock.MagicMock(side_effect=[False, True])
+        self.assertTrue(handler._wait_for_trino_ready(timeout=300, interval=5))
+
+    @mock.patch("relations.postgresql_catalog.time.sleep")
+    @mock.patch("relations.postgresql_catalog.time.time")
+    def test_wait_returns_false_on_timeout(self, mock_time, _mock_sleep):
+        """Verify wait returns False when the timeout elapses."""
+        mock_time.side_effect = [0.0, 301.0]
+        handler = self._make_handler()
+        handler._is_trino_reachable = mock.MagicMock(return_value=False)
+        self.assertFalse(handler._wait_for_trino_ready(timeout=300, interval=5))
+
+
 def _pg_yaml(entries: dict) -> str:
     """Serialise a postgresql-catalog-config dict to a YAML string."""
     return yaml.dump(entries)

--- a/tests/unit/test_policy.py
+++ b/tests/unit/test_policy.py
@@ -37,7 +37,7 @@ OPENSEARCH_TLS_CA = """-----BEGIN CERTIFICATE-----
 
 
 def _up_check_container(state):
-    """Return the container with a healthy ``up`` check applied."""
+    """Return the container with a healthy `up` check applied."""
     return dataclasses.replace(
         state.get_container("trino"),
         check_infos={
@@ -56,10 +56,10 @@ def _opensearch_setup(ctx):
     """Simulate a coordinator with Ranger and OpenSearch enabled.
 
     Args:
-        ctx: the Scenario ``Context`` for the charm.
+        ctx: the Scenario `Context` for the charm.
 
     Returns:
-        A ``(State, Relation)`` tuple with the OpenSearch index created and the
+        A `(State, Relation)` tuple with the OpenSearch index created and the
         OpenSearch relation object.
     """
     user_secret = observer_secret({"username": "testuser", "password": "testpassword"})  # nosec B105

--- a/tests/unit/test_policy.py
+++ b/tests/unit/test_policy.py
@@ -8,239 +8,178 @@
 
 # pylint:disable=protected-access
 
+import dataclasses
 import logging
 import re
-from unittest import TestCase, mock
 
 from ops.model import ActiveStatus, MaintenanceStatus
-from ops.pebble import CheckStatus
-from ops.testing import Harness
+from ops.pebble import CheckLevel, CheckStartup, CheckStatus
+from ops.testing import CheckInfo, Relation
 
-from charm import TrinoK8SCharm
 from tests.unit.helpers import (
     POLICY_MGR_URL,
     RANGER_AUDIT_PATH,
     RANGER_SECURITY_PATH,
+    build_coordinator_state,
+    carry_forward,
+    observer_secret,
+    workload_path,
 )
 
 logger = logging.getLogger(__name__)
 
-OPENSEARCH_RELATION_CHANGED_DATA = {
-    "opensearch": {
-        "secret-tls": "secretid2",
-        "secret-user": "secretid",
-        "endpoints": "opensearch-host:port",
-    }
-}
-OPENSEARCH_RELATION_BROKEN_DATA: dict = {"opensearch": {}}
-USER_SECRET_CONTENT = {
-    "username": "testuser",
-    "password": "testpassword",  # nosec
-    "tls-ca": """-----BEGIN CERTIFICATE-----
+OPENSEARCH_TLS_CA = """-----BEGIN CERTIFICATE-----
     MIIC+DCCAeCgAwIBAgIJAKJdWfG2zRAQMA0GCSqGSIb3DQEBCwUAMIGPMQswCQYD
     -----END CERTIFICATE-----
     -----BEGIN CERTIFICATE-----
     AIBC+LCCAuCgAPIBAgIuAKJdWWG2zRAQMA0GFSqGSIP3DQEBCiUAMIGPMQswCQYC
-    -----END CERTIFICATE-----""",
-}
+    -----END CERTIFICATE-----"""
 
 
-class TestPolicy(TestCase):
-    """Unit tests.
-
-    Attrs:
-        maxDiff: Specifies max difference shown by failed tests.
-    """
-
-    maxDiff = None
-
-    @mock.patch("charm.KubernetesStatefulsetPatch")
-    def setUp(self, _):
-        """Set up for the unit tests."""
-        self.harness = Harness(TrinoK8SCharm)
-        self.addCleanup(self.harness.cleanup)
-        self.harness.set_can_connect("trino", True)
-        self.harness.set_leader(True)
-        self.harness.set_model_name("trino-model")
-        self.harness.add_network("10.0.0.10", endpoint="peer")
-        self.harness.begin()
-
-    def test_policy_relation_created(self):
-        """Add policy relation."""
-        harness = self.harness
-        rel_id = simulate_lifecycle(harness)
-
-        relation_data = self.harness.get_relation_data(rel_id, "trino-k8s")
-        assert relation_data == {
-            "name": f"relation_{rel_id}",
-            "type": "trino",
-            "jdbc.driverClassName": "io.trino.jdbc.TrinoDriver",
-            "jdbc.url": "jdbc:trino://trino-k8s.trino-model.svc.cluster.local:8080",
-        }
-
-    def test_policy_relation_changed(self):
-        """Add policy_manager_url to the relation databag."""
-        harness = self.harness
-        rel_id = simulate_lifecycle(harness)
-        container = harness.model.unit.get_container("trino")
-
-        # Create and emit the policy `_on_relation_changed` event.
-        data = {
-            "ranger-k8s": {
-                "policy_manager_url": POLICY_MGR_URL,
-            },
-        }
-        event = make_relation_event("ranger-k8s", rel_id, data)
-        harness.charm.policy._on_relation_changed(event)
-
-        ranger_config = container.pull(RANGER_SECURITY_PATH).read()
-        self.assertTrue(POLICY_MGR_URL in ranger_config)
-
-    def test_policy_relation_broken(self):
-        """Add policy_manager_url to the relation databag."""
-        harness = self.harness
-        rel_id = simulate_lifecycle(harness)
-
-        data = {"ranger-k8s": {}}
-        event = make_relation_event("ranger-k8s", rel_id, data)
-        harness.charm.policy._on_relation_broken(event)
-
-        self.assertFalse(event.relation.data["ranger-k8s"].get("user-group-configuration"))
-
-    @mock.patch("charm.OpensearchRelationHandler.get_secret_content")
-    def opensearch_setup(
-        self,
-        mock_get_secret_content,
-        harness,
-        data,
-    ):
-        """Set up common state for Opensearch relation changed and broken tests.
-
-        Args:
-            mock_get_secret_content: the mocked method for accessing juju secrets.
-            harness: ops.testing.Harness object used to simulate charm lifecycle.
-            data: the opensearch relation data.
-
-        Returns:
-            rel_id: the opensearch relation id.
-        """
-        mock_get_secret_content.return_value = USER_SECRET_CONTENT
-
-        ranger_rel_id = simulate_lifecycle(harness)
-        data = {
-            "ranger-k8s": {
-                "policy_manager_url": POLICY_MGR_URL,
-            },
-        }
-        event = make_relation_event("ranger-k8s", ranger_rel_id, data)
-        harness.charm.policy._on_relation_changed(event)
-
-        rel_id = harness.add_relation("opensearch", "opensearch-app")
-        harness.add_relation_unit(rel_id, "opensearch-app/0")
-        harness.handle_exec("trino", ["keytool"], result=0)
-        event = make_relation_event("opensearch", rel_id, OPENSEARCH_RELATION_CHANGED_DATA)
-        harness.charm.opensearch_relation_handler._on_index_created(event)
-        return rel_id
-
-    def test_on_opensearch_index_created(self):
-        """Test handling of opensearch relation changed events."""
-        harness = self.harness
-        self.opensearch_setup(harness=harness, data=OPENSEARCH_RELATION_CHANGED_DATA)
-
-        self.assertEqual(
-            harness.model.unit.status,
-            MaintenanceStatus("Restarting Ranger plugin"),
-        )
-        container = harness.model.unit.get_container("trino")
-        self.assertTrue(container.exists("/opensearch.crt"))
-        ranger_config = container.pull(RANGER_AUDIT_PATH).read()
-        ranger_config = re.sub(r"\s", "", ranger_config)
-        user_config = (
-            "<name>xasecure.audit.destination.elasticsearch.user</name><value>testuser</value>"
-        )
-        self.assertTrue(user_config in ranger_config)
-
-        container.get_check = mock.Mock(status="up")
-        container.get_check.return_value.status = CheckStatus.UP
-        harness.charm.on.update_status.emit()
-        self.assertEqual(harness.model.unit.status, ActiveStatus("Status check: UP"))
-
-    def test_on_opensearch_relation_broken(self):
-        """Test handling of broken relations with opensearch."""
-        harness = self.harness
-        rel_id = self.opensearch_setup(harness=harness, data=OPENSEARCH_RELATION_CHANGED_DATA)
-        data = OPENSEARCH_RELATION_BROKEN_DATA
-        event = make_relation_event("opensearch", rel_id, data)
-        self.harness.charm.opensearch_relation_handler._on_relation_broken(event)
-        self.assertEqual(
-            harness.model.unit.status,
-            MaintenanceStatus("Restarting Ranger plugin"),
-        )
-        container = harness.model.unit.get_container("trino")
-        self.assertFalse(container.exists("/opensearch.crt"))
-        ranger_config = container.pull(RANGER_AUDIT_PATH).read()
-        self.assertFalse("testuser" in ranger_config)
-        container.get_check = mock.Mock(status="up")
-        container.get_check.return_value.status = CheckStatus.UP
-        harness.charm.on.update_status.emit()
-        self.assertEqual(harness.model.unit.status, ActiveStatus("Status check: UP"))
-
-
-def simulate_lifecycle(harness):
-    """Simulate a healthy charm life-cycle.
-
-    Args:
-        harness: ops.testing.Harness object used to simulate charm lifecycle.
-
-    Returns:
-        rel_id: Ranger relation id.
-    """
-    # Simulate peer relation readiness.
-    harness.add_relation("peer", "trino")
-
-    # Simulate pebble readiness.
-    container = harness.model.unit.get_container("trino")
-    harness.handle_exec("trino", ["htpasswd"], result=0)
-    harness.handle_exec("trino", ["/bin/sh"], result="/usr/lib/jvm/java-25-openjdk-amd64/")
-    harness.handle_exec("trino", ["keytool"], result=0)
-    harness.charm.on.trino_pebble_ready.emit(container)
-
-    # Add worker and coordinator relation
-    harness.update_config({"charm-function": "coordinator"})
-    harness.add_relation("trino-coordinator", "trino-k8s-worker")
-
-    rel_id = harness.add_relation("policy", "trino-k8s")
-    harness.add_relation_unit(rel_id, "trino-k8s/0")
-
-    data = {harness.charm.app: {}}
-    event = make_relation_event("ranger-k8s", rel_id, data)
-    harness.handle_exec("trino", ["bash"], result=0)
-    harness.charm.policy._on_relation_created(event)
-    return rel_id
-
-
-def make_relation_event(app, rel_id, data):
-    """Create and return a mock policy created event.
-
-        The event is generated by the relation with postgresql_db
-
-    Args:
-        app: name of the application.
-        rel_id: relation id.
-        data: relation data.
-
-    Returns:
-        Event dict.
-    """
-    return type(
-        "Event",
-        (),
-        {
-            "app": app,
-            "relation": type(
-                "Relation",
-                (),
-                {"data": data, "id": rel_id},
-            ),
+def _up_check_container(state):
+    """Return the container with a healthy ``up`` check applied."""
+    return dataclasses.replace(
+        state.get_container("trino"),
+        check_infos={
+            CheckInfo(
+                "up",
+                status=CheckStatus.UP,
+                level=CheckLevel.UNSET,
+                startup=CheckStartup.UNSET,
+                threshold=None,
+            )
         },
     )
+
+
+def _opensearch_setup(ctx):
+    """Simulate a coordinator with Ranger and OpenSearch enabled.
+
+    Args:
+        ctx: the Scenario ``Context`` for the charm.
+
+    Returns:
+        A ``(State, Relation)`` tuple with the OpenSearch index created and the
+        OpenSearch relation object.
+    """
+    user_secret = observer_secret({"username": "testuser", "password": "testpassword"})  # nosec B105
+    tls_secret = observer_secret({"tls-ca": OPENSEARCH_TLS_CA})
+    policy_rel = Relation(
+        "policy",
+        remote_app_name="ranger-k8s",
+        remote_app_data={"policy_manager_url": POLICY_MGR_URL},
+    )
+    opensearch_rel = Relation(
+        "opensearch",
+        remote_app_name="opensearch-app",
+        remote_app_data={
+            "secret-user": user_secret.id,
+            "secret-tls": tls_secret.id,
+            "endpoints": "opensearch-host:port",
+        },
+    )
+    state_in, _ = build_coordinator_state(
+        extra_relations=[policy_rel, opensearch_rel],
+        extra_secrets=[user_secret, tls_secret],
+    )
+
+    # Bootstrap the workload (Pebble layer + truststore password).
+    state = carry_forward(ctx.run(ctx.on.config_changed(), state_in))
+
+    # Enable the Ranger plugin via the policy relation.
+    state = carry_forward(ctx.run(ctx.on.relation_changed(policy_rel), state))
+
+    # Create the OpenSearch index. The OpenSearch credentials and certificate
+    # are resolved from real Juju secrets shared over the relation.
+    state = ctx.run(ctx.on.relation_changed(opensearch_rel), state)
+
+    return state, opensearch_rel
+
+
+def test_policy_relation_created(ctx):
+    """Add policy relation."""
+    policy_rel = Relation("policy", remote_app_name="ranger-k8s")
+    state_in, _ = build_coordinator_state(extra_relations=[policy_rel])
+
+    state_out = ctx.run(ctx.on.relation_created(policy_rel), state_in)
+
+    relation_data = state_out.get_relation(policy_rel.id).local_app_data
+    assert relation_data == {
+        "name": f"relation_{policy_rel.id}",
+        "type": "trino",
+        "jdbc.driverClassName": "io.trino.jdbc.TrinoDriver",
+        "jdbc.url": "jdbc:trino://trino-k8s.trino-model.svc.cluster.local:8080",
+    }
+
+
+def test_policy_relation_changed(ctx):
+    """Add policy_manager_url to the relation databag."""
+    policy_rel = Relation(
+        "policy",
+        remote_app_name="ranger-k8s",
+        remote_app_data={"policy_manager_url": POLICY_MGR_URL},
+    )
+    state_in, _ = build_coordinator_state(extra_relations=[policy_rel])
+    bootstrapped = carry_forward(ctx.run(ctx.on.config_changed(), state_in))
+
+    state_out = ctx.run(ctx.on.relation_changed(policy_rel), bootstrapped)
+
+    ranger_config = workload_path(state_out, ctx, RANGER_SECURITY_PATH).read_text()
+    assert POLICY_MGR_URL in ranger_config
+
+
+def test_policy_relation_broken(ctx):
+    """Removing the policy relation disables the Ranger plugin."""
+    policy_rel = Relation("policy", remote_app_name="ranger-k8s")
+    state_in, _ = build_coordinator_state(extra_relations=[policy_rel])
+    bootstrapped = carry_forward(ctx.run(ctx.on.config_changed(), state_in))
+
+    state_out = ctx.run(ctx.on.relation_broken(policy_rel), bootstrapped)
+
+    relation_data = state_out.get_relation(policy_rel.id).local_app_data
+    assert not relation_data.get("user-group-configuration")
+
+
+def test_on_opensearch_index_created(ctx):
+    """Test handling of opensearch relation changed events."""
+    state, _ = _opensearch_setup(ctx)
+
+    assert state.unit_status == MaintenanceStatus("Restarting Ranger plugin")
+    assert workload_path(state, ctx, "/opensearch.crt").exists()
+
+    ranger_config = workload_path(state, ctx, RANGER_AUDIT_PATH).read_text()
+    ranger_config = re.sub(r"\s", "", ranger_config)
+    user_config = (
+        "<name>xasecure.audit.destination.elasticsearch.user</name><value>testuser</value>"
+    )
+    assert user_config in ranger_config
+
+    state = dataclasses.replace(state, containers={_up_check_container(state)})
+    state_out = ctx.run(ctx.on.update_status(), state)
+    assert state_out.unit_status == ActiveStatus("Status check: UP")
+
+
+def test_on_opensearch_relation_broken(ctx):
+    """Test handling of broken relations with opensearch."""
+    state, opensearch_rel = _opensearch_setup(ctx)
+    state = carry_forward(state)
+    opensearch_rel = state.get_relation(opensearch_rel.id)
+
+    # The OpenSearch certificate was installed when the index was created; seed
+    # it so the broken handler can remove it (the workload filesystem is reset
+    # between Scenario runs).
+    with ctx(ctx.on.relation_broken(opensearch_rel), state) as mgr:
+        mgr.charm.unit.get_container("trino").push(
+            "/opensearch.crt", "certificate", make_dirs=True
+        )
+        state = mgr.run()
+
+    assert state.unit_status == MaintenanceStatus("Restarting Ranger plugin")
+    assert not workload_path(state, ctx, "/opensearch.crt").exists()
+
+    ranger_config = workload_path(state, ctx, RANGER_AUDIT_PATH).read_text()
+    assert "testuser" not in ranger_config
+
+    state = dataclasses.replace(state, containers={_up_check_container(state)})
+    state_out = ctx.run(ctx.on.update_status(), state)
+    assert state_out.unit_status == ActiveStatus("Status check: UP")

--- a/uv.lock
+++ b/uv.lock
@@ -34,64 +34,12 @@ wheels = [
 ]
 
 [[package]]
-name = "asttokens"
-version = "3.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/be/a5/8e3f9b6771b0b408517c82d97aed8f2036509bc247d46114925e32fe33f0/asttokens-3.0.1.tar.gz", hash = "sha256:71a4ee5de0bde6a31d64f6b13f2293ac190344478f081c3d1bccfcf5eacb0cb7", size = 62308, upload-time = "2025-11-15T16:43:48.578Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl", hash = "sha256:15a3ebc0f43c2d0a50eeafea25e19046c68398e487b9f1f5b517f7c0f40f976a", size = 27047, upload-time = "2025-11-15T16:43:16.109Z" },
-]
-
-[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
-]
-
-[[package]]
-name = "backports-datetime-fromisoformat"
-version = "2.0.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/71/81/eff3184acb1d9dc3ce95a98b6f3c81a49b4be296e664db8e1c2eeabef3d9/backports_datetime_fromisoformat-2.0.3.tar.gz", hash = "sha256:b58edc8f517b66b397abc250ecc737969486703a66eb97e01e6d51291b1a139d", size = 23588, upload-time = "2024-12-28T20:18:15.017Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/4b/d6b051ca4b3d76f23c2c436a9669f3be616b8cf6461a7e8061c7c4269642/backports_datetime_fromisoformat-2.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5f681f638f10588fa3c101ee9ae2b63d3734713202ddfcfb6ec6cea0778a29d4", size = 27561, upload-time = "2024-12-28T20:16:47.974Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/40/e39b0d471e55eb1b5c7c81edab605c02f71c786d59fb875f0a6f23318747/backports_datetime_fromisoformat-2.0.3-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:cd681460e9142f1249408e5aee6d178c6d89b49e06d44913c8fdfb6defda8d1c", size = 34448, upload-time = "2024-12-28T20:16:50.712Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/28/7a5c87c5561d14f1c9af979231fdf85d8f9fad7a95ff94e56d2205e2520a/backports_datetime_fromisoformat-2.0.3-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:ee68bc8735ae5058695b76d3bb2aee1d137c052a11c8303f1e966aa23b72b65b", size = 27093, upload-time = "2024-12-28T20:16:52.994Z" },
-    { url = "https://files.pythonhosted.org/packages/80/ba/f00296c5c4536967c7d1136107fdb91c48404fe769a4a6fd5ab045629af8/backports_datetime_fromisoformat-2.0.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8273fe7932db65d952a43e238318966eab9e49e8dd546550a41df12175cc2be4", size = 52836, upload-time = "2024-12-28T20:16:55.283Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/92/bb1da57a069ddd601aee352a87262c7ae93467e66721d5762f59df5021a6/backports_datetime_fromisoformat-2.0.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39d57ea50aa5a524bb239688adc1d1d824c31b6094ebd39aa164d6cadb85de22", size = 52798, upload-time = "2024-12-28T20:16:56.64Z" },
-    { url = "https://files.pythonhosted.org/packages/df/ef/b6cfd355982e817ccdb8d8d109f720cab6e06f900784b034b30efa8fa832/backports_datetime_fromisoformat-2.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:ac6272f87693e78209dc72e84cf9ab58052027733cd0721c55356d3c881791cf", size = 52891, upload-time = "2024-12-28T20:16:58.887Z" },
-    { url = "https://files.pythonhosted.org/packages/37/39/b13e3ae8a7c5d88b68a6e9248ffe7066534b0cfe504bf521963e61b6282d/backports_datetime_fromisoformat-2.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:44c497a71f80cd2bcfc26faae8857cf8e79388e3d5fbf79d2354b8c360547d58", size = 52955, upload-time = "2024-12-28T20:17:00.028Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/e4/70cffa3ce1eb4f2ff0c0d6f5d56285aacead6bd3879b27a2ba57ab261172/backports_datetime_fromisoformat-2.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:6335a4c9e8af329cb1ded5ab41a666e1448116161905a94e054f205aa6d263bc", size = 29323, upload-time = "2024-12-28T20:17:01.125Z" },
-    { url = "https://files.pythonhosted.org/packages/62/f5/5bc92030deadf34c365d908d4533709341fb05d0082db318774fdf1b2bcb/backports_datetime_fromisoformat-2.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e2e4b66e017253cdbe5a1de49e0eecff3f66cd72bcb1229d7db6e6b1832c0443", size = 27626, upload-time = "2024-12-28T20:17:03.448Z" },
-    { url = "https://files.pythonhosted.org/packages/28/45/5885737d51f81dfcd0911dd5c16b510b249d4c4cf6f4a991176e0358a42a/backports_datetime_fromisoformat-2.0.3-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:43e2d648e150777e13bbc2549cc960373e37bf65bd8a5d2e0cef40e16e5d8dd0", size = 34588, upload-time = "2024-12-28T20:17:04.459Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/6d/bd74de70953f5dd3e768c8fc774af942af0ce9f211e7c38dd478fa7ea910/backports_datetime_fromisoformat-2.0.3-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:4ce6326fd86d5bae37813c7bf1543bae9e4c215ec6f5afe4c518be2635e2e005", size = 27162, upload-time = "2024-12-28T20:17:06.752Z" },
-    { url = "https://files.pythonhosted.org/packages/47/ba/1d14b097f13cce45b2b35db9898957578b7fcc984e79af3b35189e0d332f/backports_datetime_fromisoformat-2.0.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d7c8fac333bf860208fd522a5394369ee3c790d0aa4311f515fcc4b6c5ef8d75", size = 54482, upload-time = "2024-12-28T20:17:08.15Z" },
-    { url = "https://files.pythonhosted.org/packages/25/e9/a2a7927d053b6fa148b64b5e13ca741ca254c13edca99d8251e9a8a09cfe/backports_datetime_fromisoformat-2.0.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:24a4da5ab3aa0cc293dc0662a0c6d1da1a011dc1edcbc3122a288cfed13a0b45", size = 54362, upload-time = "2024-12-28T20:17:10.605Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/99/394fb5e80131a7d58c49b89e78a61733a9994885804a0bb582416dd10c6f/backports_datetime_fromisoformat-2.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:58ea11e3bf912bd0a36b0519eae2c5b560b3cb972ea756e66b73fb9be460af01", size = 54162, upload-time = "2024-12-28T20:17:12.301Z" },
-    { url = "https://files.pythonhosted.org/packages/88/25/1940369de573c752889646d70b3fe8645e77b9e17984e72a554b9b51ffc4/backports_datetime_fromisoformat-2.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:8a375c7dbee4734318714a799b6c697223e4bbb57232af37fbfff88fb48a14c6", size = 54118, upload-time = "2024-12-28T20:17:13.609Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/46/f275bf6c61683414acaf42b2df7286d68cfef03e98b45c168323d7707778/backports_datetime_fromisoformat-2.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:ac677b1664c4585c2e014739f6678137c8336815406052349c85898206ec7061", size = 29329, upload-time = "2024-12-28T20:17:16.124Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/0f/69bbdde2e1e57c09b5f01788804c50e68b29890aada999f2b1a40519def9/backports_datetime_fromisoformat-2.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:66ce47ee1ba91e146149cf40565c3d750ea1be94faf660ca733d8601e0848147", size = 27630, upload-time = "2024-12-28T20:17:19.442Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/1d/1c84a50c673c87518b1adfeafcfd149991ed1f7aedc45d6e5eac2f7d19d7/backports_datetime_fromisoformat-2.0.3-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:8b7e069910a66b3bba61df35b5f879e5253ff0821a70375b9daf06444d046fa4", size = 34707, upload-time = "2024-12-28T20:17:21.79Z" },
-    { url = "https://files.pythonhosted.org/packages/71/44/27eae384e7e045cda83f70b551d04b4a0b294f9822d32dea1cbf1592de59/backports_datetime_fromisoformat-2.0.3-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:a3b5d1d04a9e0f7b15aa1e647c750631a873b298cdd1255687bb68779fe8eb35", size = 27280, upload-time = "2024-12-28T20:17:24.503Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/7a/a4075187eb6bbb1ff6beb7229db5f66d1070e6968abeb61e056fa51afa5e/backports_datetime_fromisoformat-2.0.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ec1b95986430e789c076610aea704db20874f0781b8624f648ca9fb6ef67c6e1", size = 55094, upload-time = "2024-12-28T20:17:25.546Z" },
-    { url = "https://files.pythonhosted.org/packages/71/03/3fced4230c10af14aacadc195fe58e2ced91d011217b450c2e16a09a98c8/backports_datetime_fromisoformat-2.0.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ffe5f793db59e2f1d45ec35a1cf51404fdd69df9f6952a0c87c3060af4c00e32", size = 55605, upload-time = "2024-12-28T20:17:29.208Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/0a/4b34a838c57bd16d3e5861ab963845e73a1041034651f7459e9935289cfd/backports_datetime_fromisoformat-2.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:620e8e73bd2595dfff1b4d256a12b67fce90ece3de87b38e1dde46b910f46f4d", size = 55353, upload-time = "2024-12-28T20:17:32.433Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/68/07d13c6e98e1cad85606a876367ede2de46af859833a1da12c413c201d78/backports_datetime_fromisoformat-2.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4cf9c0a985d68476c1cabd6385c691201dda2337d7453fb4da9679ce9f23f4e7", size = 55298, upload-time = "2024-12-28T20:17:34.919Z" },
-    { url = "https://files.pythonhosted.org/packages/60/33/45b4d5311f42360f9b900dea53ab2bb20a3d61d7f9b7c37ddfcb3962f86f/backports_datetime_fromisoformat-2.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:d144868a73002e6e2e6fef72333e7b0129cecdd121aa8f1edba7107fd067255d", size = 29375, upload-time = "2024-12-28T20:17:36.018Z" },
-    { url = "https://files.pythonhosted.org/packages/be/03/7eaa9f9bf290395d57fd30d7f1f2f9dff60c06a31c237dc2beb477e8f899/backports_datetime_fromisoformat-2.0.3-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90e202e72a3d5aae673fcc8c9a4267d56b2f532beeb9173361293625fe4d2039", size = 28980, upload-time = "2024-12-28T20:18:06.554Z" },
-    { url = "https://files.pythonhosted.org/packages/47/80/a0ecf33446c7349e79f54cc532933780341d20cff0ee12b5bfdcaa47067e/backports_datetime_fromisoformat-2.0.3-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2df98ef1b76f5a58bb493dda552259ba60c3a37557d848e039524203951c9f06", size = 28449, upload-time = "2024-12-28T20:18:07.77Z" },
-]
-
-[[package]]
-name = "backports-strenum"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/35/c7/2ed54c32fed313591ffb21edbd48db71e68827d43a61938e5a0bc2b6ec91/backports_strenum-1.3.1.tar.gz", hash = "sha256:77c52407342898497714f0596e86188bb7084f89063226f4ba66863482f42414", size = 7257, upload-time = "2023-12-09T14:36:40.937Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/50/56cf20e2ee5127b603b81d5a69580a1a325083e2b921aa8f067da83927c0/backports_strenum-1.3.1-py3-none-any.whl", hash = "sha256:cdcfe36dc897e2615dc793b7d3097f54d359918fc448754a517e6f23044ccf83", size = 8304, upload-time = "2023-12-09T14:36:39.905Z" },
 ]
 
 [[package]]
@@ -602,15 +550,6 @@ wheels = [
 ]
 
 [[package]]
-name = "decorator"
-version = "5.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/60/8b/32f9823da46cde7df2087faa08cd98d01b908f8dcab982cdba9c84e85355/decorator-5.3.1.tar.gz", hash = "sha256:4cbcdd55a6efadb9dbea26b858f4fb3264567b52d69ca0d25b721b553f60ea82", size = 58084, upload-time = "2026-05-18T06:03:28.057Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/7f/798705f5296a58ca505d600456748d1be48078eac8a7050d8a98bc9edb89/decorator-5.3.1-py3-none-any.whl", hash = "sha256:f47fe6fdbd2edd623ecfe36875d37aba411624e2670dd395dddae1358689bb3c", size = 10365, upload-time = "2026-05-18T06:03:26.517Z" },
-]
-
-[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -620,28 +559,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
-]
-
-[[package]]
-name = "executing"
-version = "2.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
-]
-
-[[package]]
-name = "google-auth"
-version = "2.53.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cryptography" },
-    { name = "pyasn1-modules" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/ad/ff781329bbbdc0974a098d996e89c9e1f7024262f9e3eec442fbb9ad1ac6/google_auth-2.53.0.tar.gz", hash = "sha256:e7e6aa16f6bee7b2b264830fd04f08087a1d5a836df516251a5d15327b246c9c", size = 335844, upload-time = "2026-05-15T20:53:07.928Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/c9/db44165ba7c581268c6d46017ef63339110378305062830104fc7fa144cb/google_auth-2.53.0-py3-none-any.whl", hash = "sha256:6e7449917c599b35126a99ec268ec6880301f2fea41dce198fe8fd83ff642b68", size = 246071, upload-time = "2026-05-15T20:53:05.609Z" },
 ]
 
 [[package]]
@@ -724,18 +641,6 @@ wheels = [
 ]
 
 [[package]]
-name = "hvac"
-version = "2.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/57/b46c397fb3842cfb02a44609aa834c887f38dd75f290c2fc5a34da4b2fee/hvac-2.4.0.tar.gz", hash = "sha256:e0056ad9064e7923e874e6769015b032580b639e29246f5ab1044f7959c1c7e0", size = 332543, upload-time = "2025-10-30T12:57:47.512Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/33/71e45a6bd6875f44a26f99da31c63b6840123e88bedf2c0b1ce429b8be12/hvac-2.4.0-py3-none-any.whl", hash = "sha256:008db5efd8c2f77bd37d2368ea5f713edceae1c65f11fd608393179478649e0f", size = 155921, upload-time = "2025-10-30T12:57:46.253Z" },
-]
-
-[[package]]
 name = "hyperframe"
 version = "6.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -760,105 +665,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
-]
-
-[[package]]
-name = "invoke"
-version = "3.0.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/33/f6/227c48c5fe47fa178ccf1fda8f047d16c97ba926567b661e9ce2045c600c/invoke-3.0.3.tar.gz", hash = "sha256:437b6a622223824380bfb4e64f612711a6b648c795f565efc8625af66fb57f0c", size = 343419, upload-time = "2026-04-07T15:17:48.307Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/de/bbc12563bbf979618d17625a4e753ff7a078523e28d870d3626daa97261a/invoke-3.0.3-py3-none-any.whl", hash = "sha256:f11327165e5cbb89b2ad1d88d3292b5113332c43b8553b494da435d6ec6f5053", size = 160958, upload-time = "2026-04-07T15:17:46.875Z" },
-]
-
-[[package]]
-name = "ipdb"
-version = "0.13.13"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "decorator" },
-    { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "ipython", version = "9.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/1b/7e07e7b752017f7693a0f4d41c13e5ca29ce8cbcfdcc1fd6c4ad8c0a27a0/ipdb-0.13.13.tar.gz", hash = "sha256:e3ac6018ef05126d442af680aad863006ec19d02290561ac88b8b1c0b0cfc726", size = 17042, upload-time = "2023-03-09T15:40:57.487Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/4c/b075da0092003d9a55cf2ecc1cae9384a1ca4f650d51b00fc59875fe76f6/ipdb-0.13.13-py3-none-any.whl", hash = "sha256:45529994741c4ab6d2388bfa5d7b725c2cf7fe9deffabdb8a6113aa5ed449ed4", size = 12130, upload-time = "2023-03-09T15:40:55.021Z" },
-]
-
-[[package]]
-name = "ipython"
-version = "8.39.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.11'",
-]
-dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.11'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "jedi", marker = "python_full_version < '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
-    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "stack-data", marker = "python_full_version < '3.11'" },
-    { name = "traitlets", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/40/18/f8598d287006885e7136451fdea0755af4ebcbfe342836f24deefaed1164/ipython-8.39.0.tar.gz", hash = "sha256:4110ae96012c379b8b6db898a07e186c40a2a1ef5d57a7fa83166047d9da7624", size = 5513971, upload-time = "2026-03-27T10:02:13.94Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/56/4cc7fc9e9e3f38fd324f24f8afe0ad8bb5fa41283f37f1aaf9de0612c968/ipython-8.39.0-py3-none-any.whl", hash = "sha256:bb3c51c4fa8148ab1dea07a79584d1c854e234ea44aa1283bcb37bc75054651f", size = 831849, upload-time = "2026-03-27T10:02:07.846Z" },
-]
-
-[[package]]
-name = "ipython"
-version = "9.14.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.11'",
-]
-dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.11'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
-    { name = "jedi", marker = "python_full_version >= '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
-    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
-    { name = "psutil", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten'" },
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
-    { name = "stack-data", marker = "python_full_version >= '3.11'" },
-    { name = "traitlets", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/21/c2/c0064cf15d026501a1ef70e42efd9c3f818663089399aacc5e37a82901c1/ipython-9.14.0.tar.gz", hash = "sha256:6f27ff0f1d9ea050e0551f71568bc4b34d8aba579e8f111c5b4175f44ac6b4aa", size = 4432601, upload-time = "2026-05-29T15:13:24.611Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/a3/9e59340f02c1dc8f8c0a05b09244712b8609eb5439f9996e887e2b82f452/ipython-9.14.0-py3-none-any.whl", hash = "sha256:8fd984a3372c14b12790b084ba6b5cff5678c0cb063244a0034f06a51f20d6c2", size = 627457, upload-time = "2026-05-29T15:13:22.942Z" },
-]
-
-[[package]]
-name = "ipython-pygments-lexers"
-version = "1.1.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl", hash = "sha256:a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c", size = 8074, upload-time = "2025-01-17T11:24:33.271Z" },
-]
-
-[[package]]
-name = "jedi"
-version = "0.20.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "parso" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/46/b7/a3635f6a2d7cf5b5dd98064fc1d5fbbafcb25477bcea204a3a92145d158b/jedi-0.20.0.tar.gz", hash = "sha256:c3f4ccbd276696f4b19c54618d4fb18f9fc24b0aef02acf704b23f487daa1011", size = 3119416, upload-time = "2026-05-01T23:38:47.814Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/93/242e2eab5fe682ffcb8b0084bde703a41d51e17ee0f3a31ff0d9d813620a/jedi-0.20.0-py2.py3-none-any.whl", hash = "sha256:7bdd9c2634f56713299976f4cbd59cb3fa92165cc5e05ea811fb253480728b67", size = 4884812, upload-time = "2026-05-01T23:38:43.919Z" },
 ]
 
 [[package]]
@@ -902,48 +708,15 @@ wheels = [
 ]
 
 [[package]]
-name = "juju"
-version = "3.6.1.3"
+name = "jubilant"
+version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "backports-datetime-fromisoformat" },
-    { name = "backports-strenum", marker = "python_full_version < '3.11'" },
-    { name = "hvac" },
-    { name = "kubernetes" },
-    { name = "macaroonbakery" },
-    { name = "packaging" },
-    { name = "paramiko" },
-    { name = "pyasn1" },
     { name = "pyyaml" },
-    { name = "toposort" },
-    { name = "typing-extensions" },
-    { name = "typing-inspect" },
-    { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/91/ac/42ed7565d1b031856fb7e8884089acb3eab5aa6a2dabfee3fcf09660f885/juju-3.6.1.3.tar.gz", hash = "sha256:2fcf510fa35b387abb382da3a8b2227f38852ae7e9dc1058afb228588e1aec51", size = 305052, upload-time = "2025-07-11T02:15:59.237Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0e/4b/faf53677e40ce2bf836d53d33f97b14a2a5083e25984115fa28a0dd33bb9/jubilant-1.10.0.tar.gz", hash = "sha256:c0040c5e897108ea4efb65bfd3d4bfa0ff62ef91f2a4c6ff6d6dbad8665cc992", size = 33147, upload-time = "2026-05-28T03:54:42.62Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/86/13/e31f9b9c24e723a161bc3b75729acb109d80bf3f75f937e4c3d408f19e5a/juju-3.6.1.3-py3-none-any.whl", hash = "sha256:87469500a0a4e6a3976ddf0595e316379868d5cea96e15af2d2d4b94188f76e5", size = 287075, upload-time = "2025-07-11T02:15:57.118Z" },
-]
-
-[[package]]
-name = "kubernetes"
-version = "30.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "google-auth" },
-    { name = "oauthlib" },
-    { name = "python-dateutil" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "requests-oauthlib" },
-    { name = "six" },
-    { name = "urllib3" },
-    { name = "websocket-client" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/82/3c/9f29f6cab7f35df8e54f019e5719465fa97b877be2454e99f989270b4f34/kubernetes-30.1.0.tar.gz", hash = "sha256:41e4c77af9f28e7a6c314e3bd06a8c6229ddd787cad684e0ab9f69b498e98ebc", size = 887810, upload-time = "2024-06-06T15:58:30.031Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/a1/2027ddede72d33be2effc087580aeba07e733a7360780ae87226f1f91bd8/kubernetes-30.1.0-py2.py3-none-any.whl", hash = "sha256:e212e8b7579031dd2e512168b617373bc1e03888d41ac4e04039240a292d478d", size = 1706042, upload-time = "2024-06-06T15:58:27.13Z" },
+    { url = "https://files.pythonhosted.org/packages/59/af/3ee025257fc62c0285833fa8c2c099a86a65a1d9e37eb4f41e301180deac/jubilant-1.10.0-py3-none-any.whl", hash = "sha256:af437ca48eddb6b9eace888ec60a299b003eb425b20009c21c2f49c86d126741", size = 34744, upload-time = "2026-05-28T03:54:41.074Z" },
 ]
 
 [[package]]
@@ -1024,23 +797,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/da/137ddeea14c2cb86864838277b2607d09f8253f152156a07f84e11768a28/lz4-4.4.5-cp314-cp314-win32.whl", hash = "sha256:bd85d118316b53ed73956435bee1997bd06cc66dd2fa74073e3b1322bd520a67", size = 90139, upload-time = "2025-11-03T13:02:24.301Z" },
     { url = "https://files.pythonhosted.org/packages/18/2c/8332080fd293f8337779a440b3a143f85e374311705d243439a3349b81ad/lz4-4.4.5-cp314-cp314-win_amd64.whl", hash = "sha256:92159782a4502858a21e0079d77cdcaade23e8a5d252ddf46b0652604300d7be", size = 101497, upload-time = "2025-11-03T13:02:25.187Z" },
     { url = "https://files.pythonhosted.org/packages/ca/28/2635a8141c9a4f4bc23f5135a92bbcf48d928d8ca094088c962df1879d64/lz4-4.4.5-cp314-cp314-win_arm64.whl", hash = "sha256:d994b87abaa7a88ceb7a37c90f547b8284ff9da694e6afcfaa8568d739faf3f7", size = 93812, upload-time = "2025-11-03T13:02:26.133Z" },
-]
-
-[[package]]
-name = "macaroonbakery"
-version = "1.3.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "protobuf" },
-    { name = "pymacaroons" },
-    { name = "pynacl" },
-    { name = "pyrfc3339" },
-    { name = "requests" },
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4b/ae/59f5ab870640bd43673b708e5f24aed592dc2673cc72caa49b0053b4af37/macaroonbakery-1.3.4.tar.gz", hash = "sha256:41ca993a23e4f8ef2fe7723b5cd4a30c759735f1d5021e990770c8a0e0f33970", size = 82143, upload-time = "2023-12-13T14:22:22.539Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/42/227f748dc222b7a1c5cb40c7c74ab4162c7fc146b88980776b490ab673a1/macaroonbakery-1.3.4-py2.py3-none-any.whl", hash = "sha256:1e952a189f5c1e96ef82b081b2852c770d7daa20987e2088e762dd5689fb253b", size = 103184, upload-time = "2023-12-13T14:22:20.159Z" },
 ]
 
 [[package]]
@@ -1141,18 +897,6 @@ wheels = [
 ]
 
 [[package]]
-name = "matplotlib-inline"
-version = "0.2.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "traitlets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/c0/9f7c9a46090390368a4d7bcb76bb87a4a36c421e4c0792cdb53486ffac7a/matplotlib_inline-0.2.2.tar.gz", hash = "sha256:72f3fe8fce36b70d4a5b612f899090cd0401deddc4ea90e1572b9f4bfb058c79", size = 8150, upload-time = "2026-05-08T17:33:33.49Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/09/5b161152e2d90f7b87f781c2e1267494aef9c32498df793f73ad0a0a494a/matplotlib_inline-0.2.2-py3-none-any.whl", hash = "sha256:3c821cf1c209f59fb2d2d64abbf5b23b67bcb2210d663f9918dd851c6da1fcf6", size = 9534, upload-time = "2026-05-08T17:33:32.055Z" },
-]
-
-[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1162,30 +906,12 @@ wheels = [
 ]
 
 [[package]]
-name = "mypy-extensions"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
-]
-
-[[package]]
 name = "nodeenv"
 version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
-]
-
-[[package]]
-name = "oauthlib"
-version = "3.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
 ]
 
 [[package]]
@@ -1324,142 +1050,12 @@ wheels = [
 ]
 
 [[package]]
-name = "paramiko"
-version = "5.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "bcrypt" },
-    { name = "cryptography" },
-    { name = "invoke" },
-    { name = "pynacl" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/62/93/dcc25d52f49022ae6175d15e6bd751f1acc99b98bc61fc55e5155a7be2e7/paramiko-5.0.0.tar.gz", hash = "sha256:36763b5b95c2a0dcfdf1abc48e48156ee425b21efe2f0e787c2dd5a95c0e5e79", size = 1548586, upload-time = "2026-05-09T18:28:52.256Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/5b/eadf6d45de38d30ab603f49393b6cd2cbe7e233af8cf90197e32782b68a9/paramiko-5.0.0-py3-none-any.whl", hash = "sha256:b7044611c30140d9a75261653210e2002977b71a0497ff3ba0d98d7edbf62f7c", size = 208919, upload-time = "2026-05-09T18:28:50.295Z" },
-]
-
-[[package]]
-name = "parso"
-version = "0.8.7"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/30/4b/90c937815137d43ce71ba043cd3566221e9df6b9c805f24b5d138c9d40a7/parso-0.8.7.tar.gz", hash = "sha256:eaaac4c9fdd5e9e8852dc778d2d7405897ec510f2a298071453e5e3a07914bb1", size = 401824, upload-time = "2026-05-01T23:13:02.138Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/5d/8268b644392ee874ee82a635cd0df1773de230bde356c38de28e298392cc/parso-0.8.7-py2.py3-none-any.whl", hash = "sha256:a8926eb2a1b915486941fdbd31e86a4baf88fe8c210f25f2f35ecec5b574ca1c", size = 107025, upload-time = "2026-05-01T23:12:58.867Z" },
-]
-
-[[package]]
-name = "pexpect"
-version = "4.9.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ptyprocess" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772, upload-time = "2023-11-25T06:56:14.81Z" },
-]
-
-[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
-]
-
-[[package]]
-name = "prompt-toolkit"
-version = "3.0.52"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "wcwidth" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
-]
-
-[[package]]
-name = "protobuf"
-version = "7.35.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/60/fd/5b1491d9e4b586d621c54f4c36b888714164b6875f8d6afa3f9072906a51/protobuf-7.35.0.tar.gz", hash = "sha256:a2efd84605f41e559f1881b0912b44099d0a2ac9bf46b3474823f10fb393b0e6", size = 458677, upload-time = "2026-05-19T23:02:29.197Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/ee/93d06e358a4aa32280b00e722d3ea0a1f25fc3cc5778d80581c9cca2c10e/protobuf-7.35.0-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:66be6c513931c794fa92c080ffee41671390da3d79da219cf9c0c0907f035dda", size = 433225, upload-time = "2026-05-19T23:02:19.884Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/39/1c76c2da93f3c507e958e0aecee2391cc44d4625de6c728bbc555195b5a8/protobuf-7.35.0-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:fcbe42a4ac09d3ec9c987ddfcd956afd0b15f1ff613bd8371bde9405ffd5c8e5", size = 328847, upload-time = "2026-05-19T23:02:22.3Z" },
-    { url = "https://files.pythonhosted.org/packages/91/1a/39f7ce90a238c1a987a4d81ec26379e02ca0aff367de68e4a1fa474215b9/protobuf-7.35.0-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:4cbf5cc286130e06a6c9bbefac442431173906dfcc979712183d4adcc01b37ee", size = 344030, upload-time = "2026-05-19T23:02:23.591Z" },
-    { url = "https://files.pythonhosted.org/packages/70/5b/6baf9008817964454055ff3fe65f1de0b5f1e26c80c82f7fb108b7cd4ea3/protobuf-7.35.0-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:6c0f98f10c8a05ea30f8993dfef2de093d27b490fdae78bb60c8343795d55011", size = 327130, upload-time = "2026-05-19T23:02:24.637Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/e5/e46adb0badc388bfb84877a5f9f026aff63f60e611016cf64dbe77e05446/protobuf-7.35.0-cp310-abi3-win32.whl", hash = "sha256:4c4617b83ade0e279d1d2bfe04025a1adb87f9ed657de038620dc0ff959357f6", size = 428946, upload-time = "2026-05-19T23:02:25.741Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/ab/547fbd9e16d879dd13c167478f8ae0a83a428008ca07a5e06acdc23ad473/protobuf-7.35.0-cp310-abi3-win_amd64.whl", hash = "sha256:f05bcadf9a2a6b8dda047007075135fb7d08c73d9177aabc067e1be46881a201", size = 439996, upload-time = "2026-05-19T23:02:26.808Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/ef/50433d346c56657a70d27f156c7b349ac59a068b01de4eb796e747eecc43/protobuf-7.35.0-py3-none-any.whl", hash = "sha256:c13f325cf242bad135c350629eeb5d54b24228eb472fb3e2e9ebbd4c5dc20ca0", size = 171659, upload-time = "2026-05-19T23:02:27.842Z" },
-]
-
-[[package]]
-name = "psutil"
-version = "7.2.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
-    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
-    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
-    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
-    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
-    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
-    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
-    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
-]
-
-[[package]]
-name = "ptyprocess"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762, upload-time = "2020-12-28T15:15:30.155Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993, upload-time = "2020-12-28T15:15:28.35Z" },
-]
-
-[[package]]
-name = "pure-eval"
-version = "0.2.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752, upload-time = "2024-07-21T12:58:21.801Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842, upload-time = "2024-07-21T12:58:20.04Z" },
-]
-
-[[package]]
-name = "pyasn1"
-version = "0.6.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
-]
-
-[[package]]
-name = "pyasn1-modules"
-version = "0.4.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyasn1" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -1518,66 +1114,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pymacaroons"
-version = "0.13.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pynacl" },
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/37/b4/52ff00b59e91c4817ca60210c33caf11e85a7f68f7b361748ca2eb50923e/pymacaroons-0.13.0.tar.gz", hash = "sha256:1e6bba42a5f66c245adf38a5a4006a99dcc06a0703786ea636098667d42903b8", size = 21083, upload-time = "2018-02-21T18:07:49.045Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/87/fd9b54258216e3f19671f6e9dd76da1ebc49e93ea0107c986b1071dd3068/pymacaroons-0.13.0-py2.py3-none-any.whl", hash = "sha256:3e14dff6a262fdbf1a15e769ce635a8aea72e6f8f91e408f9a97166c53b91907", size = 19463, upload-time = "2018-02-21T18:07:47.085Z" },
-]
-
-[[package]]
-name = "pynacl"
-version = "1.6.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d9/9a/4019b524b03a13438637b11538c82781a5eda427394380381af8f04f467a/pynacl-1.6.2.tar.gz", hash = "sha256:018494d6d696ae03c7e656e5e74cdfd8ea1326962cc401bcf018f1ed8436811c", size = 3511692, upload-time = "2026-01-01T17:48:10.851Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/79/0e3c34dc3c4671f67d251c07aa8eb100916f250ee470df230b0ab89551b4/pynacl-1.6.2-cp314-cp314t-macosx_10_10_universal2.whl", hash = "sha256:622d7b07cc5c02c666795792931b50c91f3ce3c2649762efb1ef0d5684c81594", size = 390064, upload-time = "2026-01-01T17:31:57.264Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/1c/23a26e931736e13b16483795c8a6b2f641bf6a3d5238c22b070a5112722c/pynacl-1.6.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d071c6a9a4c94d79eb665db4ce5cedc537faf74f2355e4d502591d850d3913c0", size = 809370, upload-time = "2026-01-01T17:31:59.198Z" },
-    { url = "https://files.pythonhosted.org/packages/87/74/8d4b718f8a22aea9e8dcc8b95deb76d4aae380e2f5b570cc70b5fd0a852d/pynacl-1.6.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fe9847ca47d287af41e82be1dd5e23023d3c31a951da134121ab02e42ac218c9", size = 1408304, upload-time = "2026-01-01T17:32:01.162Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/73/be4fdd3a6a87fe8a4553380c2b47fbd1f7f58292eb820902f5c8ac7de7b0/pynacl-1.6.2-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04316d1fc625d860b6c162fff704eb8426b1a8bcd3abacea11142cbd99a6b574", size = 844871, upload-time = "2026-01-01T17:32:02.824Z" },
-    { url = "https://files.pythonhosted.org/packages/55/ad/6efc57ab75ee4422e96b5f2697d51bbcf6cdcc091e66310df91fbdc144a8/pynacl-1.6.2-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44081faff368d6c5553ccf55322ef2819abb40e25afaec7e740f159f74813634", size = 1446356, upload-time = "2026-01-01T17:32:04.452Z" },
-    { url = "https://files.pythonhosted.org/packages/78/b7/928ee9c4779caa0a915844311ab9fb5f99585621c5d6e4574538a17dca07/pynacl-1.6.2-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:a9f9932d8d2811ce1a8ffa79dcbdf3970e7355b5c8eb0c1a881a57e7f7d96e88", size = 826814, upload-time = "2026-01-01T17:32:06.078Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/a9/1bdba746a2be20f8809fee75c10e3159d75864ef69c6b0dd168fc60e485d/pynacl-1.6.2-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:bc4a36b28dd72fb4845e5d8f9760610588a96d5a51f01d84d8c6ff9849968c14", size = 1411742, upload-time = "2026-01-01T17:32:07.651Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/2f/5e7ea8d85f9f3ea5b6b87db1d8388daa3587eed181bdeb0306816fdbbe79/pynacl-1.6.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3bffb6d0f6becacb6526f8f42adfb5efb26337056ee0831fb9a7044d1a964444", size = 801714, upload-time = "2026-01-01T17:32:09.558Z" },
-    { url = "https://files.pythonhosted.org/packages/06/ea/43fe2f7eab5f200e40fb10d305bf6f87ea31b3bbc83443eac37cd34a9e1e/pynacl-1.6.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2fef529ef3ee487ad8113d287a593fa26f48ee3620d92ecc6f1d09ea38e0709b", size = 1372257, upload-time = "2026-01-01T17:32:11.026Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/54/c9ea116412788629b1347e415f72195c25eb2f3809b2d3e7b25f5c79f13a/pynacl-1.6.2-cp314-cp314t-win32.whl", hash = "sha256:a84bf1c20339d06dc0c85d9aea9637a24f718f375d861b2668b2f9f96fa51145", size = 231319, upload-time = "2026-01-01T17:32:12.46Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/04/64e9d76646abac2dccf904fccba352a86e7d172647557f35b9fe2a5ee4a1/pynacl-1.6.2-cp314-cp314t-win_amd64.whl", hash = "sha256:320ef68a41c87547c91a8b58903c9caa641ab01e8512ce291085b5fe2fcb7590", size = 244044, upload-time = "2026-01-01T17:32:13.781Z" },
-    { url = "https://files.pythonhosted.org/packages/33/33/7873dc161c6a06f43cda13dec67b6fe152cb2f982581151956fa5e5cdb47/pynacl-1.6.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d29bfe37e20e015a7d8b23cfc8bd6aa7909c92a1b8f41ee416bbb3e79ef182b2", size = 188740, upload-time = "2026-01-01T17:32:15.083Z" },
-    { url = "https://files.pythonhosted.org/packages/be/7b/4845bbf88e94586ec47a432da4e9107e3fc3ce37eb412b1398630a37f7dd/pynacl-1.6.2-cp38-abi3-macosx_10_10_universal2.whl", hash = "sha256:c949ea47e4206af7c8f604b8278093b674f7c79ed0d4719cc836902bf4517465", size = 388458, upload-time = "2026-01-01T17:32:16.829Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/b4/e927e0653ba63b02a4ca5b4d852a8d1d678afbf69b3dbf9c4d0785ac905c/pynacl-1.6.2-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8845c0631c0be43abdd865511c41eab235e0be69c81dc66a50911594198679b0", size = 800020, upload-time = "2026-01-01T17:32:18.34Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/81/d60984052df5c97b1d24365bc1e30024379b42c4edcd79d2436b1b9806f2/pynacl-1.6.2-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:22de65bb9010a725b0dac248f353bb072969c94fa8d6b1f34b87d7953cf7bbe4", size = 1399174, upload-time = "2026-01-01T17:32:20.239Z" },
-    { url = "https://files.pythonhosted.org/packages/68/f7/322f2f9915c4ef27d140101dd0ed26b479f7e6f5f183590fd32dfc48c4d3/pynacl-1.6.2-cp38-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46065496ab748469cdd999246d17e301b2c24ae2fdf739132e580a0e94c94a87", size = 835085, upload-time = "2026-01-01T17:32:22.24Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/d0/f301f83ac8dbe53442c5a43f6a39016f94f754d7a9815a875b65e218a307/pynacl-1.6.2-cp38-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8a66d6fb6ae7661c58995f9c6435bda2b1e68b54b598a6a10247bfcdadac996c", size = 1437614, upload-time = "2026-01-01T17:32:23.766Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/58/fc6e649762b029315325ace1a8c6be66125e42f67416d3dbd47b69563d61/pynacl-1.6.2-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:26bfcd00dcf2cf160f122186af731ae30ab120c18e8375684ec2670dccd28130", size = 818251, upload-time = "2026-01-01T17:32:25.69Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/a8/b917096b1accc9acd878819a49d3d84875731a41eb665f6ebc826b1af99e/pynacl-1.6.2-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:c8a231e36ec2cab018c4ad4358c386e36eede0319a0c41fed24f840b1dac59f6", size = 1402859, upload-time = "2026-01-01T17:32:27.215Z" },
-    { url = "https://files.pythonhosted.org/packages/85/42/fe60b5f4473e12c72f977548e4028156f4d340b884c635ec6b063fe7e9a5/pynacl-1.6.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:68be3a09455743ff9505491220b64440ced8973fe930f270c8e07ccfa25b1f9e", size = 791926, upload-time = "2026-01-01T17:32:29.314Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/f9/e40e318c604259301cc091a2a63f237d9e7b424c4851cafaea4ea7c4834e/pynacl-1.6.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8b097553b380236d51ed11356c953bf8ce36a29a3e596e934ecabe76c985a577", size = 1363101, upload-time = "2026-01-01T17:32:31.263Z" },
-    { url = "https://files.pythonhosted.org/packages/48/47/e761c254f410c023a469284a9bc210933e18588ca87706ae93002c05114c/pynacl-1.6.2-cp38-abi3-win32.whl", hash = "sha256:5811c72b473b2f38f7e2a3dc4f8642e3a3e9b5e7317266e4ced1fba85cae41aa", size = 227421, upload-time = "2026-01-01T17:32:33.076Z" },
-    { url = "https://files.pythonhosted.org/packages/41/ad/334600e8cacc7d86587fe5f565480fde569dfb487389c8e1be56ac21d8ac/pynacl-1.6.2-cp38-abi3-win_amd64.whl", hash = "sha256:62985f233210dee6548c223301b6c25440852e13d59a8b81490203c3227c5ba0", size = 239754, upload-time = "2026-01-01T17:32:34.557Z" },
-    { url = "https://files.pythonhosted.org/packages/29/7d/5945b5af29534641820d3bd7b00962abbbdfee84ec7e19f0d5b3175f9a31/pynacl-1.6.2-cp38-abi3-win_arm64.whl", hash = "sha256:834a43af110f743a754448463e8fd61259cd4ab5bbedcf70f9dabad1d28a394c", size = 184801, upload-time = "2026-01-01T17:32:36.309Z" },
-]
-
-[[package]]
-name = "pyrfc3339"
-version = "1.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pytz" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/00/52/75ea0ae249ba885c9429e421b4f94bc154df68484847f1ac164287d978d7/pyRFC3339-1.1.tar.gz", hash = "sha256:81b8cbe1519cdb79bed04910dd6fa4e181faf8c88dff1e1b987b5f7ab23a5b1a", size = 5290, upload-time = "2018-06-11T00:26:31Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/7a/725f5c16756ec6211b1e7eeac09f469084595513917ea069bc023c40a5e2/pyRFC3339-1.1-py2.py3-none-any.whl", hash = "sha256:67196cb83b470709c580bb4738b83165e67c6cc60e1f2e4f286cfcb402a926f4", size = 5669, upload-time = "2018-06-11T00:22:40.934Z" },
-]
-
-[[package]]
 name = "pyright"
 version = "1.1.410"
 source = { registry = "https://pypi.org/simple" }
@@ -1621,20 +1157,16 @@ wheels = [
 ]
 
 [[package]]
-name = "pytest-operator"
-version = "0.43.2"
+name = "pytest-jubilant"
+version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ipdb" },
-    { name = "jinja2" },
-    { name = "juju" },
+    { name = "jubilant" },
     { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2e/48/880facbcaca080b852854f60fd46b37ca2985b27dc7f1713857d9de6d469/pytest_operator-0.43.2.tar.gz", hash = "sha256:3db34dcd9c114a2e41a9bc61da72daf1264e7644fd5b92e855f250cb337e01c3", size = 149628, upload-time = "2025-10-04T14:38:45.16Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/11/3baee677f3cf51ef41e06a7cbcfe8551613723695a458997b9d63026e0b5/pytest_jubilant-2.1.1.tar.gz", hash = "sha256:04c083ef1366f92237da79e3d499094ca50f50519a19462f388c38c699ee495a", size = 17971, upload-time = "2026-06-09T23:01:56.332Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/a0/22b018287f4ff7a36cdb79745c196f28897184d27e18b90177f5dfc2a0f4/pytest_operator-0.43.2-py3-none-any.whl", hash = "sha256:d7d01ffe35d14b75577fd80a07c34f0a9f4835cfc6d373b8e2f995bcb4146bda", size = 48322, upload-time = "2025-10-04T14:38:43.763Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/ea/33ecce9a52a022547544ab3b6393368944b1b55480a35ae00b7d9bd02f39/pytest_jubilant-2.1.1-py3-none-any.whl", hash = "sha256:d710cf9c41fb8daed6218d7b6ce68f4d4c234c5b0ee066d2be1dc9dd07265d35", size = 14922, upload-time = "2026-06-09T23:01:55.13Z" },
 ]
 
 [[package]]
@@ -1750,19 +1282,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
-]
-
-[[package]]
-name = "requests-oauthlib"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "oauthlib" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
 ]
 
 [[package]]
@@ -2078,20 +1597,6 @@ wheels = [
 ]
 
 [[package]]
-name = "stack-data"
-version = "0.6.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "asttokens" },
-    { name = "executing" },
-    { name = "pure-eval" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521, upload-time = "2023-09-30T13:58:03.53Z" },
-]
-
-[[package]]
 name = "stevedore"
 version = "5.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2173,24 +1678,6 @@ wheels = [
 ]
 
 [[package]]
-name = "toposort"
-version = "1.10"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/69/19/8e955d90985ecbd3b9adb2a759753a6840da2dff3c569d412b2c9217678b/toposort-1.10.tar.gz", hash = "sha256:bfbb479c53d0a696ea7402601f4e693c97b0367837c8898bc6471adfca37a6bd", size = 11132, upload-time = "2023-02-27T13:59:51.834Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/17/57b444fd314d5e1593350b9a31d000e7411ba8e17ce12dc7ad54ca76b810/toposort-1.10-py3-none-any.whl", hash = "sha256:cbdbc0d0bee4d2695ab2ceec97fe0679e9c10eab4b2a87a9372b929e70563a87", size = 8500, upload-time = "2023-02-25T20:07:06.538Z" },
-]
-
-[[package]]
-name = "traitlets"
-version = "5.15.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1b/22/40f55b26baeab80c2d7b3f1db0682f8954e4617fee7d90ce634022ef05c6/traitlets-5.15.0.tar.gz", hash = "sha256:4fead733f81cf1c4c938e06f8ca4633896833c9d89eff878159457f4d4392971", size = 163197, upload-time = "2026-05-06T08:05:58.016Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/98/a9937a969d018a23badfea0b381f66783649d48e0ea6c41923265c3cbeb3/traitlets-5.15.0-py3-none-any.whl", hash = "sha256:fb36a18867a6803deab09f3c5e0fa81bb7b26a5c9e82501c9933f759166eff40", size = 85877, upload-time = "2026-05-06T08:05:55.853Z" },
-]
-
-[[package]]
 name = "trino"
 version = "0.337.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2239,10 +1726,9 @@ charmlibs-pydeps = [
 ]
 integration = [
     { name = "apache-ranger" },
-    { name = "juju" },
+    { name = "jubilant" },
     { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-operator" },
+    { name = "pytest-jubilant" },
     { name = "trino" },
 ]
 lint = [
@@ -2290,10 +1776,9 @@ charmlibs-pydeps = [
 ]
 integration = [
     { name = "apache-ranger", specifier = ">=0.0.12,<0.1" },
-    { name = "juju", specifier = ">=3.6.1.3,<4" },
+    { name = "jubilant", specifier = ">=1.10.0,<2" },
     { name = "pytest", specifier = ">=9.0.3,<10" },
-    { name = "pytest-asyncio", specifier = ">=0.21.2,<0.22" },
-    { name = "pytest-operator", specifier = ">=0.43.2,<0.44" },
+    { name = "pytest-jubilant", specifier = ">=2.1.1,<3" },
     { name = "trino", specifier = ">=0.337.0,<0.338" },
 ]
 lint = [
@@ -2318,19 +1803,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
-]
-
-[[package]]
-name = "typing-inspect"
-version = "0.9.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mypy-extensions" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/74/1789779d91f1961fa9438e9a8710cdae6bd138c80d7303996933d117264a/typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78", size = 13825, upload-time = "2023-05-24T20:25:47.612Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl", hash = "sha256:9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f", size = 8827, upload-time = "2023-05-24T20:25:45.287Z" },
 ]
 
 [[package]]
@@ -2364,89 +1836,12 @@ wheels = [
 ]
 
 [[package]]
-name = "wcwidth"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132, upload-time = "2026-05-02T16:04:12.653Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825, upload-time = "2026-05-02T16:04:11.033Z" },
-]
-
-[[package]]
 name = "websocket-client"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
-]
-
-[[package]]
-name = "websockets"
-version = "16.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/74/221f58decd852f4b59cc3354cccaf87e8ef695fede361d03dc9a7396573b/websockets-16.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:04cdd5d2d1dacbad0a7bf36ccbcd3ccd5a30ee188f2560b7a62a30d14107b31a", size = 177343, upload-time = "2026-01-10T09:22:21.28Z" },
-    { url = "https://files.pythonhosted.org/packages/19/0f/22ef6107ee52ab7f0b710d55d36f5a5d3ef19e8a205541a6d7ffa7994e5a/websockets-16.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8ff32bb86522a9e5e31439a58addbb0166f0204d64066fb955265c4e214160f0", size = 175021, upload-time = "2026-01-10T09:22:22.696Z" },
-    { url = "https://files.pythonhosted.org/packages/10/40/904a4cb30d9b61c0e278899bf36342e9b0208eb3c470324a9ecbaac2a30f/websockets-16.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:583b7c42688636f930688d712885cf1531326ee05effd982028212ccc13e5957", size = 175320, upload-time = "2026-01-10T09:22:23.94Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/2f/4b3ca7e106bc608744b1cdae041e005e446124bebb037b18799c2d356864/websockets-16.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7d837379b647c0c4c2355c2499723f82f1635fd2c26510e1f587d89bc2199e72", size = 183815, upload-time = "2026-01-10T09:22:25.469Z" },
-    { url = "https://files.pythonhosted.org/packages/86/26/d40eaa2a46d4302becec8d15b0fc5e45bdde05191e7628405a19cf491ccd/websockets-16.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df57afc692e517a85e65b72e165356ed1df12386ecb879ad5693be08fac65dde", size = 185054, upload-time = "2026-01-10T09:22:27.101Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/ba/6500a0efc94f7373ee8fefa8c271acdfd4dca8bd49a90d4be7ccabfc397e/websockets-16.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:2b9f1e0d69bc60a4a87349d50c09a037a2607918746f07de04df9e43252c77a3", size = 184565, upload-time = "2026-01-10T09:22:28.293Z" },
-    { url = "https://files.pythonhosted.org/packages/04/b4/96bf2cee7c8d8102389374a2616200574f5f01128d1082f44102140344cc/websockets-16.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:335c23addf3d5e6a8633f9f8eda77efad001671e80b95c491dd0924587ece0b3", size = 183848, upload-time = "2026-01-10T09:22:30.394Z" },
-    { url = "https://files.pythonhosted.org/packages/02/8e/81f40fb00fd125357814e8c3025738fc4ffc3da4b6b4a4472a82ba304b41/websockets-16.0-cp310-cp310-win32.whl", hash = "sha256:37b31c1623c6605e4c00d466c9d633f9b812ea430c11c8a278774a1fde1acfa9", size = 178249, upload-time = "2026-01-10T09:22:32.083Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/5f/7e40efe8df57db9b91c88a43690ac66f7b7aa73a11aa6a66b927e44f26fa/websockets-16.0-cp310-cp310-win_amd64.whl", hash = "sha256:8e1dab317b6e77424356e11e99a432b7cb2f3ec8c5ab4dabbcee6add48f72b35", size = 178685, upload-time = "2026-01-10T09:22:33.345Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/db/de907251b4ff46ae804ad0409809504153b3f30984daf82a1d84a9875830/websockets-16.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:31a52addea25187bde0797a97d6fc3d2f92b6f72a9370792d65a6e84615ac8a8", size = 177340, upload-time = "2026-01-10T09:22:34.539Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/fa/abe89019d8d8815c8781e90d697dec52523fb8ebe308bf11664e8de1877e/websockets-16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:417b28978cdccab24f46400586d128366313e8a96312e4b9362a4af504f3bbad", size = 175022, upload-time = "2026-01-10T09:22:36.332Z" },
-    { url = "https://files.pythonhosted.org/packages/58/5d/88ea17ed1ded2079358b40d31d48abe90a73c9e5819dbcde1606e991e2ad/websockets-16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:af80d74d4edfa3cb9ed973a0a5ba2b2a549371f8a741e0800cb07becdd20f23d", size = 175319, upload-time = "2026-01-10T09:22:37.602Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/ae/0ee92b33087a33632f37a635e11e1d99d429d3d323329675a6022312aac2/websockets-16.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:08d7af67b64d29823fed316505a89b86705f2b7981c07848fb5e3ea3020c1abe", size = 184631, upload-time = "2026-01-10T09:22:38.789Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/c5/27178df583b6c5b31b29f526ba2da5e2f864ecc79c99dae630a85d68c304/websockets-16.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7be95cfb0a4dae143eaed2bcba8ac23f4892d8971311f1b06f3c6b78952ee70b", size = 185870, upload-time = "2026-01-10T09:22:39.893Z" },
-    { url = "https://files.pythonhosted.org/packages/87/05/536652aa84ddc1c018dbb7e2c4cbcd0db884580bf8e95aece7593fde526f/websockets-16.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d6297ce39ce5c2e6feb13c1a996a2ded3b6832155fcfc920265c76f24c7cceb5", size = 185361, upload-time = "2026-01-10T09:22:41.016Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/e2/d5332c90da12b1e01f06fb1b85c50cfc489783076547415bf9f0a659ec19/websockets-16.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1c1b30e4f497b0b354057f3467f56244c603a79c0d1dafce1d16c283c25f6e64", size = 184615, upload-time = "2026-01-10T09:22:42.442Z" },
-    { url = "https://files.pythonhosted.org/packages/77/fb/d3f9576691cae9253b51555f841bc6600bf0a983a461c79500ace5a5b364/websockets-16.0-cp311-cp311-win32.whl", hash = "sha256:5f451484aeb5cafee1ccf789b1b66f535409d038c56966d6101740c1614b86c6", size = 178246, upload-time = "2026-01-10T09:22:43.654Z" },
-    { url = "https://files.pythonhosted.org/packages/54/67/eaff76b3dbaf18dcddabc3b8c1dba50b483761cccff67793897945b37408/websockets-16.0-cp311-cp311-win_amd64.whl", hash = "sha256:8d7f0659570eefb578dacde98e24fb60af35350193e4f56e11190787bee77dac", size = 178684, upload-time = "2026-01-10T09:22:44.941Z" },
-    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365, upload-time = "2026-01-10T09:22:46.787Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038, upload-time = "2026-01-10T09:22:47.999Z" },
-    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328, upload-time = "2026-01-10T09:22:49.809Z" },
-    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915, upload-time = "2026-01-10T09:22:51.071Z" },
-    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152, upload-time = "2026-01-10T09:22:52.224Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583, upload-time = "2026-01-10T09:22:53.443Z" },
-    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880, upload-time = "2026-01-10T09:22:55.033Z" },
-    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload-time = "2026-01-10T09:22:56.251Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload-time = "2026-01-10T09:22:57.478Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
-    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
-    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
-    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
-    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
-    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
-    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
-    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
-    { url = "https://files.pythonhosted.org/packages/72/07/c98a68571dcf256e74f1f816b8cc5eae6eb2d3d5cfa44d37f801619d9166/websockets-16.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:349f83cd6c9a415428ee1005cadb5c2c56f4389bc06a9af16103c3bc3dcc8b7d", size = 174947, upload-time = "2026-01-10T09:23:36.166Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/52/93e166a81e0305b33fe416338be92ae863563fe7bce446b0f687b9df5aea/websockets-16.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:4a1aba3340a8dca8db6eb5a7986157f52eb9e436b74813764241981ca4888f03", size = 175260, upload-time = "2026-01-10T09:23:37.409Z" },
-    { url = "https://files.pythonhosted.org/packages/56/0c/2dbf513bafd24889d33de2ff0368190a0e69f37bcfa19009ef819fe4d507/websockets-16.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f4a32d1bd841d4bcbffdcb3d2ce50c09c3909fbead375ab28d0181af89fd04da", size = 176071, upload-time = "2026-01-10T09:23:39.158Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968, upload-time = "2026-01-10T09:23:41.031Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735, upload-time = "2026-01-10T09:23:42.259Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# What

As part of charm modernization, we want to migrate the testing frameworks we use to the new standards. This PR contains the work for that.

Changes:
* Convert Harness based unit tests to the Scenario framework.
* Convert integration tests to the Jubilant framework.

## Note for code reviewers
I reviewed pretty much everything thoroughly except `tests/unit/test_charm.py`.

I would recommend that you pay attention to base charm changes, `tests/**/{conftest,helpers}.py` and `tests/unit/test_charm.py` more. I am not sure if there is value in reviewing the rest given the scope and the size of the change.