### PR TITLE
Refactor/migrate tests to canonical k8s

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
     with:
       runs-on: "self-hosted-linux-amd64-noble-xlarge"
-      channel: 1.34-strict/stable
+      channel: 1.35-classic/stable
       modules: >-
         ["test_charm.py",
         "test_policy.py",
@@ -30,6 +30,11 @@ jobs:
         "test_trino_catalog_relation.py",
         "test_pg_catalog_relation.py"]
       juju-channel: 3/stable
-      microk8s-addons: "dns ingress rbac storage metallb:10.15.119.2-10.15.119.4 registry"
+      use-canonical-k8s: true
+      provider: k8s
+      extra-arguments: >-
+        --kube-config=~/.kube/config
+        --juju-controller=localhost-localhost
+        --juju-cloud=canonical-k8s
       trivy-severity-config: CRITICAL
       with-uv: true

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -32,9 +32,5 @@ jobs:
       juju-channel: 3/stable
       use-canonical-k8s: true
       provider: k8s
-      extra-arguments: >-
-        --kube-config=~/.kube/config
-        --juju-controller=localhost-localhost
-        --juju-cloud=canonical-k8s
       trivy-severity-config: CRITICAL
       with-uv: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -233,3 +233,37 @@ make clean-rockcraft
 lxc project switch rockcraft
 lxc delete rockcraft-trino-amd64-4
 ```
+
+## Writing tests
+
+### Incremental test classes
+
+Integration tests that must run in order use the `@pytest.mark.incremental` marker. When a
+test in an incremental class fails, pytest xfails all subsequent tests in that class instead
+of running them (avoiding cascading failures that obscure the root cause).
+
+Apply the marker at the **class level** alongside any fixture decorators:
+
+```python
+@pytest.mark.incremental
+@pytest.mark.usefixtures("deploy")
+class TestMyFeature:
+    def test_01_setup(self, juju): ...
+    def test_02_behaviour(self, juju): ...
+```
+
+> **Important:** incremental tests **must** live inside a class. The implementation keys
+> on `str(item.cls)` to track failures. Bare module-level functions with
+> `@pytest.mark.incremental` all map to the same `"None"` key and will collide across
+> modules, causing spurious xfails in unrelated tests. Wrap them in a class instead.
+
+### Running the integration suite
+
+Integration tests only run on CI. You can verify collection locally without deploying:
+
+```bash
+uv tool tox run -e integration -- --collect-only
+```
+
+Use the per-file tox environments for targeted runs (e.g. `integration-scaling`,
+`integration-charm`). See `tox.ini` for the full list.

--- a/lib/charms/comsys_libs/v0/kubernetes_statefulset_patch.py
+++ b/lib/charms/comsys_libs/v0/kubernetes_statefulset_patch.py
@@ -209,7 +209,6 @@ class KubernetesStatefulsetPatch(Object):
 
             # Apply the patch if any updates were made
             if needs_patching:
-                statefulset.metadata.resourceVersion = None
                 client.patch(
                     StatefulSet,
                     name=self.statefulset_name,

--- a/lib/charms/comsys_libs/v0/kubernetes_statefulset_patch.py
+++ b/lib/charms/comsys_libs/v0/kubernetes_statefulset_patch.py
@@ -209,6 +209,7 @@ class KubernetesStatefulsetPatch(Object):
 
             # Apply the patch if any updates were made
             if needs_patching:
+                statefulset.metadata.resourceVersion = None
                 client.patch(
                     StatefulSet,
                     name=self.statefulset_name,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,15 +24,14 @@ def pytest_addoption(parser: pytest.Parser):
     parser.addoption("--charm-file", action="append", default=[])
     # The charm image name:tag.
     parser.addoption("--trino-image", action="store", default="")
-    parser.addoption(
-        "--keep-models",
-        action="store_true",
-        default=False,
-    )
-    parser.addoption(
-        "--model",
-        action="store",
-    )
+
+    # Passed by integration_test.yaml.
+    parser.addoption("--model", action="store", default=None)
+    parser.addoption("--keep-models", action="store_true", default=False)
+    parser.addoption("--series", action="store", default=None)
+
+    # Passed by operator-workflows when use-canonical-k8s: true.
+    parser.addoption("--kube-config", action="store", default=None)
 
 
 @pytest.hookimpl(hookwrapper=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,12 +5,22 @@
 
 import pytest
 
+# Incremental test support: once a test in a class marked @pytest.mark.incremental
+# fails, the remaining tests in that class are xfailed. This is the recipe from
+# the pytest docs.
+#
+# IMPORTANT: incremental tests MUST live in a class (item.cls must not be None).
+# Bare module-level functions with @pytest.mark.incremental will all share the
+# same str(item.cls) == "None" key and collide across modules, causing spurious
+# xfails. Wrap them in a class instead.
+_test_failed_incremental: dict[str, dict[tuple[int, ...], str]] = {}
+
 
 def pytest_configure(config: pytest.Config):
     """Register custom markers used by the test suite."""
     config.addinivalue_line(
         "markers",
-        "abort_on_fail: xfail the remaining tests in the same module after a failure",
+        "incremental: mark a test class so a failure aborts the remaining tests in the class.",
     )
 
 
@@ -33,24 +43,28 @@ def pytest_addoption(parser: pytest.Parser):
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo[None]):
-    """Expose per-phase reports on each collected test item."""
+    """Expose per-phase reports on each collected test item and record incremental failures."""
     outcome = yield
     report = outcome.get_result()
     setattr(item, f"rep_{report.when}", report)
 
+    if "incremental" in item.keywords and call.excinfo is not None:
+        cls_name = str(item.cls)
+        parametrize_index = (
+            tuple(item.callspec.indices.values()) if hasattr(item, "callspec") else ()
+        )
+        test_name = item.originalname or item.name
+        _test_failed_incremental.setdefault(cls_name, {}).setdefault(parametrize_index, test_name)
 
-# TODO (mertalpt): Retire this fixture in favor of `pytest -x`
-# and clean up tests and `pytest_configure`.
-@pytest.fixture(autouse=True)
-def abort_on_fail(request: pytest.FixtureRequest):
-    """Preserve pytest-operator abort-on-fail semantics at module scope."""
-    module = request.module
-    if module is not None and getattr(module, "_abort_on_fail_triggered", False):
-        pytest.xfail("aborted")
 
-    yield
-
-    marker = request.node.get_closest_marker("abort_on_fail")
-    report = getattr(request.node, "rep_call", None)
-    if module is not None and marker and report and report.failed:
-        setattr(module, "_abort_on_fail_triggered", True)
+def pytest_runtest_setup(item: pytest.Item) -> None:
+    """Xfail a test if an earlier test in its incremental-marked class failed."""
+    if "incremental" in item.keywords:
+        cls_name = str(item.cls)
+        if cls_name in _test_failed_incremental:
+            parametrize_index = (
+                tuple(item.callspec.indices.values()) if hasattr(item, "callspec") else ()
+            )
+            test_name = _test_failed_incremental[cls_name].get(parametrize_index)
+            if test_name is not None:
+                pytest.xfail(f"previous test failed ({test_name})")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,9 +30,6 @@ def pytest_addoption(parser: pytest.Parser):
     parser.addoption("--keep-models", action="store_true", default=False)
     parser.addoption("--series", action="store", default=None)
 
-    # Passed by operator-workflows when use-canonical-k8s: true.
-    parser.addoption("--kube-config", action="store", default=None)
-
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo[None]):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,6 +4,7 @@
 """Trino charm integration test config."""
 
 import logging
+import os
 import subprocess  # nosec B404
 from pathlib import Path
 
@@ -21,6 +22,47 @@ from helpers import (
 from pytest import FixtureRequest
 
 logger = logging.getLogger(__name__)
+
+LXD_CONTROLLER = "localhost-localhost"
+K8S_CLOUD = "canonical-k8s"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def setup_canonical_k8s(request: FixtureRequest):
+    """Register Canonical Kubernetes as a Juju cloud before any tests run.
+
+    Args:
+        request: pytest request, used to read the --kube-config option.
+
+    Raises:
+        RuntimeError: If the canonical-k8s cloud cannot be registered.
+    """
+    logger.info("Bootstrapping the Juju controller and Canonical Kubernetes cloud.")
+
+    # Host the controller on LXD; canonical-k8s is added to it as a K8s cloud below.
+    subprocess.run(["/snap/bin/juju", "bootstrap", "localhost", LXD_CONTROLLER], check=False)  # nosec B603
+
+    # The kubeconfig path is supplied by operator-workflows via --kube-config;
+    # default to the conventional location.
+    kubeconfig = os.path.expanduser(request.config.getoption("--kube-config") or "~/.kube/config")
+
+    # Register the canonical-k8s cluster as a cloud on the LXD controller.
+    # `juju add-k8s` reads the cluster + credential from $KUBECONFIG.
+    result = subprocess.run(
+        ["/snap/bin/juju", "add-k8s", K8S_CLOUD, "--client", "--controller", LXD_CONTROLLER],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={**os.environ, "KUBECONFIG": kubeconfig},
+    )  # nosec B603
+    if result.returncode != 0:
+        if "already exists" in result.stderr or "already exists" in result.stdout:
+            logger.info("Canonical Kubernetes cloud already configured")
+        else:
+            raise RuntimeError(
+                f"Failed to add canonical-k8s cloud.\n"
+                f"Stdout: {result.stdout}\nStderr: {result.stderr}"
+            )
 
 
 def pack_charm(source_dir: Path) -> Path:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,8 +3,6 @@
 
 """Trino charm integration test config."""
 
-import logging
-import os
 import subprocess  # nosec B404
 from pathlib import Path
 
@@ -20,49 +18,6 @@ from helpers import (
     wait_for_apps,
 )
 from pytest import FixtureRequest
-
-logger = logging.getLogger(__name__)
-
-LXD_CONTROLLER = "localhost-localhost"
-K8S_CLOUD = "canonical-k8s"
-
-
-@pytest.fixture(scope="session", autouse=True)
-def setup_canonical_k8s(request: FixtureRequest):
-    """Register Canonical Kubernetes as a Juju cloud before any tests run.
-
-    Args:
-        request: pytest request, used to read the --kube-config option.
-
-    Raises:
-        RuntimeError: If the canonical-k8s cloud cannot be registered.
-    """
-    logger.info("Bootstrapping the Juju controller and Canonical Kubernetes cloud.")
-
-    # Host the controller on LXD; canonical-k8s is added to it as a K8s cloud below.
-    subprocess.run(["/snap/bin/juju", "bootstrap", "localhost", LXD_CONTROLLER], check=False)  # nosec B603
-
-    # The kubeconfig path is supplied by operator-workflows via --kube-config;
-    # default to the conventional location.
-    kubeconfig = os.path.expanduser(request.config.getoption("--kube-config") or "~/.kube/config")
-
-    # Register the canonical-k8s cluster as a cloud on the LXD controller.
-    # `juju add-k8s` reads the cluster + credential from $KUBECONFIG.
-    result = subprocess.run(
-        ["/snap/bin/juju", "add-k8s", K8S_CLOUD, "--client", "--controller", LXD_CONTROLLER],
-        capture_output=True,
-        text=True,
-        check=False,
-        env={**os.environ, "KUBECONFIG": kubeconfig},
-    )  # nosec B603
-    if result.returncode != 0:
-        if "already exists" in result.stderr or "already exists" in result.stdout:
-            logger.info("Canonical Kubernetes cloud already configured")
-        else:
-            raise RuntimeError(
-                f"Failed to add canonical-k8s cloud.\n"
-                f"Stdout: {result.stdout}\nStderr: {result.stderr}"
-            )
 
 
 def pack_charm(source_dir: Path) -> Path:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -88,19 +88,9 @@ def deploy(juju: jubilant.Juju, charm: str, charm_image: str):
     )
     juju.deploy(NGINX_NAME, trust=True)
 
-    wait_for_apps(
-        juju,
-        [APP_NAME, WORKER_NAME],
-        status="blocked",
-        timeout=600,
-    )
-    wait_for_apps(
-        juju,
-        [NGINX_NAME],
-        status="waiting",
-        timeout=600,
-    )
-
+    # Integrate immediately so relation processing overlaps with workload startup.
+    # This avoids the deploy->wait(blocked)->integrate->wait(active) sequencing
+    # that depends on a deferred relation-changed to clear stale blocked status.
     juju.integrate(f"{APP_NAME}:trino-coordinator", f"{WORKER_NAME}:trino-worker")
     juju.integrate(APP_NAME, NGINX_NAME)
 
@@ -108,6 +98,7 @@ def deploy(juju: jubilant.Juju, charm: str, charm_image: str):
         juju,
         [APP_NAME, WORKER_NAME],
         status="active",
-        timeout=900,
+        idle_period=30,
+        timeout=1200,  # Extend timeout as we do not wait for apps to go `active` first anymore.
     )
     assert get_unit(juju, APP_NAME).workload_status.current == "active"

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -6,6 +6,7 @@
 
 import logging
 import os
+import subprocess  # nosec B404
 import textwrap
 import time
 from contextlib import contextmanager
@@ -371,40 +372,26 @@ def get_active_workers(juju: jubilant.Juju):
     return active_workers
 
 
-def simulate_crash_and_restart(juju: jubilant.Juju, charm, charm_image):
-    """Simulate the crash of the Trino coordinator.
+def simulate_crash_and_restart(juju: jubilant.Juju):
+    """Simulate the crash of the Trino coordinator by force-deleting its pod.
+
+    The coordinator unit is part of a Kubernetes StatefulSet, so Juju recreates
+    the pod automatically while the application, its relations, peer databag,
+    storage and secrets remain intact.
 
     Args:
         juju: Jubilant Juju object.
-        charm: charm path.
-        charm_image: path to rock image to be used.
     """
-    # Destroy charm
-    juju.remove_application(APP_NAME)
-    wait_for_app_gone(juju, APP_NAME)
-
-    # Deploy charm again
-    juju.deploy(
-        charm,
-        APP_NAME,
-        resources={"trino-image": charm_image},
-        config=COORDINATOR_CONFIG,
-        num_units=1,
-        trust=True,
+    pod = f"{APP_NAME}-0"
+    subprocess.run(  # nosec B603 B607
+        ["kubectl", "delete", "pod", pod, "-n", juju.model, "--grace-period=0", "--force"],
+        check=True,
     )
-
-    wait_for_apps(
-        juju,
-        [APP_NAME],
-        status="blocked",
-        timeout=1000,
-    )
-
-    juju.integrate(f"{APP_NAME}:trino-coordinator", f"{WORKER_NAME}:trino-worker")
     wait_for_apps(
         juju,
         [APP_NAME, WORKER_NAME],
         status="active",
+        idle_period=30,
         timeout=1000,
     )
 

--- a/tests/integration/test_catalog_updates.py
+++ b/tests/integration/test_catalog_updates.py
@@ -23,7 +23,7 @@ from helpers import (
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.abort_on_fail
+@pytest.mark.incremental
 @pytest.mark.usefixtures("deploy")
 class TestCatalogUpdates:
     """Integration tests for catalog changes in Trino charm."""

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -90,15 +90,13 @@ class TestDeployment:
         assert "bigquery" not in str(catalogs)
         assert "gsheets-1" in str(catalogs)
 
-    def test_simulate_crash(self, juju: jubilant.Juju, charm: str, charm_image: str):
-        """Simulate the crash of the Trino coordinator charm.
+    def test_simulate_crash(self, juju: jubilant.Juju):
+        """Simulate the crash of the Trino coordinator charm by force-deleting its pod.
 
         Args:
             juju: Jubilant Juju object.
-            charm: charm path.
-            charm_image: path to rock image to be used.
         """
-        simulate_crash_and_restart(juju, charm, charm_image)
+        simulate_crash_and_restart(juju)
         response = curl_unit_ip(juju)
         assert response.status_code == 200
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -24,7 +24,7 @@ from helpers import (
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.abort_on_fail
+@pytest.mark.incremental
 @pytest.mark.usefixtures("deploy")
 class TestDeployment:
     """Integration tests for Trino charm."""

--- a/tests/integration/test_managers.py
+++ b/tests/integration/test_managers.py
@@ -69,7 +69,7 @@ def _set_manager_config(
     )
 
 
-@pytest.mark.abort_on_fail
+@pytest.mark.incremental
 @pytest.mark.usefixtures("deploy")
 class TestManagers:
     """Integration tests for Trino managers."""

--- a/tests/integration/test_pg_catalog_relation.py
+++ b/tests/integration/test_pg_catalog_relation.py
@@ -233,7 +233,7 @@ def get_properties_file(juju: jubilant.Juju, catalog_name):
         return None
 
 
-@pytest.mark.abort_on_fail
+@pytest.mark.incremental
 @pytest.mark.usefixtures("deploy")
 class TestPostgresqlCatalogRelation:
     """Integration tests for PostgreSQL catalog relation."""

--- a/tests/integration/test_policy.py
+++ b/tests/integration/test_policy.py
@@ -96,5 +96,5 @@ class TestPolicyManager:
         logger.info("%s can access %s.", USER_WITH_ACCESS, catalogs)
 
         catalogs = get_catalogs(juju, USER_WITHOUT_ACCESS, APP_NAME)
-        logger.info("%s can not access %s.", USER_WITH_ACCESS, catalogs)
+        logger.info("%s can not access %s.", USER_WITHOUT_ACCESS, catalogs)
         assert catalogs == []

--- a/tests/integration/test_policy.py
+++ b/tests/integration/test_policy.py
@@ -58,7 +58,7 @@ def deploy_policy_engine(juju: jubilant.Juju):
     wait_for_apps(juju, [POSTGRES_NAME, RANGER_NAME], status="active", timeout=2000)
 
 
-@pytest.mark.abort_on_fail
+@pytest.mark.incremental
 @pytest.mark.usefixtures("deploy-policy")
 class TestPolicyManager:
     """Integration test for Ranger policy enforcement."""

--- a/tests/integration/test_resources.py
+++ b/tests/integration/test_resources.py
@@ -34,7 +34,7 @@ def deploy(juju: jubilant.Juju, charm: str, charm_image: str):
     assert get_unit(juju, APP_NAME).workload_status.current == "active"
 
 
-@pytest.mark.abort_on_fail
+@pytest.mark.incremental
 @pytest.mark.usefixtures("deploy-resources")
 class TestResources:
     """Integration test for resource limits and requests."""

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -12,7 +12,7 @@ from helpers import WORKER_NAME, get_active_workers, scale
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.abort_on_fail
+@pytest.mark.incremental
 @pytest.mark.usefixtures("deploy")
 class TestScaling:
     """Integration tests for Trino worker scaling."""

--- a/tests/integration/test_trino_catalog_relation.py
+++ b/tests/integration/test_trino_catalog_relation.py
@@ -54,316 +54,293 @@ def deploy_trino(juju: jubilant.Juju, charm: str, charm_image: str):
     wait_for_apps(juju, [APP_NAME], status="active", timeout=1000)
 
 
-@pytest.mark.abort_on_fail
+@pytest.mark.incremental
 @pytest.mark.usefixtures("deploy-trino", "deploy-requirer")
-def test_01_requirer_deployment(juju: jubilant.Juju):
-    """Test that the requirer charm has been deployed."""
-    # Verify requirer is blocked waiting for relation
-    assert get_unit(juju, REQUIRER_APP).workload_status.current == "blocked"
+class TestTrinoCatalogRelation:
+    """Integration tests for the trino-catalog relation."""
 
+    def test_01_requirer_deployment(self, juju: jubilant.Juju):
+        """Test that the requirer charm has been deployed."""
+        # Verify requirer is blocked waiting for relation
+        assert get_unit(juju, REQUIRER_APP).workload_status.current == "blocked"
 
-@pytest.mark.abort_on_fail
-@pytest.mark.usefixtures("deploy-trino", "deploy-requirer")
-def test_02_trino_catalog_relation_created(juju: jubilant.Juju):
-    """Test creating the trino-catalog relation."""
-    # Add the relation
-    juju.integrate(f"{APP_NAME}:trino-catalog", f"{REQUIRER_APP}:trino-catalog")
-    wait_for_apps(juju, [APP_NAME, REQUIRER_APP], status="active", timeout=1000)
+    def test_02_trino_catalog_relation_created(self, juju: jubilant.Juju):
+        """Test creating the trino-catalog relation."""
+        # Add the relation
+        juju.integrate(f"{APP_NAME}:trino-catalog", f"{REQUIRER_APP}:trino-catalog")
+        wait_for_apps(juju, [APP_NAME, REQUIRER_APP], status="active", timeout=1000)
 
-    # Verify relation exists
-    trino_catalog_relations = juju.status().apps[APP_NAME].relations.get("trino-catalog", [])
-    assert len(trino_catalog_relations) > 0
+        # Verify relation exists
+        trino_catalog_relations = juju.status().apps[APP_NAME].relations.get("trino-catalog", [])
+        assert len(trino_catalog_relations) > 0
 
+    def test_03_auto_generated_credentials(self, juju: jubilant.Juju):
+        """Test that per-relation credentials are auto-generated."""
+        action = juju.run(f"{REQUIRER_APP}/0", "get-relation-data")
+        assert action.status == "completed"
 
-@pytest.mark.abort_on_fail
-@pytest.mark.usefixtures("deploy-trino", "deploy-requirer")
-def test_03_auto_generated_credentials(juju: jubilant.Juju):
-    """Test that per-relation credentials are auto-generated."""
-    action = juju.run(f"{REQUIRER_APP}/0", "get-relation-data")
-    assert action.status == "completed"
+        # Verify auto-generated username follows pattern app-{app_name}-{relation_id}
+        result_username = action.results.get("trino-username")
+        assert result_username.startswith(f"app-{REQUIRER_APP}-"), (
+            f"Expected username starting with 'app-{REQUIRER_APP}-', got '{result_username}'"
+        )
 
-    # Verify auto-generated username follows pattern app-{app_name}-{relation_id}
-    result_username = action.results.get("trino-username")
-    assert result_username.startswith(f"app-{REQUIRER_APP}-"), (
-        f"Expected username starting with 'app-{REQUIRER_APP}-', got '{result_username}'"
-    )
+        # Verify password is a non-empty random string
+        result_password = action.results.get("trino-password")
+        assert result_password and len(result_password) > 0, (
+            "Expected non-empty auto-generated password"
+        )
 
-    # Verify password is a non-empty random string
-    result_password = action.results.get("trino-password")
-    assert result_password and len(result_password) > 0, (
-        "Expected non-empty auto-generated password"
-    )
+        # Verify internal URL (no nginx relation at this point)
+        result_url = action.results.get("trino-url")
+        expected_internal_url = f"{APP_NAME}.{juju.model}.svc.cluster.local:{TRINO_PORTS['HTTP']}"
+        assert result_url == expected_internal_url, (
+            f"Expected internal URL '{expected_internal_url}', got '{result_url}'"
+        )
 
-    # Verify internal URL (no nginx relation at this point)
-    result_url = action.results.get("trino-url")
-    expected_internal_url = f"{APP_NAME}.{juju.model}.svc.cluster.local:{TRINO_PORTS['HTTP']}"
-    assert result_url == expected_internal_url, (
-        f"Expected internal URL '{expected_internal_url}', got '{result_url}'"
-    )
+        logger.info(
+            "Verified auto-generated credentials: username='%s', URL='%s'",
+            result_username,
+            result_url,
+        )
 
-    logger.info(
-        "Verified auto-generated credentials: username='%s', URL='%s'",
-        result_username,
-        result_url,
-    )
+    def test_04_trino_catalog_relation_set_catalogs(self, juju: jubilant.Juju):
+        """Test that catalog-config changes propagate to the requirer."""
+        # Create catalog secrets
+        postgresql_secret_id = add_juju_secret(juju, "postgresql")
+        mysql_secret_id = add_juju_secret(juju, "mysql")
+        redshift_secret_id = add_juju_secret(juju, "redshift")
+        bigquery_secret_id = add_juju_secret(juju, "bigquery")
+        gsheets_secret_id = add_juju_secret(juju, "gsheets")
 
+        # Grant secrets to Trino
+        juju.grant_secret("postgresql-secret", APP_NAME)
+        juju.grant_secret("mysql-secret", APP_NAME)
+        juju.grant_secret("redshift-secret", APP_NAME)
+        juju.grant_secret("bigquery-secret", APP_NAME)
+        juju.grant_secret("gsheets-secret", APP_NAME)
 
-@pytest.mark.abort_on_fail
-@pytest.mark.usefixtures("deploy-trino", "deploy-requirer")
-def test_04_trino_catalog_relation_set_catalogs(juju: jubilant.Juju):
-    """Test that catalog-config changes propagate to the requirer."""
-    # Create catalog secrets
-    postgresql_secret_id = add_juju_secret(juju, "postgresql")
-    mysql_secret_id = add_juju_secret(juju, "mysql")
-    redshift_secret_id = add_juju_secret(juju, "redshift")
-    bigquery_secret_id = add_juju_secret(juju, "bigquery")
-    gsheets_secret_id = add_juju_secret(juju, "gsheets")
+        # Create catalog config
+        catalog_config = create_catalog_config(
+            postgresql_secret_id,
+            mysql_secret_id,
+            redshift_secret_id,
+            bigquery_secret_id,
+            gsheets_secret_id,
+            include_bigquery=True,
+        )
 
-    # Grant secrets to Trino
-    juju.grant_secret("postgresql-secret", APP_NAME)
-    juju.grant_secret("mysql-secret", APP_NAME)
-    juju.grant_secret("redshift-secret", APP_NAME)
-    juju.grant_secret("bigquery-secret", APP_NAME)
-    juju.grant_secret("gsheets-secret", APP_NAME)
+        # Update Trino with catalog config
+        juju.config(APP_NAME, {"catalog-config": catalog_config})
+        wait_for_apps(juju, [APP_NAME, REQUIRER_APP], status="active", timeout=1000)
 
-    # Create catalog config
-    catalog_config = create_catalog_config(
-        postgresql_secret_id,
-        mysql_secret_id,
-        redshift_secret_id,
-        bigquery_secret_id,
-        gsheets_secret_id,
-        include_bigquery=True,
-    )
+        # Verify the requirer received the catalogs
+        action = juju.run(f"{REQUIRER_APP}/0", "get-relation-data")
+        assert action.status == "completed"
 
-    # Update Trino with catalog config
-    juju.config(APP_NAME, {"catalog-config": catalog_config})
-    wait_for_apps(juju, [APP_NAME, REQUIRER_APP], status="active", timeout=1000)
+        # Parse the catalogs list from string representation
+        catalogs_str = action.results.get("trino-catalogs", "[]")
+        catalogs = ast.literal_eval(catalogs_str)
+        catalogs_count = len(catalogs)
 
-    # Verify the requirer received the catalogs
-    action = juju.run(f"{REQUIRER_APP}/0", "get-relation-data")
-    assert action.status == "completed"
+        assert catalogs_count == 5, f"Expected 5 catalogs, got {catalogs_count}"
 
-    # Parse the catalogs list from string representation
-    catalogs_str = action.results.get("trino-catalogs", "[]")
-    catalogs = ast.literal_eval(catalogs_str)
-    catalogs_count = len(catalogs)
+        # Verify catalog names are present
+        catalog_names = {cat["name"] for cat in catalogs}
+        expected_catalogs = {
+            "postgresql-1",
+            "mysql",
+            "redshift",
+            "bigquery",
+            "gsheets-1",
+        }
+        assert expected_catalogs.issubset(catalog_names), (
+            f"Expected catalogs {expected_catalogs}, got {catalog_names}"
+        )
 
-    assert catalogs_count == 5, f"Expected 5 catalogs, got {catalogs_count}"
+        logger.info(
+            "Verified requirer received %s catalogs: %s",
+            catalogs_count,
+            catalog_names,
+        )
 
-    # Verify catalog names are present
-    catalog_names = {cat["name"] for cat in catalogs}
-    expected_catalogs = {
-        "postgresql-1",
-        "mysql",
-        "redshift",
-        "bigquery",
-        "gsheets-1",
-    }
-    assert expected_catalogs.issubset(catalog_names), (
-        f"Expected catalogs {expected_catalogs}, got {catalog_names}"
-    )
+    def test_05_catalog_exclusions(self, juju: jubilant.Juju):
+        """Test that catalog-exclusions filters catalogs for a specific requirer."""
+        # Exclude one catalog for the requirer app
+        exclusion_config = f"{REQUIRER_APP}:\n  - postgresql-1"
 
-    logger.info(
-        "Verified requirer received %s catalogs: %s",
-        catalogs_count,
-        catalog_names,
-    )
+        juju.config(APP_NAME, {"catalog-exclusions": exclusion_config})
+        wait_for_apps(juju, [APP_NAME], status="active", timeout=1000)
 
+        # Verify the requirer receives 4 catalogs (postgresql-1 excluded)
+        action = juju.run(f"{REQUIRER_APP}/0", "get-relation-data")
+        assert action.status == "completed"
 
-@pytest.mark.abort_on_fail
-@pytest.mark.usefixtures("deploy-trino", "deploy-requirer")
-def test_05_catalog_exclusions(juju: jubilant.Juju):
-    """Test that catalog-exclusions filters catalogs for a specific requirer."""
-    # Exclude one catalog for the requirer app
-    exclusion_config = f"{REQUIRER_APP}:\n  - postgresql-1"
+        catalogs_str = action.results.get("trino-catalogs", "[]")
+        catalogs = ast.literal_eval(catalogs_str)
+        catalog_names = {cat["name"] for cat in catalogs}
 
-    juju.config(APP_NAME, {"catalog-exclusions": exclusion_config})
-    wait_for_apps(juju, [APP_NAME], status="active", timeout=1000)
+        assert "postgresql-1" not in catalog_names, (
+            f"postgresql-1 should be excluded, but found in {catalog_names}"
+        )
+        assert len(catalogs) == 4, f"Expected 4 catalogs, got {len(catalogs)}"
 
-    # Verify the requirer receives 4 catalogs (postgresql-1 excluded)
-    action = juju.run(f"{REQUIRER_APP}/0", "get-relation-data")
-    assert action.status == "completed"
+        # Reset exclusions and verify all catalogs are restored
+        juju.config(APP_NAME, reset=["catalog-exclusions"])
+        wait_for_apps(juju, [APP_NAME], status="active", timeout=1000)
 
-    catalogs_str = action.results.get("trino-catalogs", "[]")
-    catalogs = ast.literal_eval(catalogs_str)
-    catalog_names = {cat["name"] for cat in catalogs}
+        action = juju.run(f"{REQUIRER_APP}/0", "get-relation-data")
+        assert action.status == "completed"
 
-    assert "postgresql-1" not in catalog_names, (
-        f"postgresql-1 should be excluded, but found in {catalog_names}"
-    )
-    assert len(catalogs) == 4, f"Expected 4 catalogs, got {len(catalogs)}"
+        catalogs_str = action.results.get("trino-catalogs", "[]")
+        catalogs = ast.literal_eval(catalogs_str)
+        catalog_names = {cat["name"] for cat in catalogs}
 
-    # Reset exclusions and verify all catalogs are restored
-    juju.config(APP_NAME, reset=["catalog-exclusions"])
-    wait_for_apps(juju, [APP_NAME], status="active", timeout=1000)
+        assert "postgresql-1" in catalog_names, (
+            f"postgresql-1 should be restored after clearing exclusions, got {catalog_names}"
+        )
+        assert len(catalogs) == 5, f"Expected 5 catalogs, got {len(catalogs)}"
 
-    action = juju.run(f"{REQUIRER_APP}/0", "get-relation-data")
-    assert action.status == "completed"
+        logger.info("Verified catalog exclusions work correctly")
 
-    catalogs_str = action.results.get("trino-catalogs", "[]")
-    catalogs = ast.literal_eval(catalogs_str)
-    catalog_names = {cat["name"] for cat in catalogs}
+    def test_06_trino_catalog_external_url_with_nginx(self, juju: jubilant.Juju):
+        """Test that the requirer receives external URL when nginx-route relation exists."""
+        # Deploy nginx-ingress-integrator
+        juju.deploy(NGINX_NAME, trust=True)
+        wait_for_apps(juju, [NGINX_NAME], status="waiting", timeout=1000)
 
-    assert "postgresql-1" in catalog_names, (
-        f"postgresql-1 should be restored after clearing exclusions, got {catalog_names}"
-    )
-    assert len(catalogs) == 5, f"Expected 5 catalogs, got {len(catalogs)}"
+        # Relate Trino to nginx-ingress-integrator
+        juju.integrate(APP_NAME, NGINX_NAME)
+        wait_for_apps(juju, [APP_NAME], status="active", timeout=1000)
 
-    logger.info("Verified catalog exclusions work correctly")
+        # Set external-hostname config
+        juju.config(APP_NAME, {"external-hostname": "trino.test.com"})
+        wait_for_apps(juju, [APP_NAME], status="active", timeout=1000)
 
+        # Verify the requirer received the external URL
+        action = juju.run(f"{REQUIRER_APP}/0", "get-relation-data")
+        assert action.status == "completed"
 
-@pytest.mark.abort_on_fail
-@pytest.mark.usefixtures("deploy-trino", "deploy-requirer")
-def test_06_trino_catalog_external_url_with_nginx(
-    juju: jubilant.Juju,
-):
-    """Test that the requirer receives external URL when nginx-route relation exists."""
-    # Deploy nginx-ingress-integrator
-    juju.deploy(NGINX_NAME, trust=True)
-    wait_for_apps(juju, [NGINX_NAME], status="waiting", timeout=1000)
+        result_url = action.results.get("trino-url")
+        expected_external_url = f"trino.test.com:{TRINO_PORTS['HTTPS']}"
+        assert result_url == expected_external_url, (
+            f"Expected external URL '{expected_external_url}', got '{result_url}'"
+        )
+        logger.info("Verified requirer received external Trino URL: %s", result_url)
 
-    # Relate Trino to nginx-ingress-integrator
-    juju.integrate(APP_NAME, NGINX_NAME)
-    wait_for_apps(juju, [APP_NAME], status="active", timeout=1000)
+        # Clean up: remove nginx relation and reset external-hostname
+        juju.remove_relation(APP_NAME, NGINX_NAME)
+        wait_for_apps(juju, [APP_NAME], status="active", timeout=1000)
+        juju.config(APP_NAME, reset=["external-hostname"])
+        wait_for_apps(juju, [APP_NAME], status="active", timeout=1000)
 
-    # Set external-hostname config
-    juju.config(APP_NAME, {"external-hostname": "trino.test.com"})
-    wait_for_apps(juju, [APP_NAME], status="active", timeout=1000)
+    def test_07_catalog_config_propagation(self, juju: jubilant.Juju):
+        """Test that catalog-config changes propagate to the requirer."""
+        # Get catalog secrets
+        postgresql_secret_id = get_secret_id_by_label(juju, "postgresql-secret")
+        mysql_secret_id = get_secret_id_by_label(juju, "mysql-secret")
+        redshift_secret_id = get_secret_id_by_label(juju, "redshift-secret")
+        bigquery_secret_id = get_secret_id_by_label(juju, "bigquery-secret")
+        gsheets_secret_id = get_secret_id_by_label(juju, "gsheets-secret")
 
-    # Verify the requirer received the external URL
-    action = juju.run(f"{REQUIRER_APP}/0", "get-relation-data")
-    assert action.status == "completed"
+        logger.info("PostgreSQL secret ID: %s", postgresql_secret_id)
+        logger.info("MySQL secret ID: %s", mysql_secret_id)
+        logger.info("Redshift secret ID: %s", redshift_secret_id)
+        logger.info("BigQuery secret ID: %s", bigquery_secret_id)
+        logger.info("GSheets secret ID: %s", gsheets_secret_id)
 
-    result_url = action.results.get("trino-url")
-    expected_external_url = f"trino.test.com:{TRINO_PORTS['HTTPS']}"
-    assert result_url == expected_external_url, (
-        f"Expected external URL '{expected_external_url}', got '{result_url}'"
-    )
-    logger.info("Verified requirer received external Trino URL: %s", result_url)
+        # Update to remove bigquery
+        catalog_config_without_bigquery = create_catalog_config(
+            postgresql_secret_id,
+            mysql_secret_id,
+            redshift_secret_id,
+            bigquery_secret_id,
+            gsheets_secret_id,
+            include_bigquery=False,
+        )
 
-    # Clean up: remove nginx relation and reset external-hostname
-    juju.remove_relation(APP_NAME, NGINX_NAME)
-    wait_for_apps(juju, [APP_NAME], status="active", timeout=1000)
-    juju.config(APP_NAME, reset=["external-hostname"])
-    wait_for_apps(juju, [APP_NAME], status="active", timeout=1000)
+        juju.config(APP_NAME, {"catalog-config": catalog_config_without_bigquery})
+        wait_for_apps(juju, [APP_NAME], status="active", timeout=1000)
 
+        # Verify the requirer received the updated catalogs (without bigquery)
+        action = juju.run(f"{REQUIRER_APP}/0", "get-relation-data")
+        assert action.status == "completed"
 
-@pytest.mark.abort_on_fail
-@pytest.mark.usefixtures("deploy-trino", "deploy-requirer")
-def test_07_catalog_config_propagation(juju: jubilant.Juju):
-    """Test that catalog-config changes propagate to the requirer."""
-    # Get catalog secrets
-    postgresql_secret_id = get_secret_id_by_label(juju, "postgresql-secret")
-    mysql_secret_id = get_secret_id_by_label(juju, "mysql-secret")
-    redshift_secret_id = get_secret_id_by_label(juju, "redshift-secret")
-    bigquery_secret_id = get_secret_id_by_label(juju, "bigquery-secret")
-    gsheets_secret_id = get_secret_id_by_label(juju, "gsheets-secret")
+        # Parse the catalogs list from string representation
+        catalogs_str = action.results.get("trino-catalogs", "[]")
+        catalogs = ast.literal_eval(catalogs_str)
+        catalogs_count = len(catalogs)
 
-    logger.info("PostgreSQL secret ID: %s", postgresql_secret_id)
-    logger.info("MySQL secret ID: %s", mysql_secret_id)
-    logger.info("Redshift secret ID: %s", redshift_secret_id)
-    logger.info("BigQuery secret ID: %s", bigquery_secret_id)
-    logger.info("GSheets secret ID: %s", gsheets_secret_id)
+        assert catalogs_count == 4, (
+            f"Expected 4 catalogs after removing bigquery, got {catalogs_count}"
+        )
 
-    # Update to remove bigquery
-    catalog_config_without_bigquery = create_catalog_config(
-        postgresql_secret_id,
-        mysql_secret_id,
-        redshift_secret_id,
-        bigquery_secret_id,
-        gsheets_secret_id,
-        include_bigquery=False,
-    )
+        # Verify bigquery is no longer present
+        catalog_names = {cat["name"] for cat in catalogs}
+        assert "bigquery" not in catalog_names, (
+            f"bigquery should be removed, but found in {catalog_names}"
+        )
+        expected_catalogs = {"postgresql-1", "mysql", "redshift", "gsheets-1"}
+        assert expected_catalogs.issubset(catalog_names), (
+            f"Expected catalogs {expected_catalogs}, got {catalog_names}"
+        )
 
-    juju.config(APP_NAME, {"catalog-config": catalog_config_without_bigquery})
-    wait_for_apps(juju, [APP_NAME], status="active", timeout=1000)
+        logger.info(
+            "Verified catalog count reduced to %s after removing bigquery: %s",
+            catalogs_count,
+            catalog_names,
+        )
 
-    # Verify the requirer received the updated catalogs (without bigquery)
-    action = juju.run(f"{REQUIRER_APP}/0", "get-relation-data")
-    assert action.status == "completed"
+    def test_08_multiple_requirers(self, juju: jubilant.Juju):
+        """Test that multiple requirers each get separate auto-generated credentials."""
+        # Deploy a second requirer
+        requirer_charm = pack_charm(Path(REQUIRER_CHARM_PATH))
+        requirer_app_2 = "second-requirer"
 
-    # Parse the catalogs list from string representation
-    catalogs_str = action.results.get("trino-catalogs", "[]")
-    catalogs = ast.literal_eval(catalogs_str)
-    catalogs_count = len(catalogs)
+        juju.deploy(requirer_charm, requirer_app_2, num_units=1)
+        wait_for_apps(juju, [requirer_app_2], status="blocked", timeout=1000)
 
-    assert catalogs_count == 4, (
-        f"Expected 4 catalogs after removing bigquery, got {catalogs_count}"
-    )
+        # Relate second requirer to Trino
+        juju.integrate(f"{APP_NAME}:trino-catalog", f"{requirer_app_2}:trino-catalog")
+        wait_for_apps(juju, [requirer_app_2], status="active", timeout=1000)
 
-    # Verify bigquery is no longer present
-    catalog_names = {cat["name"] for cat in catalogs}
-    assert "bigquery" not in catalog_names, (
-        f"bigquery should be removed, but found in {catalog_names}"
-    )
-    expected_catalogs = {"postgresql-1", "mysql", "redshift", "gsheets-1"}
-    assert expected_catalogs.issubset(catalog_names), (
-        f"Expected catalogs {expected_catalogs}, got {catalog_names}"
-    )
+        # Verify both requirers are connected
+        trino_catalog_relations = juju.status().apps[APP_NAME].relations.get("trino-catalog", [])
+        # Should have at least 2 relations
+        assert len(trino_catalog_relations) >= 2
 
-    logger.info(
-        "Verified catalog count reduced to %s after removing bigquery: %s",
-        catalogs_count,
-        catalog_names,
-    )
+        # Verify each requirer got different credentials
+        action_1 = juju.run(f"{REQUIRER_APP}/0", "get-relation-data")
+        action_2 = juju.run(f"{requirer_app_2}/0", "get-relation-data")
 
+        username_1 = action_1.results.get("trino-username")
+        username_2 = action_2.results.get("trino-username")
 
-@pytest.mark.abort_on_fail
-@pytest.mark.usefixtures("deploy-trino", "deploy-requirer")
-def test_08_multiple_requirers(juju: jubilant.Juju):
-    """Test that multiple requirers each get separate auto-generated credentials."""
-    # Deploy a second requirer
-    requirer_charm = pack_charm(Path(REQUIRER_CHARM_PATH))
-    requirer_app_2 = "second-requirer"
+        assert username_1.startswith(f"app-{REQUIRER_APP}-")
+        assert username_2.startswith(f"app-{requirer_app_2}-")
+        assert username_1 != username_2, (
+            f"Each requirer should get a unique username, got '{username_1}' and '{username_2}'"
+        )
 
-    juju.deploy(requirer_charm, requirer_app_2, num_units=1)
-    wait_for_apps(juju, [requirer_app_2], status="blocked", timeout=1000)
+        logger.info(
+            "Verified separate credentials: requirer1='%s', requirer2='%s'",
+            username_1,
+            username_2,
+        )
 
-    # Relate second requirer to Trino
-    juju.integrate(f"{APP_NAME}:trino-catalog", f"{requirer_app_2}:trino-catalog")
-    wait_for_apps(juju, [requirer_app_2], status="active", timeout=1000)
+        # Clean up second requirer
+        juju.remove_application(requirer_app_2)
+        wait_for_app_gone(juju, requirer_app_2)
 
-    # Verify both requirers are connected
-    trino_catalog_relations = juju.status().apps[APP_NAME].relations.get("trino-catalog", [])
-    # Should have at least 2 relations
-    assert len(trino_catalog_relations) >= 2
+    def test_09_relation_broken(self, juju: jubilant.Juju):
+        """Test that relation can be broken cleanly."""
+        # Remove the relation
+        juju.remove_relation(f"{APP_NAME}:trino-catalog", f"{REQUIRER_APP}:trino-catalog")
+        wait_for_apps(juju, [REQUIRER_APP], status="blocked", timeout=1000)
 
-    # Verify each requirer got different credentials
-    action_1 = juju.run(f"{REQUIRER_APP}/0", "get-relation-data")
-    action_2 = juju.run(f"{requirer_app_2}/0", "get-relation-data")
+        # Verify relation is removed
+        trino_catalog_relations = juju.status().apps[APP_NAME].relations.get("trino-catalog", [])
+        assert len(trino_catalog_relations) == 0
 
-    username_1 = action_1.results.get("trino-username")
-    username_2 = action_2.results.get("trino-username")
-
-    assert username_1.startswith(f"app-{REQUIRER_APP}-")
-    assert username_2.startswith(f"app-{requirer_app_2}-")
-    assert username_1 != username_2, (
-        f"Each requirer should get a unique username, got '{username_1}' and '{username_2}'"
-    )
-
-    logger.info(
-        "Verified separate credentials: requirer1='%s', requirer2='%s'",
-        username_1,
-        username_2,
-    )
-
-    # Clean up second requirer
-    juju.remove_application(requirer_app_2)
-    wait_for_app_gone(juju, requirer_app_2)
-
-
-@pytest.mark.abort_on_fail
-@pytest.mark.usefixtures("deploy-trino", "deploy-requirer")
-def test_09_relation_broken(juju: jubilant.Juju):
-    """Test that relation can be broken cleanly."""
-    # Remove the relation
-    juju.remove_relation(f"{APP_NAME}:trino-catalog", f"{REQUIRER_APP}:trino-catalog")
-    wait_for_apps(juju, [REQUIRER_APP], status="blocked", timeout=1000)
-
-    # Verify relation is removed
-    trino_catalog_relations = juju.status().apps[APP_NAME].relations.get("trino-catalog", [])
-    assert len(trino_catalog_relations) == 0
-
-    # Requirer should be blocked
-    assert get_unit(juju, REQUIRER_APP).workload_status.current == "blocked"
+        # Requirer should be blocked
+        assert get_unit(juju, REQUIRER_APP).workload_status.current == "blocked"

--- a/tests/integration/test_upgrades.py
+++ b/tests/integration/test_upgrades.py
@@ -27,7 +27,7 @@ def deploy(juju: jubilant.Juju):
     assert get_unit(juju, APP_NAME).workload_status.current == "active"
 
 
-@pytest.mark.abort_on_fail
+@pytest.mark.incremental
 @pytest.mark.usefixtures("deploy-upgrade")
 class TestUpgrade:
     """Integration test for Trino charm upgrade from previous release."""


### PR DESCRIPTION
Changes:
* Migrates integration tests to Canonical K8s.
* Rewrites the crash test to delete the pod rather than remove the application and re-deploy.
* Streamlines integration test `deploy` fixture to improve resolution speed.
* Changes the fixture used to `xfail` tests if an earlier test fails.

## Note for reviewers
Considering how heavy the CI pipeline is, any non-vital change I will do with a future PR as there will be plenty in the near future. So, please approve accordingly.