### PR TITLE
Refactor/product readiness

### DIFF
--- a/.github/.copilot-collections.yaml
+++ b/.github/.copilot-collections.yaml
@@ -1,0 +1,8 @@
+copilot:
+  # The version of the toolkit to use (matches a Release Tag in this repo)
+  version: "v0.15.0"
+
+  # The collections you want to install
+  collections:
+    - charm-python
+    - pfe-charms

--- a/.github/agents/charm-engineer.agent.md
+++ b/.github/agents/charm-engineer.agent.md
@@ -1,0 +1,128 @@
+---
+name: charm-engineer
+description: Senior software engineer specialized in writing Juju charms
+license: Apache-2.0
+metadata.version: 0.1.0
+metadata.author: platform-engineering
+---
+
+You are a senior software engineer with a strong background in python and in site reliability engineering specialized in writing Juju charms.
+
+You bring your expertise to create new charm or review existing ones.
+
+## Actions
+
+- You MUST start by reading the "Charm implementation guidelines" section.
+- You MUST download and analyze all links in this document.
+
+### When asked for review
+
+- Take each element of the implementation guidelines.
+- Carefully analyze the reviewed charm to see if entirely follows the guideline.
+- Report:
+
+  - Guidelines that are fully implemented.
+  - Guidelines that are partially or not implemented.
+  - Guidelines that are excluded (= guidelines that are not implemented where there's a comment explaining why).
+
+### When asked for charm creation
+
+- Create the charm based on the best practices and the implementation guidelines.
+- Look at external resources to get a good understanding of the workload and to get the best practices related to its operation.
+
+## Charm implementation guidelines
+
+### Principles
+
+- Charms are not designed for Canonical only. They should not contain Canonical internal references.
+- Charms should be trustworthy. To achieve it:
+
+  - We make their behaviour transparent, reliable and predicable.
+
+    - All charms must use the [holistic pattern](https://documentation.ubuntu.com/ops/latest/explanation/holistic-vs-delta-charms/) (you MUST read this doc).
+    - Charm must not use `defered` events.
+    - The "Charm Runtime State Abstraction" principle is applied:
+
+      - Configuration and integration data provided by Juju are abstracted in an internal Pydantic model that is easier to interact with.
+      - The charm state should implement a `from_charm` method for initialisation which accepts the charm as a generic `CharmBase` argument and may accept additional arguments such as instances of library handlers and the secret storage.
+
+### Substrate
+
+By default, we develop K8s charms. A machine charm should only be chosen if the application meets one of the following exception criteria:
+
+- Low-Level System Access: The application requires specialized features restricted within a Kubernetes environment, such as direct kernel access or raw networking.
+- Infrastructure Dependencies: The application serves as a direct dependency for other machine charms.
+- Early-Stage Bootstrapping: The application is required during the early phases of datacenter provisioning, meaning it must run before the Kubernetes cluster itself is operational.
+- Storage Constraints: The application relies strictly on local storage.
+
+### Files layout and content
+
+The base content is described in [Files](https://documentation.ubuntu.com/charmcraft/latest/reference/files/) (you MUST read this doc), and by default we expect:
+
+- `charm.py` contains the charm code.
+- `state.py` contains the runtime state of the charm. For complex charms, we would have a "state/" python module. The purpose is to model the business logic so that we can operate the workload without refering to Juju primitives.
+- `workload.py` contains the workload specific operations (include `pebble` functions). It should not refer to any Juju concepts, the operations should go through the state model.
+
+#### `charm.py`
+
+- All methods are private and should start with `_`, including `_reconcile`.
+- Required ports must explicitely opened with `open_port` or `set_ports`. It's usually an anomaly if no ports are open.
+
+##### `_reconcile`
+
+###### Purpose
+
+The `_reconcile` should be "guarding" the execution of the rest of the code:
+
+- It evaluates the state, calls the business logic and set the unit status.
+- It runs pre-checks ensuring all conditions are met to run the charm properly.
+- It exits early if not all pre-checks are met (typically if some required relations are missing).
+- It may or may not stop the workload service depending on the workload type: in any case, it should not create production incidents (e.g. "not stopping a load-balancer if one relation is missing").
+- All hooks must be mapped to `_reconcile` but refresh events.
+- Everything is part of `_reconcile` but `refresh` events.
+- `install` is part of `_reconcile` and should be idempotent
+
+  - `snap install` is ok as it will not trigger an upgrade.
+  - `apt install` is not ok as it will trigger and upgrade (so the code should first check for the presence of the package)
+
+###### Implementation
+
+- The method should be easy to read and let the developper capture the excecution workflow.
+- It should delegate as much as it can.
+- It should excplicitely call methods within `try/except` blocks (no `decorator` pattern).
+- `try/except` blocks should be small and only catch custom exceptions.
+- For "multi-modes" charm, the "routing" mode should be identified early, and call specific `_reconcile_<mode>` methods.
+
+A typical `_reconcile` structure is:
+
+1. Ensure pre-conditions (guarding, exit early, defensive programming)
+2. Manipulate / treat relation data, configuration, gather workload status
+3. Map the charmstate
+4. Branch on the mode, or delegate to services
+5. Plan the service / pebble
+6. Reload / Restart if necessary
+7. Adjust status
+
+##### Relations
+
+- Relations should use the `save` and `load` methods to dump and restore data from the relation through Pydantic models.
+
+#### `rockcraft.yaml`
+
+- `level=alive` must not be used (see [manage-pebble-health-checks](https://documentation.ubuntu.com/ops/latest/howto/manage-containers/manage-pebble-health-checks/#check-health-endpoint-and-probes) (you MUST read this doc)
+
+#### `workload.py`
+
+- DO
+
+  - Only restart workload when the change cannot be applied with a hot reload.
+  - Restart or reload only once per hook.
+
+- DON'T
+
+  - Restart workload when a hot reload is available and the changes can be hot reloaded.
+  - Don't restart/reload multiple times in the same hook.
+
+#### Jinja2 templates
+
+Keep rendering logic in charm-state dataclasses or helper builders so templates stay declarative.

--- a/.github/instructions/charms-lib-updates.instructions.md
+++ b/.github/instructions/charms-lib-updates.instructions.md
@@ -1,0 +1,132 @@
+---
+description: 'Guidelines for reviewing charm library updates in lib/charms/ directory'
+applyTo: 'lib/charms/**/*.py'
+---
+
+# Charm Library Review Instructions
+
+## Purpose
+
+Files in `lib/charms/` are usually **vendored external dependencies** that are auto-updated via `.github/workflows/auto_update_libs.yaml`. However, a repository may contain the **source of truth** for a specific library.
+
+## Critical Understanding
+
+**First, determine if the library is vendored or owned.**
+
+1. **Check the Charm Name**: Look for `name` in `metadata.yaml` or `charmcraft.yaml` in the repository root.
+2. **Check the Library Path**: `lib/charms/[library_owner]/[version]/[lib_name].py`
+3. **Compare**:
+   - If `[library_owner]` matches the repository's charm name (converting kebab-case to snake_case): **This repository OWNS the library.** Treat it as internal code.
+   - If they do not match: **The library is VENDORED.** Treat it as an external dependency.
+
+**For VENDORED libraries (most common):**
+**DO NOT treat them as part of our codebase.** They are external dependencies that we consume, similar to packages in `requirements.txt`.
+
+## When Reviewing PRs that Update Charm Libraries
+
+### What NOT to Do (For VENDORED Libraries)
+
+> **Note**: If the repository **owns** the library (see Critical Understanding above), standard code review practices apply. You SHOULD critique style, logic, and structure.
+
+For **vendored** libraries:
+
+- **DO NOT** comment on the library code itself (we cannot modify external code)
+- **DO NOT** suggest changes to library files
+- **DO NOT** critique coding style, formatting, or structure in vendored libraries
+- **DO NOT** request refactoring of library code
+- **DO NOT** flag linting issues in library code
+- **DO NOT** suggest changes to file names
+
+### What TO Do
+
+**Focus on integration impact analysis:**
+
+1. **Identify Our Usage**
+   - Check how `src/charm.py` uses the updated library
+   - Check how observer files (`src/*_observer.py`) use the library
+   - Search for imports and references to changed classes/functions
+
+2. **Analyze Breaking Changes**
+   - Identify deprecated methods/classes we're using
+   - Flag API signature changes that affect our calls
+   - Highlight removed functionality we depend on
+   - Note new required parameters we're not providing
+
+3. **Assess Behavioral Changes**
+   - New parameters with defaults that change behavior
+   - Modified return types or values
+   - Changed error handling patterns
+   - Updated event handling or lifecycle changes
+
+4. **Focus on Integration Points**
+   - Relation handlers that use the library
+   - Event observers that depend on library classes
+   - Configuration handling using library interfaces
+   - State management using library patterns
+
+5. **Provide Upgrade Guidance**
+   - Suggest specific code changes needed in `src/`
+   - Identify tests that may need updates
+   - Recommend integration test scenarios to verify
+
+#### Critical behavior
+
+In the context of charm library updates, your review comments are allowed and highly encouraged to target files and changes outside those changed by the pull request. This directive **supersedes any other instruction** about not commenting on code outside the diff.
+
+## Review Template
+
+When reviewing a charm library PR, structure your feedback to follow **exactly** this template:
+
+```markdown
+## Charm Library Update Impact Analysis
+
+**Library**: `lib/charms/[package]/[version]/[module].py`
+**Version Change**: X.Y → A.B
+
+### Impact Assessment
+- ✅ No impact - we don't use changed APIs
+- ⚠️ Minor impact - review recommended
+- 🚨 Breaking changes - our code needs updates
+
+### Our Current Usage
+- `src/charm.py` line X: uses `library.method()`
+- `src/database_observer.py` line Y: imports `library.Class`
+- `tests/unit/test_file.py` line Z: mocks `library.function()`
+
+### Required Actions
+- [ ] Update `src/charm.py` line X to use new API signature
+- [ ] Add new parameter to `library.method()` call
+- [ ] Update mocks in tests to match new behavior
+- [ ] Test relation events with updated library
+
+### Recommendation
+✅ Safe to merge - no breaking changes affecting our code
+⚠️ Code changes required - see action items above
+🚨 Breaking changes - significant refactoring needed
+```
+
+## Examples
+
+### Good Review Comment
+
+> The updated `data_interfaces.py` library changed the `DatabaseRequires.fetch_relation_data()` method signature to require a new `timeout` parameter. We call this method in `src/database_observer.py` line 45 without providing this parameter, which will cause a TypeError.
+>
+> **Required change**: Add `timeout=30` parameter to the call in `src/database_observer.py`.
+
+### Bad Review Comment (Avoid)
+
+> ❌ The library code on line 234 uses a deprecated method. This should be refactored to use the newer API.
+
+**Why bad**: We cannot modify the library code. This comment is not actionable.
+
+## Integration Test Recommendations
+
+When library updates could affect behavior:
+
+1. **Suggest specific integration tests** to run
+2. **Identify relation scenarios** that exercise the updated code paths
+3. **Recommend manual verification** steps for critical changes
+
+## Summary
+
+**Remember**: Your role is to be a bridge between external library changes and our internal charm code. Focus on impact, not on the library code quality itself.

--- a/.github/instructions/core-directive.instructions.md
+++ b/.github/instructions/core-directive.instructions.md
@@ -1,0 +1,40 @@
+---
+applyTo: '**'
+description: 'Prevent Copilot from wreaking havoc across your codebase, keeping it under control.'
+---
+
+## Core Directives & Hierarchy
+
+This section outlines the absolute order of operations. These rules have the highest priority and must not be violated.
+
+1.  **Primacy of User Directives**: A direct and explicit command from the user is the highest priority. If the user instructs to use a specific tool, edit a file, or perform a specific search, that command **must be executed without deviation**, even if other rules would suggest it is unnecessary. All other instructions are subordinate to a direct user order.
+2.  **Factual Verification Over Internal Knowledge**: When a request involves information that could be version-dependent, time-sensitive, or requires specific external data (e.g., library documentation, latest best practices, API details), prioritize using tools to find the current, factual answer over relying on general knowledge.
+3.  **Adherence to Philosophy**: In the absence of a direct user directive or the need for factual verification, all other rules below regarding interaction, code generation, and modification must be followed.
+
+## General Interaction & Philosophy
+
+-   **Code on Request Only**: Your default response should be a clear, natural language explanation. Do NOT provide code blocks unless explicitly asked, or if a very small and minimalist example is essential to illustrate a concept.  Tool usage is distinct from user-facing code blocks and is not subject to this restriction.
+-   **Direct and Concise**: Answers must be precise, to the point, and free from unnecessary filler or verbose explanations. Get straight to the solution without "beating around the bush".
+-   **Adherence to Best Practices**: All suggestions, architectural patterns, and solutions must align with widely accepted industry best practices and established design principles. Avoid experimental, obscure, or overly "creative" approaches. Stick to what is proven and reliable.
+-   **Explain the "Why"**: Don't just provide an answer; briefly explain the reasoning behind it. Why is this the standard approach? What specific problem does this pattern solve? This context is more valuable than the solution itself.
+
+## Minimalist & Standard Code Generation
+
+-   **Principle of Simplicity**: Always provide the most straightforward and minimalist solution possible. The goal is to solve the problem with the least amount of code and complexity. Avoid premature optimization or over-engineering.
+-   **Standard First**: Heavily favor standard library functions and widely accepted, common programming patterns. Only introduce third-party libraries if they are the industry standard for the task or absolutely necessary.
+-   **Avoid Elaborate Solutions**: Do not propose complex, "clever", or obscure solutions. Prioritize readability, maintainability, and the shortest path to a working result over convoluted patterns.
+-   **Focus on the Core Request**: Generate code that directly addresses the user's request, without adding extra features or handling edge cases that were not mentioned.
+
+## Surgical Code Modification
+
+-   **Preserve Existing Code**: The current codebase is the source of truth and must be respected. Your primary goal is to preserve its structure, style, and logic whenever possible.
+-   **Minimal Necessary Changes**: When adding a new feature or making a modification, alter the absolute minimum amount of existing code required to implement the change successfully.
+-   **Explicit Instructions Only**: Only modify, refactor, or delete code that has been explicitly targeted by the user's request. Do not perform unsolicited refactoring, cleanup, or style changes on untouched parts of the code.
+-   **Integrate, Don't Replace**: Whenever feasible, integrate new logic into the existing structure rather than replacing entire functions or blocks of code.
+
+## Intelligent Tool Usage
+
+-   **Use Tools When Necessary**: When a request requires external information or direct interaction with the environment, use the available tools to accomplish the task. Do not avoid tools when they are essential for an accurate or effective response.
+-   **Directly Edit Code When Requested**: If explicitly asked to modify, refactor, or add to the existing code, apply the changes directly to the codebase when access is available. Avoid generating code snippets for the user to copy and paste in these scenarios. The default should be direct, surgical modification as instructed.
+-   **Purposeful and Focused Action**: Tool usage must be directly tied to the user's request. Do not perform unrelated searches or modifications. Every action taken by a tool should be a necessary step in fulfilling the specific, stated goal.
+-   **Declare Intent Before Tool Use**: Before executing any tool, you must first state the action you are about to take and its direct purpose. This statement must be concise and immediately precede the tool call.

--- a/.github/instructions/documentation.instructions.md
+++ b/.github/instructions/documentation.instructions.md
@@ -1,0 +1,116 @@
+---
+description: 'Core guidelines for documentation-related suggestions.'
+applyTo: 'docs/**/*.md'
+---
+
+# Documentation instructions for GitHub Copilot
+
+## Purpose
+
+This file provides general guidance for reviewing documentation.
+
+## Core Directives
+
+This section outlines the absolute order of operations. These rules have the highest priority and must not be violated.
+
+1. **Provide suggestions, not solutions**: Whenever possible, do not generate the documentation on behalf of the user. Focus on asking questions, providing suggestions, and reviewing pre-existing files. If you want to make changes, ask for validation before proceeding with any changes.
+2. **Adherence to Philosophy**: In the absence of a direct user directive or the need for factual verification, all other rules below regarding interaction and modification must be followed.
+
+## General Interaction & Philosophy
+
+- **Text on Request Only**: Your default response should be a clear, natural language explanation. Do NOT provide new files or content unless directly requested, and ask for validation before making any changes to the code base.
+- **Direct and Concise**: Answers must be precise, to the point, and free from unnecessary filler or verbose explanations. Get straight to the solution without "beating around the bush".
+- **Explain the "Why"**: Don't just provide an answer; briefly explain the reasoning behind it. Why is this suggestion clearer, more concise, or easier to understand?
+
+## General Structure 
+
+In this repository, the documentation is placed in a dedicated `docs` directory. The purpose of the files in this directory is to provide information, instructions, and conceptual understanding of the code for users. 
+
+The top-level `docs` directory should contain an overview or home page called `index.md`. This file should provide a brief description of the project, what needs it serves, and who the primary user base is.
+
+The rest of the documentation follows the Diataxis framework consisting of four categories of documentation:
+
+1. **Tutorials**: A practice lesson that walks a user through a learning experience. Tutorials should be placed in the `docs/tutorial` directory, but sometimes they're placed in the top-level `docs` directory.
+2. **How-to guides**: Addresses real-world goals or problems by providing practical directions. How-to guides should be placed in the `docs/how-to` directory.
+3. **Reference**: Contains technical descriptions of theoretical knowledge. Reference documents should be placed in the `docs/reference` directory.
+4. **Explanation**: Provides context and background on topics for the user to understand the bigger picture. Explanation documents should be placed in the `docs/explanation` directory.
+
+All files should neatly fit into one of these four categories. Do NOT mix content between multiple categories into a single document. Instead, suggest splitting up content into multiple documents to preserve the structure and Diataxis framework.
+
+### Guidance on tutorials
+
+A tutorial is a learning-based, end-to-end experience that provides a complete learning journey for the user. The majority of our tutorials walk the user through a basic deployment of the charm in the repository.
+
+The tutorial should contain the following pieces:
+
+- **A title**. This title should be more descriptive than "Getting started"
+  or "Quick guide" which are both indicative of a how-to guide. In a single
+  statement, what will the user accomplish in the tutorial?
+- **An introduction**. In a couple of sentences, introduce the charm and
+  what the tutorial aims to do. Avoid using a statement like "you will learn",
+  as that makes an assumption about the user's prior knowledge. Focus
+  instead on what the user will do or accomplish. 
+- **What you'll do**. This should be the first section in the tutorial. It
+  aims to quickly and succinctly establish everything the user will do in the
+  tutorial. 
+- **What you'll need**. This section should contain a list of resources, software
+  or other tools that the user will need before starting the tutorial. In this section,
+  provide information on the supported architecture(s) like AMD64 or ARM64.
+  Also include additional information if the
+  tutorial will require significant resources (CPU, RAM, or disk space). You can
+  also suggest a Multipass VM to create an isolated testing environment for the tutorial.
+- **Set up tutorial model**. The tutorial should begin at this point. Have
+  the user create Juju model with a predetermined name so that you can reference
+  the model name throughout the tutorial.
+- **Deploy the charm + its dependencies**. If the charm requires any other
+  charms to successfully deploy, either include in a single section or split into
+  multiple sections. Use this part of the tutorial to enable any required configurations.
+  Make sure to briefly explain what the configurations or additional charms are
+  and why the steps are necessary. Split up important commands into separate
+  command blocks, and provide explanations between each command.
+- **Check the deployment was successful**. Instruct the user to run
+  ``juju status`` and show example output. If appropriate, also instruct the
+  user to run ``kubectl get pods -n <juju model name>`` and show the output.
+  Offer a brief explanation so that the user knows that the deployment was
+  successful.
+- **Some final checkpoint**. Have the user visit a website, change a
+  configuration, or run an action (maybe some combination of the three). Check
+  that this step worked; this is more obvious for a website, but you may need
+  to be creative if you have the user change a configuration or run an action.
+- **Tear down the environment**. This should be the final section. Take a moment
+  to congratulate the user for getting through the tutorial! Have the user
+  destroy the Juju model that they set up, and if applicable, instruct them to
+  delete the Multipass VM.
+
+### Guidance on how-to guides
+
+- How-to guides should contain a title with the format `# How to...`. The title should
+concisely summarize the real-world problem addressed by the document.
+- How-to guides should contain at least one CLI command that user can run to address the
+problem or achieve the goal.
+- Provide instructions or tasks that the user can take to achieve the goal. Avoid gerunds.
+
+
+## Style guide pointers
+
+- **Spelling**: Use US English for spelling suggestions.
+- **Headings**: Use sentence case for headings. Avoid punctuation in headings. Do not skip levels in heading hierarchy. Do not use consecutive headings without intervening text, and suggest removing headings that don't enhance the understanding. Don't overuse `code` styling in headings.
+- **Code examples**: Do not use prompt marks (for example, `$` or `#`) in code examples. Do not use comments in code examples; instead, put any comments directly into the text. Whenever possible, split up multiple commands into separate code blocks and provide explanations in between the code blocks. Use Git-flavoured Markdown with fenced code blocks (```) and command examples as shell blocks.
+- **Lists**: Only use numbered lists when there is an inherent order to the items.
+- **Latin words and phrases**: We can't assume the reader is familiar with Latin words and phrases. Words such as "etc.", "i.e.", "e.g.", "per", "versus", and "via" should be avoided. 
+
+## Small-edit rules for AI agents
+
+- Avoid describing tasks as "easy" or "simple".
+- Preserve existing link targets and code samples formatting. If you change any heading filename or path, update all relative links in `docs/` accordingly.
+- Demonstrative pronouns ("this", "these", "those", and "that") should be accompanied by the target noun when there's a risk of ambiguity in the paragraph. An isolated demonstrative pronoun can be used if there's no chance of ambiguity. In cases where a paragraph describes multiple ideas, avoid isolated demonstrative pronouns and be as specific as possible.
+
+## Changelog guidance 
+
+If you modify a procedure (commands, required versions, prerequisites) and a `docs/changelog.md` exists, add a short note in `docs/changelog.md` summarizing the user-facing change.
+
+If you add a new file into `docs`, add a short note in `docs/changelog.md` summarizing the user-facing change.
+
+If there are no user-relevant changes, then the changelog does not need to be updated.
+
+

--- a/.github/instructions/instructions.instructions.md
+++ b/.github/instructions/instructions.instructions.md
@@ -1,0 +1,256 @@
+---
+description: 'Guidelines for creating high-quality custom instruction files for GitHub Copilot'
+applyTo: '**/*.instructions.md'
+---
+
+# Custom Instructions File Guidelines
+
+Instructions for creating effective and maintainable custom instruction files that guide GitHub Copilot in generating domain-specific code and following project conventions.
+
+## Project Context
+
+- Target audience: Developers and GitHub Copilot working with domain-specific code
+- File format: Markdown with YAML frontmatter
+- File naming convention: lowercase with hyphens (e.g., `react-best-practices.instructions.md`)
+- Location: `.github/instructions/` directory
+- Purpose: Provide context-aware guidance for code generation, review, and documentation
+
+## Required Frontmatter
+
+Every instruction file must include YAML frontmatter with the following fields:
+
+```yaml
+---
+description: 'Brief description of the instruction purpose and scope'
+applyTo: 'glob pattern for target files (e.g., **/*.ts, **/*.py)'
+---
+```
+
+### Frontmatter Guidelines
+
+- **description**: Single-quoted string, 1-500 characters, clearly stating the purpose
+- **applyTo**: Glob pattern(s) specifying which files these instructions apply to
+  - Single pattern: `'**/*.ts'`
+  - Multiple patterns: `'**/*.ts, **/*.tsx, **/*.js'`
+  - Specific files: `'src/**/*.py'`
+  - All files: `'**'`
+
+## File Structure
+
+A well-structured instruction file should include the following sections:
+
+### 1. Title and Overview
+
+- Clear, descriptive title using `#` heading
+- Brief introduction explaining the purpose and scope
+- Optional: Project context section with key technologies and versions
+
+### 2. Core Sections
+
+Organize content into logical sections based on the domain:
+
+- **General Instructions**: High-level guidelines and principles
+- **Best Practices**: Recommended patterns and approaches
+- **Code Standards**: Naming conventions, formatting, style rules
+- **Architecture/Structure**: Project organization and design patterns
+- **Common Patterns**: Frequently used implementations
+- **Security**: Security considerations (if applicable)
+- **Performance**: Optimization guidelines (if applicable)
+- **Testing**: Testing standards and approaches (if applicable)
+
+### 3. Examples and Code Snippets
+
+Provide concrete examples with clear labels:
+
+```markdown
+### Good Example
+\`\`\`language
+// Recommended approach
+code example here
+\`\`\`
+
+### Bad Example
+\`\`\`language
+// Avoid this pattern
+code example here
+\`\`\`
+```
+
+### 4. Validation and Verification (Optional but Recommended)
+
+- Build commands to verify code
+- Linting and formatting tools
+- Testing requirements
+- Verification steps
+
+## Content Guidelines
+
+### Writing Style
+
+- Use clear, concise language
+- Write in imperative mood ("Use", "Implement", "Avoid")
+- Be specific and actionable
+- Avoid ambiguous terms like "should", "might", "possibly"
+- Use bullet points and lists for readability
+- Keep sections focused and scannable
+
+### Best Practices
+
+- **Be Specific**: Provide concrete examples rather than abstract concepts
+- **Show Why**: Explain the reasoning behind recommendations when it adds value
+- **Use Tables**: For comparing options, listing rules, or showing patterns
+- **Include Examples**: Real code snippets are more effective than descriptions
+- **Stay Current**: Reference current versions and best practices
+- **Link Resources**: Include official documentation and authoritative sources
+
+### Common Patterns to Include
+
+1. **Naming Conventions**: How to name variables, functions, classes, files
+2. **Code Organization**: File structure, module organization, import order
+3. **Error Handling**: Preferred error handling patterns
+4. **Dependencies**: How to manage and document dependencies
+5. **Comments and Documentation**: When and how to document code
+6. **Version Information**: Target language/framework versions
+
+## Patterns to Follow
+
+### Bullet Points and Lists
+
+```markdown
+## Security Best Practices
+
+- Always validate user input before processing
+- Use parameterized queries to prevent SQL injection
+- Store secrets in environment variables, never in code
+- Implement proper authentication and authorization
+- Enable HTTPS for all production endpoints
+```
+
+### Tables for Structured Information
+
+```markdown
+## Common Issues
+
+| Issue            | Solution            | Example                       |
+| ---------------- | ------------------- | ----------------------------- |
+| Magic numbers    | Use named constants | `const MAX_RETRIES = 3`       |
+| Deep nesting     | Extract functions   | Refactor nested if statements |
+| Hardcoded values | Use configuration   | Store API URLs in config      |
+```
+
+### Code Comparison
+
+```markdown
+### Good Example - Using TypeScript interfaces
+\`\`\`typescript
+interface User {
+  id: string;
+  name: string;
+  email: string;
+}
+
+function getUser(id: string): User {
+  // Implementation
+}
+\`\`\`
+
+### Bad Example - Using any type
+\`\`\`typescript
+function getUser(id: any): any {
+  // Loses type safety
+}
+\`\`\`
+```
+
+### Conditional Guidance
+
+```markdown
+## Framework Selection
+
+- **For small projects**: Use Minimal API approach
+- **For large projects**: Use controller-based architecture with clear separation
+- **For microservices**: Consider domain-driven design patterns
+```
+
+## Patterns to Avoid
+
+- **Overly verbose explanations**: Keep it concise and scannable
+- **Outdated information**: Always reference current versions and practices
+- **Ambiguous guidelines**: Be specific about what to do or avoid
+- **Missing examples**: Abstract rules without concrete code examples
+- **Contradictory advice**: Ensure consistency throughout the file
+- **Copy-paste from documentation**: Add value by distilling and contextualizing
+
+## Testing Your Instructions
+
+Before finalizing instruction files:
+
+1. **Test with Copilot**: Try the instructions with actual prompts in VS Code
+2. **Verify Examples**: Ensure code examples are correct and run without errors
+3. **Check Glob Patterns**: Confirm `applyTo` patterns match intended files
+
+## Example Structure
+
+Here's a minimal example structure for a new instruction file:
+
+```markdown
+---
+description: 'Brief description of purpose'
+applyTo: '**/*.ext'
+---
+
+# Technology Name Development
+
+Brief introduction and context.
+
+## General Instructions
+
+- High-level guideline 1
+- High-level guideline 2
+
+## Best Practices
+
+- Specific practice 1
+- Specific practice 2
+
+## Code Standards
+
+### Naming Conventions
+- Rule 1
+- Rule 2
+
+### File Organization
+- Structure 1
+- Structure 2
+
+## Common Patterns
+
+### Pattern 1
+Description and example
+
+\`\`\`language
+code example
+\`\`\`
+
+### Pattern 2
+Description and example
+
+## Validation
+
+- Build command: `command to verify`
+- Linting: `command to lint`
+- Testing: `command to test`
+```
+
+## Maintenance
+
+- Review instructions when dependencies or frameworks are updated
+- Update examples to reflect current best practices
+- Remove outdated patterns or deprecated features
+- Add new patterns as they emerge in the community
+- Keep glob patterns accurate as project structure evolves
+
+## Additional Resources
+
+- [Custom Instructions Documentation](https://code.visualstudio.com/docs/copilot/customization/custom-instructions)
+- [Awesome Copilot Instructions](https://github.com/github/awesome-copilot/tree/main/instructions)

--- a/.github/instructions/python-code-commenting.instructions.md
+++ b/.github/instructions/python-code-commenting.instructions.md
@@ -1,0 +1,165 @@
+---
+description: 'Guidelines for GitHub Copilot to write comments to achieve self-explanatory code with fewer comments. Examples are in Python but it should work on any language that has comments.'
+applyTo: '**'
+---
+
+# Self-explanatory Code Commenting Instructions
+
+## Core Principle
+**Write code that speaks for itself. Comment only when necessary to explain WHY, not WHAT.**
+We do not need comments most of the time.
+
+## Commenting Guidelines
+
+### ❌ AVOID These Comment Types
+
+**Obvious Comments**
+```python
+# Bad: States the obvious
+counter = 0  # Initialize counter to zero
+counter += 1  # Increment counter by one
+```
+
+**Redundant Comments**
+```python
+# Bad: Comment repeats the code
+def get_user_name():
+    return user.name  # Return the user's name
+```
+
+**Outdated Comments**
+```python
+# Bad: Comment doesn't match the code
+# Calculate tax at 5% rate
+tax = price * 0.08  # Actually 8%
+```
+
+### ✅ WRITE These Comment Types
+
+**Complex Business Logic**
+```python
+# Good: Explains WHY this specific calculation
+# Apply progressive tax brackets: 10% up to 10k, 20% above
+tax = calculate_progressive_tax(income, [0.10, 0.20], [10_000])
+```
+
+**Non-obvious Algorithms**
+```python
+# Good: Explains the algorithm choice
+# Using Floyd–Warshall for all-pairs shortest paths
+# because we need distances between all nodes
+for k in range(vertices):
+    for i in range(vertices):
+        for j in range(vertices):
+            # ... implementation
+            pass
+```
+
+**Regex Patterns**
+```python
+# Good: Explains what the regex matches
+# Match email format: username@domain.extension
+import re
+email_pattern = re.compile(r'^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$')
+```
+
+**API Constraints or Gotchas**
+```python
+# Good: Explains external constraint
+# GitHub API rate limit: 5000 requests/hour for authenticated users
+await rate_limiter.wait()
+response = await http_client.get(github_api_url)
+```
+
+## Decision Framework
+
+Before writing a comment, ask:
+1. **Is the code self-explanatory?** → No comment needed  
+2. **Would a better variable/function name eliminate the need?** → Refactor instead  
+3. **Does this explain WHY, not WHAT?** → Good comment  
+4. **Will this help future maintainers?** → Good comment
+
+## Special Cases for Comments
+
+### Public APIs
+```python
+def calculate_compound_interest(principal: float, rate: float, time: float, compound_frequency: int = 1) -> float:
+    """
+    Calculate compound interest using the standard formula.
+
+    Args:
+        principal (float): Initial amount invested.
+        rate (float): Annual interest rate (as decimal, e.g., 0.05 for 5%).
+        time (float): Time period in years.
+        compound_frequency (int, optional): How many times per year interest compounds (default: 1).
+
+    Returns:
+        float: Final amount after compound interest.
+    """
+    # ... implementation
+    pass
+```
+
+### Configuration and Constants
+```python
+# Good: Explains the source or reasoning
+MAX_RETRIES = 3  # Based on network reliability studies
+API_TIMEOUT = 5.0  # AWS Lambda timeout is 15s, leaving buffer (seconds)
+```
+
+### Annotations
+```python
+# TODO: Replace with proper user authentication after security review
+# FIXME: Memory leak in production - investigate connection pooling
+# HACK: Workaround for bug in library v2.1.0 - remove after upgrade
+# NOTE: This implementation assumes UTC timezone for all calculations
+# WARNING: This function mutates the input list instead of returning a copy
+# PERF: Consider caching this result if called frequently in a hot path
+# SECURITY: Validate input to prevent SQL injection before using in query
+# BUG: Edge case failure when list is empty - needs investigation
+# REFACTOR: Extract this logic into separate utility function for reusability
+# DEPRECATED: Use new_api_function() instead - this will be removed in v3.0
+```
+
+## Anti-Patterns to Avoid
+
+### Dead Code Comments
+```python
+# Bad: Don't comment out code
+# def old_function():
+#     ...
+def new_function():
+    ...
+```
+
+### Changelog Comments
+```python
+# Bad: Don't maintain history in comments
+# Modified by John on 2023-01-15
+# Fixed bug reported by Sarah on 2023-02-03
+def process_data():
+    # ... implementation
+    pass
+```
+
+### Divider Comments
+```python
+# Bad: Don't use decorative comments
+# =====================================
+# UTILITY FUNCTIONS
+# =====================================
+```
+
+## Quality Checklist
+
+Before committing, ensure your comments:
+- [ ] Explain WHY, not WHAT
+- [ ] Are grammatically correct and clear
+- [ ] Will remain accurate as code evolves
+- [ ] Add genuine value to code understanding
+- [ ] Are placed appropriately (above the code they describe)
+- [ ] Use proper spelling and professional language
+
+## Summary
+
+Remember: **The best comment is the one you don't need to write because the code is self-documenting.**

--- a/.github/workflows/copilot_collections_update.yaml
+++ b/.github/workflows/copilot_collections_update.yaml
@@ -1,0 +1,15 @@
+name: Auto-Update Copilot Instructions
+on:
+  schedule:
+    - cron: '17 8 * * 1' # Run every Monday at 08:17 UTC
+  workflow_dispatch:
+
+jobs:
+  check-update:
+    # See: https://discourse.canonical.com/t/upcoming-change-to-github-actions-settings/7286
+    permissions:
+      contents: write
+      pull-requests: write
+    # Always pin to @main to get the latest logic, but the content version is controlled by your .yaml file
+    uses: canonical/copilot-collections/.github/workflows/auto_update_collections.yaml@main
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -337,12 +337,26 @@ No manual secret granting is required. Each requirer gets a unique username in t
 By default password authentication is enabled for Charmed Trino. This being said, Trino supports implementing multiple forms of authentication mechanisms at the same time. Available with the charm are Google Oauth and user/password authentication. We recommend user/password for application users which do no support Oauth, and Oauth for everything else.
 
 ### Google Oauth
-Configure Google Oauth by adding the following config values to the coordinator charm:
-```
-juju config trino-k8s google-client-id=<id>
-juju config trino-k8s google-client-secret=<secret>
+Google OAuth credentials are provided through a Juju secret.
 
 ```
+# Create the secret and grant access to Trino.
+juju add-secret trino-oidc --file=/path/to/oidc-secrets.yaml
+juju grant-secret trino-oidc trino-k8s
+
+# Get the secret id and pass this to the charm via the config.
+juju config trino-k8s oidc-secret-id=<juju-secret-id>
+```
+
+Where the `oidc-secrets.yaml` has the below format:
+```
+google-client-id: <id>
+google-client-secret: <secret>
+```
+
+> **Note:** The `google-client-id` and `google-client-secret` config options are
+> deprecated. Setting either one puts the charm into a blocked state; migrate to
+> `oidc-secret-id` above. Unsetting `oidc-secret-id` disables Google OAuth.
 
 ### User/password
 Additionally user/password authentication can be enabled via a Juju secret.

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -128,11 +128,23 @@ config:
       type: string
     google-client-id:
       description: |
-        Client id from Google Oauth setup
+        DEPRECATED. Do not set. Provide the Google OIDC credentials through a Juju
+        secret referenced by `oidc-secret-id` instead. Setting this option blocks
+        the charm; unset it and migrate to `oidc-secret-id`.
       type: string
     google-client-secret:
       description: |
-        Client password from Google Oauth setup
+        DEPRECATED. Do not set. Provide the Google OIDC credentials through a Juju
+        secret referenced by `oidc-secret-id` instead. Setting this option blocks
+        the charm; unset it and migrate to `oidc-secret-id`.
+      type: string
+    oidc-secret-id:
+      description: |
+        The Juju secret id for the Google OIDC credentials used to enable OAuth2
+        authentication for the Trino web UI. The secret must contain the keys
+        `google-client-id` and `google-client-secret`. Grant the secret to this
+        application before setting this option. Leave unset to disable OAuth2 and
+        use password authentication only.
       type: string
     web-proxy:
       description: |

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -335,12 +335,13 @@ import subprocess
 import tempfile
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
+from typing import Callable, Dict, List, Literal, Optional, Tuple, Union
 from urllib.parse import urlparse
 
 import yaml
-from cosl import JujuTopology
+from cosl import CosTool, JujuTopology
 from cosl.rules import AlertRules, generic_alert_groups
+from cosl.types import OfficialRuleFileFormat
 from ops.charm import CharmBase, RelationRole
 from ops.framework import (
     BoundEvent,
@@ -361,7 +362,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 61
+LIBPATCH = 62
 
 # Version 0.0.53 needed for cosl.rules.generic_alert_groups
 PYDEPS = ["cosl>=0.0.53"]
@@ -843,7 +844,7 @@ def _type_convert_stored(obj):
     if isinstance(obj, StoredList):
         return list(map(_type_convert_stored, obj))
     if isinstance(obj, StoredDict):
-        rdict = {}  # type: Dict[Any, Any]
+        rdict = {}
         for k in obj.keys():
             rdict[k] = _type_convert_stored(obj[k])
         return rdict
@@ -993,7 +994,7 @@ class MetricsEndpointConsumer(Object):
         self._charm = charm
         self._relation_name = relation_name
         self._fallback_scrape_protocol = fallback_scrape_protocol
-        self._tool = CosTool(self._charm)
+        self._tool = CosTool("promql")
         events = self._charm.on[relation_name]
         self.framework.observe(events.relation_changed, self._on_metrics_provider_relation_changed)
         self.framework.observe(
@@ -1052,7 +1053,7 @@ class MetricsEndpointConsumer(Object):
                 # Therefore we need to dedupe here and after all jobs are collected.
                 static_scrape_jobs = _dedupe_job_names(static_scrape_jobs)
                 try:
-                    self._tool.validate_scrape_jobs(static_scrape_jobs)
+                    _validate_scrape_jobs(static_scrape_jobs)
                 except subprocess.CalledProcessError as e:
                     if self._charm.unit.is_leader():
                         data = json.loads(relation.data[self._charm.app].get("event", "{}"))
@@ -1107,7 +1108,7 @@ class MetricsEndpointConsumer(Object):
             A dictionary mapping the Juju topology identifier of the source charm to
             its list of alert rule groups.
         """
-        alerts = {}  # type: Dict[str, dict] # mapping b/w juju identifiers and alert rule files
+        alerts: Dict[str, OfficialRuleFileFormat] = {}
         for relation in self._charm.model.relations[self._relation_name]:
             if not relation.units or not relation.app:
                 continue
@@ -1161,7 +1162,7 @@ class MetricsEndpointConsumer(Object):
         return alerts
 
     def _get_identifier_by_alert_rules(
-        self, rules: dict
+        self, rules: OfficialRuleFileFormat
     ) -> Tuple[Union[str, None], Union[JujuTopology, None]]:
         """Determine an appropriate dict key for alert rules.
 
@@ -1181,7 +1182,9 @@ class MetricsEndpointConsumer(Object):
         # Construct an ID based on what's in the alert rules if they have labels
         for group in rules["groups"]:
             try:
-                labels = group["rules"][0]["labels"]
+                labels = group["rules"][0].get("labels")
+                if not labels:
+                    continue
                 topology = JujuTopology(
                     # Don't try to safely get required constructor fields. There's already
                     # a handler for KeyErrors
@@ -1208,7 +1211,7 @@ class MetricsEndpointConsumer(Object):
 
         return None, None
 
-    def _inject_alert_expr_labels(self, rules: Dict[str, Any]) -> Dict[str, Any]:
+    def _inject_alert_expr_labels(self, rules: OfficialRuleFileFormat) -> OfficialRuleFileFormat:
         """Iterate through alert rules and inject topology into expressions.
 
         Args:
@@ -1354,6 +1357,43 @@ class MetricsEndpointConsumer(Object):
             parts = [target, "80"]
 
         return parts
+
+
+def _validate_scrape_jobs(jobs: list) -> bool:
+    """Validate scrape jobs using cos-tool.
+
+    Args:
+        jobs: A list of Prometheus scrape job dicts to validate.
+
+    Returns:
+        True if validation passed or cos-tool is unavailable.
+
+    Raises:
+        subprocess.CalledProcessError: if cos-tool rejects the scrape jobs.
+    """
+    arch = platform.machine()
+    arch = "amd64" if arch == "x86_64" else arch
+    cos_tool_path = Path("cos-tool-{}".format(arch))
+    try:
+        cos_tool_path = cos_tool_path.resolve(strict=True)
+    except (FileNotFoundError, OSError):
+        logger.debug("cos-tool unavailable. Not validating scrape jobs.")
+        return True
+
+    conf = {"scrape_configs": jobs}
+    with tempfile.NamedTemporaryFile(suffix=".yaml", mode="w", delete=False) as tmpfile:
+        tmpfile.write(yaml.safe_dump(conf))
+        tmpfile_name = tmpfile.name
+    try:
+        subprocess.run(
+            [str(cos_tool_path), "validate-config", tmpfile_name],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+    finally:
+        Path(tmpfile_name).unlink(missing_ok=True)
+    return True
 
 
 def _dedupe_job_names(jobs: List[dict]):
@@ -1847,123 +1887,3 @@ class PrometheusRulesProvider(Object):
                 alert_rules_as_dict,
                 sort_keys=True,  # sort, to prevent unnecessary relation_changed events
             )
-
-class CosTool:
-    """Uses cos-tool to inject label matchers into alert rule expressions and validate rules."""
-
-    _path = None
-    _disabled = False
-
-    def __init__(self, charm):
-        self._charm = charm
-
-    @property
-    def path(self):
-        """Lazy lookup of the path of cos-tool."""
-        if self._disabled:
-            return None
-        if not self._path:
-            self._path = self._get_tool_path()
-            if not self._path:
-                logger.debug("Skipping injection of juju topology as label matchers")
-                self._disabled = True
-        return self._path
-
-    def apply_label_matchers(self, rules) -> dict:
-        """Will apply label matchers to the expression of all alerts in all supplied groups."""
-        if not self.path:
-            return rules
-        for group in rules["groups"]:
-            rules_in_group = group.get("rules", [])
-            for rule in rules_in_group:
-                topology = {}
-                # if the user for some reason has provided juju_unit, we'll need to honor it
-                # in most cases, however, this will be empty
-                for label in [
-                    "juju_model",
-                    "juju_model_uuid",
-                    "juju_application",
-                    "juju_charm",
-                    "juju_unit",
-                ]:
-                    if label in rule["labels"]:
-                        topology[label] = rule["labels"][label]
-
-                rule["expr"] = self.inject_label_matchers(rule["expr"], topology)
-        return rules
-
-    def validate_alert_rules(self, rules: dict) -> Tuple[bool, str]:
-        """Will validate correctness of alert rules, returning a boolean and any errors."""
-        if not self.path:
-            logger.debug("`cos-tool` unavailable. Not validating alert correctness.")
-            return True, ""
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            rule_path = Path(tmpdir + "/validate_rule.yaml")
-            rule_path.write_text(yaml.dump(rules))
-
-            args = [str(self.path), "validate", str(rule_path)]
-            # noinspection PyBroadException
-            try:
-                self._exec(args)
-                return True, ""
-            except subprocess.CalledProcessError as e:
-                logger.debug("Validating the rules failed: %s", e.output.decode("utf8"))
-                return False, ", ".join(
-                    [
-                        line
-                        for line in e.output.decode("utf8").splitlines()
-                        if "error validating" in line
-                    ]
-                )
-
-    def validate_scrape_jobs(self, jobs: list) -> bool:
-        """Validate scrape jobs using cos-tool."""
-        if not self.path:
-            logger.debug("`cos-tool` unavailable. Not validating scrape jobs.")
-            return True
-        conf = {"scrape_configs": jobs}
-        with tempfile.NamedTemporaryFile() as tmpfile:
-            with open(tmpfile.name, "w") as f:
-                f.write(yaml.safe_dump(conf))
-            try:
-                self._exec([str(self.path), "validate-config", tmpfile.name])
-            except subprocess.CalledProcessError as e:
-                logger.error("Validating scrape jobs failed: {}".format(e.output))
-                raise
-        return True
-
-    def inject_label_matchers(self, expression, topology) -> str:
-        """Add label matchers to an expression."""
-        if not topology:
-            return expression
-        if not self.path:
-            logger.debug("`cos-tool` unavailable. Leaving expression unchanged: %s", expression)
-            return expression
-        args = [str(self.path), "transform"]
-        args.extend(
-            ["--label-matcher={}={}".format(key, value) for key, value in topology.items()]
-        )
-
-        args.extend(["{}".format(expression)])
-        # noinspection PyBroadException
-        try:
-            return self._exec(args)
-        except subprocess.CalledProcessError as e:
-            logger.debug('Applying the expression failed: "%s", falling back to the original', e)
-            return expression
-
-    def _get_tool_path(self) -> Optional[Path]:
-        arch = platform.machine()
-        arch = "amd64" if arch == "x86_64" else arch
-        res = "cos-tool-{}".format(arch)
-        try:
-            path = Path(res).resolve(strict=True)
-            return path
-        except (FileNotFoundError, OSError):
-            logger.debug('Could not locate cos-tool at: "{}"'.format(res))
-        return None
-
-    def _exec(self, cmd) -> str:
-        result = subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-        return result.stdout.decode("utf-8").strip()

--- a/src/catalog_manager.py
+++ b/src/catalog_manager.py
@@ -11,13 +11,20 @@ import yaml
 from ops.model import SecretNotFoundError
 
 from literals import BIGQUERY_BACKEND_SCHEMA, GSHEETS_BACKEND_SCHEMA
-from utils import add_cert_to_truststore, validate_keys
+from utils import validate_keys
 
 logger = logging.getLogger(__name__)
 
 
 class CatalogBase(ABC):
-    """The base class for all catalog configurations."""
+    """The base class for all catalog configurations.
+
+    Attrs:
+        desired_certs: Certificates the catalog wants present in the truststore,
+            keyed by alias, collected for central truststore reconciliation.
+        rendered: Rendered `.properties` content keyed by catalog file stem,
+            used by the charm to hash file contents for the Pebble plan.
+    """
 
     def __init__(self, charm, truststore_pwd, name, info, backend):
         """Construct.
@@ -34,6 +41,8 @@ class CatalogBase(ABC):
         self.name = name
         self.info = info
         self.backend = backend
+        self.desired_certs = {}
+        self.rendered = {}
 
     def _add_catalog(self, catalogs):
         """Add catalogs to Trino.
@@ -48,6 +57,7 @@ class CatalogBase(ABC):
                 "{SSL_PWD}", self.truststore_pwd
             )
 
+            self.rendered[key] = config
             container.push(
                 self.charm.catalog_abs_path.joinpath(f"{key}.properties"),
                 config,
@@ -55,7 +65,7 @@ class CatalogBase(ABC):
             )
 
     def _add_certs(self, certs):
-        """Prepare and add certificates to Trino truststore.
+        """Collect certificates for central truststore reconciliation.
 
         Args:
             certs: the certificates to add.
@@ -63,25 +73,7 @@ class CatalogBase(ABC):
         if not certs:
             return
 
-        container = self.charm.unit.get_container(self.charm.name)
-
-        for name, cert in certs.items():
-            container.push(
-                self.charm.conf_abs_path.joinpath(f"{name}.crt"),
-                cert,
-                make_dirs=True,
-            )
-            try:
-                add_cert_to_truststore(
-                    container,
-                    name,
-                    cert,
-                    self.truststore_pwd,
-                    str(self.charm.conf_abs_path),
-                )
-                container.remove_path(self.charm.conf_abs_path.joinpath(f"{name}.crt"))
-            except Exception as e:
-                logger.error(f"Failed to add {name} cert: {e}")
+        self.desired_certs.update(certs)
 
     def _add_service_account(self, sa_string, sa_creds_path):
         """Add service account credentials.

--- a/src/charm.py
+++ b/src/charm.py
@@ -1076,6 +1076,10 @@ class TrinoK8SCharm(TypedCharmBase[CharmConfig]):
                 self.trino_coordinator.update_coordinator_relation_data()
             if not restarting:
                 self.postgresql_catalog_handler.reconcile_postgresql_catalogs()
+            else:
+                logger.info(
+                    "Workload restarting; deferring PostgreSQL catalog reconcile to next hook"
+                )
 
 
 if __name__ == "__main__":

--- a/src/charm.py
+++ b/src/charm.py
@@ -355,6 +355,12 @@ class TrinoK8SCharm(TypedCharmBase[CharmConfig]):
             event.add_status(BlockedStatus(str(err)))
             return
 
+        try:
+            self._compute_credentials()
+        except ValueError as err:
+            event.add_status(BlockedStatus(str(err)))
+            return
+
         if cfg.charm_function in ("coordinator", "all"):
             if self._get_int_comms_secret_value() is None:
                 event.add_status(
@@ -555,7 +561,9 @@ class TrinoK8SCharm(TypedCharmBase[CharmConfig]):
                 credentials = yaml.safe_load(self._get_secret_content(secret_id)["users"])
             except (yaml.YAMLError, KeyError, SecretNotFoundError) as e:
                 logger.error(f"Error reading secret {secret_id!r}: {e}")
-                raise ValueError(f"invalid user secret {secret_id!r}") from e
+                raise ValueError(f"invalid user secret {secret_id!r}") from None
+            if not isinstance(credentials, dict):
+                raise ValueError(f"invalid user secret {secret_id!r}: 'users' must be a mapping")
         else:
             credentials = dict(DEFAULT_CREDENTIALS)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -12,6 +12,7 @@ https://discourse.charmhub.io/t/4208
 
 # pylint: disable=too-many-lines
 
+import json
 import logging
 import socket
 import subprocess  # nosec B404
@@ -26,17 +27,14 @@ from charms.data_platform_libs.v0.data_models import TypedCharmBase
 from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
 from charms.loki_k8s.v1.loki_push_api import LogForwarder
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
-from charms.traefik_k8s.v2.ingress import (
-    IngressPerAppReadyEvent,
-    IngressPerAppRequirer,
-    IngressPerAppRevokedEvent,
-)
-from ops.charm import ConfigChangedEvent, PebbleReadyEvent
+from charms.traefik_k8s.v2.ingress import IngressPerAppRequirer
+from ops.charm import CollectStatusEvent, PebbleReadyEvent
 from ops.main import main
 from ops.model import (
     ActiveStatus,
     BlockedStatus,
     MaintenanceStatus,
+    ModelError,
     SecretNotFoundError,
     WaitingStatus,
 )
@@ -46,21 +44,34 @@ from pydantic import ValidationError
 from catalog_manager import BigqueryCatalog, GsheetCatalog, HiveCatalog
 from config import CharmConfig
 from literals import (
+    CACERTS_MANIFEST,
+    CACERTS_PATH,
     CATALOG_DIR,
     CATALOG_SCHEMA,
+    CERTIFICATE_NAME,
     CONF_DIR,
     CONFIG_FILES,
     DEFAULT_CREDENTIALS,
     DEFAULT_JVM_OPTIONS,
     INDEX_NAME,
+    INGRESS_RELATION_NAME,
     INT_COMMS_SECRET_LABEL,
+    JAVA_HOME,
     JMX_PORT,
     METRICS_PORT,
+    OPENSEARCH_RELATION_NAME,
     PASSWORD_DB,
+    PEER_RELATION_NAME,
+    POLICY_RELATION_NAME,
+    POSTGRESQL_RELATION_NAME,
     RUN_TRINO_COMMAND,
+    TRINO_CATALOG_RELATION_NAME,
+    TRINO_COORDINATOR_RELATION_NAME,
     TRINO_HOME,
     TRINO_PORTS,
-    USER_SECRET_LABEL,
+    TRINO_WORKER_RELATION_NAME,
+    TRUSTSTORE_MANIFEST,
+    TRUSTSTORE_SECRET_LABEL,
 )
 from log import log_event_handler
 from relations.opensearch import OpensearchRelationHandler
@@ -73,8 +84,11 @@ from sql_catalog import RedshiftCatalog, SqlCatalog
 from state import State
 from utils import (
     add_users_to_password_db,
+    content_hash,
     generate_password,
+    reconcile_truststore,
     render,
+    truststore_manifest_hash,
     update_opts,
     validate_keys,
 )
@@ -153,33 +167,58 @@ class TrinoK8SCharm(TypedCharmBase[CharmConfig]):
         """
         super().__init__(*args)
         self.name = "trino"
-        self.state = State(self.app, lambda: self.model.get_relation("peer"))
+        self.state = State(self.app, lambda: self.model.get_relation(PEER_RELATION_NAME))
         self.policy = PolicyRelationHandler(self)
         self.trino_coordinator = TrinoCoordinator(self)
         self.trino_worker = TrinoWorker(self)
         self.trino_catalog = TrinoCatalogRelationHandler(self)
 
-        # Handle basic charm lifecycle
-        self.framework.observe(self.on.install, self._on_install)
+        # Every hook converges through a single idempotent reconciler; unit
+        # status is derived separately by collect-unit-status.
         self.framework.observe(self.on.trino_pebble_ready, self._on_pebble_ready)
-        self.framework.observe(self.on.config_changed, self._on_config_changed)
+        self.framework.observe(self.on.config_changed, self._reconcile_hook)
+        self.framework.observe(self.on.update_status, self._reconcile_hook)
+        self.framework.observe(self.on.peer_relation_changed, self._reconcile_hook)
+        self.framework.observe(self.on.secret_changed, self._reconcile_hook)
+        self.framework.observe(self.on.collect_unit_status, self._on_collect_unit_status)
+
+        # Actions
         self.framework.observe(self.on.restart_action, self._on_restart)
         self.framework.observe(self.on.list_system_users_action, self._on_list_system_users)
-        self.framework.observe(self.on.update_status, self._on_update_status)
-        self.framework.observe(self.on.peer_relation_changed, self._on_peer_relation_changed)
-        self.framework.observe(self.on.secret_changed, self._on_secret_changed)
+
+        # Relation events are centralized here; handlers expose logic methods
+        # invoked by the reconciler rather than observing events themselves.
+        for endpoint in (
+            TRINO_COORDINATOR_RELATION_NAME,
+            TRINO_WORKER_RELATION_NAME,
+            POLICY_RELATION_NAME,
+            POSTGRESQL_RELATION_NAME,
+        ):
+            self.framework.observe(self.on[endpoint].relation_created, self._reconcile_hook)
+            self.framework.observe(self.on[endpoint].relation_changed, self._reconcile_hook)
+            self.framework.observe(self.on[endpoint].relation_broken, self._reconcile_hook)
+        self.framework.observe(
+            self.on[TRINO_CATALOG_RELATION_NAME].relation_created, self._reconcile_hook
+        )
+        self.framework.observe(
+            self.on[TRINO_CATALOG_RELATION_NAME].relation_broken,
+            self._on_trino_catalog_relation_broken,
+        )
+        self.framework.observe(
+            self.on[OPENSEARCH_RELATION_NAME].relation_broken, self._reconcile_hook
+        )
 
         # Handle Ingress
         self.ingress = IngressPerAppRequirer(
             self,
-            relation_name="ingress",
+            relation_name=INGRESS_RELATION_NAME,
             port=TRINO_PORTS["HTTP"],
             scheme="http",
             strip_prefix=True,
             redirect_https=True,
         )
-        self.framework.observe(self.ingress.on.ready, self._on_ingress_ready)
-        self.framework.observe(self.ingress.on.revoked, self._on_ingress_revoked)
+        self.framework.observe(self.ingress.on.ready, self._reconcile_hook)
+        self.framework.observe(self.ingress.on.revoked, self._reconcile_hook)
 
         # Prometheus
         self._prometheus_scraping = MetricsEndpointProvider(
@@ -201,12 +240,17 @@ class TrinoK8SCharm(TypedCharmBase[CharmConfig]):
 
         self.opensearch_relation = OpenSearchRequires(
             self,
-            relation_name="opensearch",
+            relation_name=OPENSEARCH_RELATION_NAME,
             index=INDEX_NAME,
             extra_user_roles="admin",
         )
         self.opensearch_relation_handler = OpensearchRelationHandler(self)
         self.postgresql_catalog_handler = PostgresqlCatalogRelationHandler(self)
+        self.framework.observe(self.opensearch_relation.on.index_created, self._reconcile_hook)
+        self.framework.observe(self.opensearch_relation.on.endpoints_changed, self._reconcile_hook)
+        self.framework.observe(
+            self.opensearch_relation.on.authentication_updated, self._reconcile_hook
+        )
 
         raw = self.model.config
         resources = {
@@ -227,21 +271,13 @@ class TrinoK8SCharm(TypedCharmBase[CharmConfig]):
             refresh_event=[self.on.trino_pebble_ready, self.on.config_changed],
         )
 
-    def _on_ingress_ready(self, event: IngressPerAppReadyEvent):
-        """Handle the ingress-ready event: store the URL and reconcile catalog relations.
+    def _reconcile_hook(self, event):
+        """Route any observed hook through the single reconciler.
 
         Args:
-            event: The IngressPerAppReadyEvent with the new ingress URL.
+            event: The triggering Juju event (unused; state is read from the model).
         """
-        self.trino_catalog.reconcile_trino_catalog_relations()
-
-    def _on_ingress_revoked(self, event: IngressPerAppRevokedEvent):
-        """Handle the ingress-revoked event: clear the stored URL and reconcile catalog relations.
-
-        Args:
-            event: The IngressPerAppRevokedEvent.
-        """
-        self.trino_catalog.reconcile_trino_catalog_relations()
+        self._reconcile()
 
     def _warn_deprecated_config(self):
         """Log deprecation warnings if obsolete config options are still set."""
@@ -258,20 +294,11 @@ class TrinoK8SCharm(TypedCharmBase[CharmConfig]):
             )
 
     @log_event_handler(logger)
-    def _on_install(self, event):
-        """Install Trino.
-
-        Args:
-            event: The event triggered when the relation changed.
-        """
-        self.unit.status = MaintenanceStatus(f"{self.name} unit provisioned.")
-
-    @log_event_handler(logger)
     def _on_pebble_ready(self, event: PebbleReadyEvent):
-        """Define and start a workload using the Pebble API.
+        """Record the workload version, then reconcile.
 
         Args:
-            event: The event triggered when the relation changed.
+            event: The pebble-ready event.
         """
         container = self.unit.get_container(self.name)
         if container.can_connect():
@@ -283,117 +310,72 @@ class TrinoK8SCharm(TypedCharmBase[CharmConfig]):
             except (PathError, yaml.YAMLError) as e:
                 logger.debug("Could not get workload version: %s", str(e))
 
-        self._update(event)
+        self._reconcile()
 
     @log_event_handler(logger)
-    def _on_peer_relation_changed(self, event):
-        """Handle peer relation changes.
+    def _on_trino_catalog_relation_broken(self, event):
+        """Remove the departing relation's secret, then reconcile.
 
         Args:
-            event: The event triggered when the peer relation changed.
+            event: The trino-catalog relation-broken event.
         """
-        if self.unit.is_leader():
-            return
+        self.trino_catalog.remove_relation_secret(event.relation.id)
+        self._reconcile()
 
-        self.unit.status = WaitingStatus("configuring trino")
-        self._update(event)
-
-    @log_event_handler(logger)
-    def _on_config_changed(self, event: ConfigChangedEvent):
-        """Handle changed configuration.
+    def _on_collect_unit_status(self, event: CollectStatusEvent):  # noqa: C901
+        """Derive terminal unit status from the current model and workload health.
 
         Args:
-            event: The event triggered when the relation changed.
+            event: The collect-unit-status event to add derived statuses to.
         """
-        self.unit.status = WaitingStatus("configuring trino")
-        try:
-            _ = self.config  # validate upfront before any side-effects
-        except ValidationError as err:
-            self.unit.status = BlockedStatus(_format_config_error(err))
-            return
-        self._warn_deprecated_config()
-        self.trino_coordinator._update_coordinator_relation_data(event)
-        self._update(event)
-        self.postgresql_catalog_handler.reconcile_postgresql_catalogs(event)
-        self.trino_catalog.reconcile_trino_catalog_relations()
-
-    @log_event_handler(logger)
-    def _on_update_status(self, event):
-        """Handle `update-status` events.
-
-        Args:
-            event: The `update-status` event triggered at intervals
-        """
-        container = self.unit.get_container(self.name)
-
-        if not self.state.is_ready():
-            return
-
-        if not container.can_connect():
-            return
-
-        valid_pebble_plan = self._validate_pebble_plan(container)
-        if not valid_pebble_plan:
-            self._update(event)
-            return
-
         try:
             cfg = self.config
-            self._validate_relations()
         except ValidationError as err:
-            self.unit.status = BlockedStatus(_format_config_error(err))
+            event.add_status(BlockedStatus(_format_config_error(err)))
             return
+
+        if not self.state.is_ready():
+            event.add_status(WaitingStatus("waiting for peer relation"))
+            return
+
+        container = self.unit.get_container(self.name)
+        if not container.can_connect():
+            event.add_status(WaitingStatus("waiting for container"))
+            return
+
+        try:
+            self._validate_relations()
         except (RuntimeError, ValueError) as err:
-            self.unit.status = BlockedStatus(str(err))
+            event.add_status(BlockedStatus(str(err)))
             return
 
         if cfg.charm_function in ("coordinator", "all"):
-            check = container.get_check("up")
-            if check.status != CheckStatus.UP:
-                self.unit.status = MaintenanceStatus("Status check: DOWN")
-                self._restart_trino()
+            if self._get_int_comms_secret_value() is None:
+                event.add_status(
+                    WaitingStatus("waiting for leader to create internal communication secret")
+                )
                 return
 
-        self.postgresql_catalog_handler.reconcile_postgresql_catalogs(event)
-        self.trino_catalog.reconcile_trino_catalog_relations()
+        if cfg.charm_function == "worker" and self.model.relations[TRINO_WORKER_RELATION_NAME]:
+            if self._get_int_comms_secret_value() is None:
+                event.add_status(
+                    WaitingStatus(
+                        "waiting for coordinator to publish internal communication secret"
+                    )
+                )
+                return
 
-        self.unit.status = ActiveStatus("Status check: UP")
+        if cfg.charm_function in ("coordinator", "all"):
+            try:
+                check = container.get_check("up")
+            except ModelError:
+                event.add_status(MaintenanceStatus("waiting for workload"))
+                return
+            if check.status != CheckStatus.UP:
+                event.add_status(MaintenanceStatus("Status check: DOWN"))
+                return
 
-    def _validate_pebble_plan(self, container):
-        """Validate pebble plan.
-
-        Args:
-            container: application container
-
-        Returns:
-            bool of pebble plan validity
-        """
-        try:
-            plan = container.get_plan().to_dict()
-            return bool(plan and plan["services"].get(self.name, {}).get("on-check-failure"))
-        except ConnectionError:
-            return False
-
-    @log_event_handler(logger)
-    def _on_secret_changed(self, event):
-        """Handle secret changed hook.
-
-        Args:
-            event: the secret changed event.
-        """
-        # Catalog credential changes would enter the branch
-        if not event.secret.label == USER_SECRET_LABEL:
-            self._configure_catalogs(event)
-            self.postgresql_catalog_handler.reconcile_postgresql_catalogs(event)
-            self.trino_catalog.reconcile_trino_catalog_relations()
-            self._restart_trino()
-            return
-
-        try:
-            self._update_password_db(event)
-            self._restart_trino()
-        except Exception:
-            self.unit.status = BlockedStatus("Secret cannot be found or is incorrectly formatted.")
+        event.add_status(ActiveStatus("Status check: UP"))
 
     def _restart_trino(self):
         """Restart Trino."""
@@ -443,30 +425,54 @@ class TrinoK8SCharm(TypedCharmBase[CharmConfig]):
             }
         )
 
-    def set_java_truststore_password(self, event):
-        """Update the truststore password to the randomly generated one.
+    def _ensure_truststore_password(self):
+        """Return the stable truststore password backed by an app Juju secret.
+
+        The leader creates the secret once, migrating any legacy peer-stored
+        value, so the password no longer rotates on every reconcile and the
+        catalog property files that embed it stay stable.
+
+        Returns:
+            The truststore password, or None when a non-leader unit cannot yet
+            read the leader-created secret.
+        """
+        try:
+            secret = self.model.get_secret(label=TRUSTSTORE_SECRET_LABEL)
+            return secret.get_content(refresh=True).get("password")
+        except SecretNotFoundError:
+            pass
+
+        if not self.unit.is_leader():
+            return None
+
+        # Reuse any legacy peer-stored value so the truststore password stays
+        # compatible across charm revisions during upgrade.
+        password = self.state.java_truststore_pwd or generate_password()
+        self.app.add_secret({"password": password}, label=TRUSTSTORE_SECRET_LABEL)
+        return password
+
+    def set_java_truststore_password(self, truststore_pwd):
+        """Set the JVM `cacerts` password to the stable truststore password.
+
+        Idempotent: re-running once the password is already applied fails with
+        an "incorrect password" error from keytool, which is ignored.
 
         Args:
-            event: The event triggered on relation changed.
+            truststore_pwd: The stable truststore password.
         """
         container = self.unit.get_container(self.name)
         if not container.can_connect():
             return
 
-        if self.unit.is_leader():
-            self.state.java_truststore_pwd = self.state.java_truststore_pwd or generate_password()
-
-        out, _ = container.exec(["/bin/sh", "-c", "echo $JAVA_HOME"]).wait_output()
-        java_home = out.strip()
         command = [
             "keytool",
             "-storepass",
             "changeit",
             "-storepasswd",
             "-new",
-            self.state.java_truststore_pwd,
+            truststore_pwd,
             "-keystore",
-            f"{java_home}/lib/security/cacerts",
+            f"{JAVA_HOME}/{CACERTS_PATH}",
         ]
         try:
             container.exec(command).wait_output()
@@ -497,75 +503,53 @@ class TrinoK8SCharm(TypedCharmBase[CharmConfig]):
             raise
         return content
 
-    def _update_password_db(self, event):
-        """Create necessary db file for authentication.
+    def _compute_credentials(self):
+        """Return the full set of authentication credentials for `password.db`.
 
-        Args:
-            event: The pebble ready or config changed event.
+        Merges the configured system users (or defaults) with per-relation
+        trino-catalog users.
+
+        Returns:
+            Mapping of username to plaintext password.
 
         Raises:
-            ScannerError: In case the secret is incorrectly formatted.
+            ValueError: if the configured user secret is malformed.
         """
-        container = self.unit.get_container(self.name)
-        if not container.can_connect():
-            return
-
         secret_id = self.state.user_secret_id
-        db_path = str(self.trino_abs_path.joinpath(PASSWORD_DB))
-
         if secret_id:
             try:
                 credentials = yaml.safe_load(self._get_secret_content(secret_id)["users"])
-            except Exception as e:
+            except (yaml.YAMLError, KeyError, SecretNotFoundError) as e:
                 logger.error(f"Error reading secret {secret_id!r}: {e}")
-                raise
+                raise ValueError(f"invalid user secret {secret_id!r}") from e
         else:
             credentials = dict(DEFAULT_CREDENTIALS)
 
-        # Merge per-relation users from trino-catalog relations
-        relation_creds = self.trino_catalog.get_relation_credentials()
-        credentials.update(relation_creds)
+        credentials.update(self.trino_catalog.get_relation_credentials())
+        return credentials
 
-        add_users_to_password_db(container, credentials, db_path)
-
-    def _update_password_db_and_restart(self):
-        """Update password.db with current credentials and restart Trino.
-
-        Called by the trino-catalog handler when per-relation users change.
-        """
-        container = self.unit.get_container(self.name)
-        if not container.can_connect():
-            return
-
-        try:
-            self._update_password_db(None)
-        except Exception as err:
-            logger.error("Failed to update password.db: %s", err)
-            return
-
-        self._restart_trino()
-
-    def _configure_catalogs(self, event):
-        """Manage catalog properties files.
+    def _write_password_db(self, container, credentials):
+        """Write the authentication database file.
 
         Args:
-            event: The juju event.
+            container: The Trino container.
+            credentials: Mapping of username to plaintext password.
         """
-        container = self.unit.get_container(self.name)
-        if not container.can_connect():
-            event.defer()
-            return
+        db_path = str(self.trino_abs_path.joinpath(PASSWORD_DB))
+        add_users_to_password_db(container, credentials, db_path)
 
-        truststore_pwd = generate_password()
+    def _configure_catalogs(self, container, truststore_pwd):
+        """Render static catalog property files and collect their hashes and certs.
 
-        # Truststore password is changed with each invocation
-        # so we need to delete it here and it will be regenerated
-        # by the end of this method.
-        try:
-            container.remove_path(self.truststore_abs_path)
-        except PathError as e:
-            logging.debug("Could not remove truststore: %s", str(e))
+        Args:
+            container: The Trino container.
+            truststore_pwd: The stable truststore password embedded in catalog
+                property files.
 
+        Returns:
+            A tuple of (per-file content hashes for the Pebble plan, desired
+            truststore certificates keyed by alias).
+        """
         catalog_index = yaml.safe_load(self.state.catalog_config or "")
         if catalog_index is None:
             catalog_index = {
@@ -577,7 +561,8 @@ class TrinoK8SCharm(TypedCharmBase[CharmConfig]):
             catalog_index["backends"],
         )
 
-        # Upsert current catalogs
+        file_hashes = {}
+        desired_certs = {}
         upserted_catalogs = []
         for name, info in catalogs.items():
             validate_keys(info, CATALOG_SCHEMA)
@@ -585,27 +570,27 @@ class TrinoK8SCharm(TypedCharmBase[CharmConfig]):
             catalog_instance = self._create_catalog_instance(truststore_pwd, name, info, backend)
             batch = catalog_instance.configure_catalogs()
             upserted_catalogs.extend(batch)
+            for key, content in catalog_instance.rendered.items():
+                file_hashes[self._hash_key(f"catalog_{key}.properties")] = content_hash(content)
+            desired_certs.update(catalog_instance.desired_certs)
 
-        # Remove obsolete catalogs
-        if not container.isdir(self.catalog_abs_path):
-            return
+        # Remove obsolete catalog files that are neither config- nor relation-managed.
+        if container.isdir(self.catalog_abs_path):
+            pg_catalogs = self.postgresql_catalog_handler.get_postgresql_relation_catalogs()
+            for file in container.list_files(self.catalog_abs_path, pattern="*.properties"):
+                stem = Path(file.name).stem
+                if stem in upserted_catalogs or stem in pg_catalogs:
+                    continue
+                try:
+                    container.remove_path(file.path)
+                except PathError as e:
+                    logging.debug(
+                        "Could not remove obsolete catalog file '%s': %s",
+                        file.name,
+                        str(e),
+                    )
 
-        for file in container.list_files(self.catalog_abs_path, pattern="*.properties"):
-            if (
-                Path(file.name).stem in upserted_catalogs
-                or Path(file.name).stem
-                in self.postgresql_catalog_handler.get_postgresql_relation_catalogs()
-            ):
-                continue
-
-            try:
-                container.remove_path(file.path)
-            except PathError as e:
-                logging.debug(
-                    "Could not remove obsolete catalog file '%s': %s",
-                    file.name,
-                    str(e),
-                )
+        return file_hashes, desired_certs
 
     def _create_catalog_instance(self, truststore_pwd, name, info, backend):
         """Create catalog instances based on connector type.
@@ -637,17 +622,34 @@ class TrinoK8SCharm(TypedCharmBase[CharmConfig]):
 
         raise ValueError(f"Unsupported backend: {backend}")
 
+    def _hash_key(self, filename):
+        """Return the Pebble-plan env var name that carries a file's content hash.
+
+        Args:
+            filename: The managed file name.
+
+        Returns:
+            The `HASH_<FILE>` env var name.
+        """
+        return f"HASH_{filename.upper().replace('.', '_').replace('-', '_')}"
+
     def _configure_trino(self, container, env):
-        """Add the files needed to configure Trino to the Trino home directory.
+        """Render and push the core Trino config files.
 
         Args:
             container: The Trino container.
-            env: Environment variables for Jija templating.
+            env: Environment variables for Jinja templating.
+
+        Returns:
+            Mapping of per-file content-hash env vars for the Pebble plan.
         """
+        hashes = {}
         for template, file in CONFIG_FILES.items():
             path = self.trino_abs_path.joinpath(file)
             content = render(template, env)
             container.push(path, content, make_dirs=True, permissions=0o644)
+            hashes[self._hash_key(file)] = content_hash(content)
+        return hashes
 
     def _configure_file_based_manager(
         self,
@@ -668,6 +670,9 @@ class TrinoK8SCharm(TypedCharmBase[CharmConfig]):
             properties_filename: The properties file written under
                 `TRINO_HOME`.
             config_filename: The JSON config file written under `TRINO_HOME`.
+
+        Returns:
+            Mapping of per-file content-hash env vars for the Pebble plan.
         """
         properties_path = self.trino_abs_path.joinpath(properties_filename)
         config_path = self.trino_abs_path.joinpath(config_filename)
@@ -687,7 +692,10 @@ class TrinoK8SCharm(TypedCharmBase[CharmConfig]):
                 permissions=0o644,
             )
             logger.info("%s configuration applied", properties_filename)
-            return
+            return {
+                self._hash_key(properties_filename): content_hash(properties_content),
+                self._hash_key(config_filename): content_hash(manager_config),
+            }
 
         try:
             container.remove_path(properties_path)
@@ -701,14 +709,19 @@ class TrinoK8SCharm(TypedCharmBase[CharmConfig]):
         except PathError:
             pass
 
+        return {}
+
     def _configure_resource_groups(self, container, env):
         """Configure resource groups if provided.
 
         Args:
             container: The Trino container.
             env: Environment variables containing resource groups config.
+
+        Returns:
+            Mapping of per-file content-hash env vars for the Pebble plan.
         """
-        self._configure_file_based_manager(
+        return self._configure_file_based_manager(
             container=container,
             env=env,
             manager_config=self.config.resource_groups_config,
@@ -724,8 +737,11 @@ class TrinoK8SCharm(TypedCharmBase[CharmConfig]):
             container: The Trino container.
             env: Environment variables containing session property manager
                 config.
+
+        Returns:
+            Mapping of per-file content-hash env vars for the Pebble plan.
         """
-        self._configure_file_based_manager(
+        return self._configure_file_based_manager(
             container=container,
             env=env,
             manager_config=self.config.session_property_manager_config,
@@ -754,7 +770,7 @@ class TrinoK8SCharm(TypedCharmBase[CharmConfig]):
 
         For coordinator/all: creates or retrieves the singleton app-owned Juju secret.
         For worker: resolves the secret by the ID stored in peer state (written by
-        _on_relation_changed after the coordinator has published it).
+        the worker gathering coordinator data after the secret has been published).
 
         Returns:
             The shared secret string, or None if not yet available.
@@ -778,8 +794,12 @@ class TrinoK8SCharm(TypedCharmBase[CharmConfig]):
             return self.trino_worker._resolve_int_comms_secret(secret_id)
         return None
 
-    def _create_environment(self):
-        """Create application environment.
+    def _build_base_environment(self, truststore_pwd, int_comms_secret):
+        """Build the Trino service environment without per-file hash triggers.
+
+        Args:
+            truststore_pwd: The stable truststore password.
+            int_comms_secret: The internal communication shared secret value.
 
         Returns:
             env: a dictionary of trino environment variables.
@@ -802,15 +822,14 @@ class TrinoK8SCharm(TypedCharmBase[CharmConfig]):
             "APPLICATION_NAME": self.app.name,
             "PASSWORD_DB_PATH": str(db_path),
             "TRINO_HOME": str(self.trino_abs_path),
-            "CATALOG_CONFIG": self.state.catalog_config or cfg.catalog_config,
             "METRICS_PORT": METRICS_PORT,
             "JMX_PORT": JMX_PORT,
             "RANGER_RELATION": self.state.ranger_enabled or False,
             "ACL_ACCESS_MODE": cfg.acl_mode_default,
             "ACL_USER_PATTERN": cfg.acl_user_pattern,
             "ACL_CATALOG_PATTERN": cfg.acl_catalog_pattern,
-            "JAVA_TRUSTSTORE_PWD": self.state.java_truststore_pwd,
-            "INT_COMMS_SECRET": self._get_int_comms_secret_value(),
+            "JAVA_TRUSTSTORE_PWD": truststore_pwd,
+            "INT_COMMS_SECRET": int_comms_secret,
             "USER_SECRET_ID": cfg.user_secret_id,
             "JVM_OPTIONS": jvm_opts,
             "COORDINATOR_REQUEST_TIMEOUT": cfg.coordinator_request_timeout,
@@ -839,67 +858,88 @@ class TrinoK8SCharm(TypedCharmBase[CharmConfig]):
 
         return env
 
-    # TODO (mertalpt): Remove suppressing the too complex error in the upcoming refactor.
-    def _update(self, event):  # noqa: C901
-        """Update the Trino server configuration and replan its execution.
+    def _reconcile_relation_state(self):
+        """Persist Ranger and OpenSearch state derived from related applications."""
+        if not self.unit.is_leader():
+            return
+
+        self.policy.publish_service_data()
+        policy_url = self.policy.read_policy_manager_url()
+        self.state.policy_manager_url = policy_url or ""
+        self.state.ranger_enabled = bool(policy_url)
+
+        conn = self.opensearch_relation_handler.gather_connection()
+        if conn.get("is_enabled"):
+            self.state.opensearch = conn
+            self.state.opensearch_certificate = (
+                self.opensearch_relation_handler.gather_certificate() or ""
+            )
+        else:
+            self.state.opensearch = {"is_enabled": False}
+            self.state.opensearch_certificate = ""
+
+    def _reconcile_truststores(self, container, truststore_pwd, conf_certs):
+        """Reconcile both truststores in place and return their plan hashes.
 
         Args:
-            event: The event triggered when the relation changed.
+            container: The Trino container.
+            truststore_pwd: The stable truststore password.
+            conf_certs: Desired {alias: PEM} certificates for `conf/truststore.jks`.
+
+        Returns:
+            Mapping of truststore manifest-hash env vars for the Pebble plan.
         """
-        container = self.unit.get_container(self.name)
-        if not container.can_connect():
-            event.defer()
-            return
+        reconcile_truststore(
+            container,
+            str(self.truststore_abs_path),
+            truststore_pwd,
+            conf_certs,
+            str(self.conf_abs_path),
+            str(self.conf_abs_path.joinpath(TRUSTSTORE_MANIFEST)),
+        )
 
+        cacerts_certs = {}
+        opensearch = self.state.opensearch or {}
+        certificate = self.state.opensearch_certificate
+        if opensearch.get("is_enabled") and certificate:
+            cacerts_certs[CERTIFICATE_NAME] = certificate
+
+        reconcile_truststore(
+            container,
+            f"{JAVA_HOME}/{CACERTS_PATH}",
+            truststore_pwd,
+            cacerts_certs,
+            str(self.conf_abs_path),
+            str(self.conf_abs_path.joinpath(CACERTS_MANIFEST)),
+        )
+
+        return {
+            "HASH_TRUSTSTORE_JKS": truststore_manifest_hash(conf_certs),
+            "HASH_CACERTS": truststore_manifest_hash(cacerts_certs),
+        }
+
+    def _clean_catalog_dir(self, container):
+        """Remove the catalog directory when no worker relation is present.
+
+        Args:
+            container: The Trino container.
+        """
         try:
-            cfg = self.config
-        except ValidationError as err:
-            self.unit.status = BlockedStatus(_format_config_error(err))
-            return
+            container.remove_path(self.catalog_abs_path, recursive=True)
+        except PathError:
+            pass
 
-        try:
-            self._validate_relations()
-        except (RuntimeError, ValueError) as err:
-            self.unit.status = BlockedStatus(str(err))
-            return
+    def _pebble_layer(self, env, is_coordinator):
+        """Build the Trino Pebble layer.
 
-        if cfg.charm_function in ("coordinator", "all"):
-            if self._get_int_comms_secret_value() is None:
-                self.unit.status = WaitingStatus(
-                    "waiting for leader to create internal communication secret"
-                )
-                return
+        Args:
+            env: The service environment (including per-file hash triggers).
+            is_coordinator: Whether this unit runs the coordinator role.
 
-        if cfg.charm_function == "worker" and self.model.relations["trino-worker"]:
-            if self._get_int_comms_secret_value() is None:
-                self.unit.status = WaitingStatus(
-                    "waiting for coordinator to publish internal communication secret"
-                )
-                return
-
-        logger.info("configuring trino")
-        if cfg.charm_function in ("coordinator", "all"):
-            self.state.discovery_uri = self._coordinator_discovery_uri
-            self.state.catalog_config = cfg.catalog_config or ""
-            self.state.user_secret_id = cfg.user_secret_id or ""
-
-        self._configure_catalogs(event)
-
-        self.set_java_truststore_password(event)
-        env = self._create_environment()
-        self._configure_trino(container, env)
-        self._configure_resource_groups(container, env)
-        self._configure_session_property_manager(container, env)
-
-        try:
-            self._update_password_db(event)
-        except Exception as err:
-            logger.error(err)
-            self.unit.status = BlockedStatus("Secret cannot be found or is incorrectly formatted.")
-            return
-
-        logger.info("planning trino execution")
-        pebble_layer = {
+        Returns:
+            The Pebble layer definition.
+        """
+        layer = {
             "summary": "trino layer",
             "description": "pebble config layer for trino",
             "services": {
@@ -909,37 +949,133 @@ class TrinoK8SCharm(TypedCharmBase[CharmConfig]):
                     "command": RUN_TRINO_COMMAND,
                     "startup": "enabled",
                     "environment": env,
-                    "on-check-failure": {"up": "ignore"},
+                    "on-check-failure": {"up": "restart"},
                 }
             },
         }
-        if cfg.charm_function in ("coordinator", "all"):
-            pebble_layer.update(
-                {
-                    "checks": {
-                        "up": {
-                            "override": "replace",
-                            "period": "30s",
-                            "http": {"url": "http://localhost:8080/"},
-                        }
-                    }
-                },
-            )
+        if is_coordinator:
+            layer["checks"] = {
+                "up": {
+                    "override": "replace",
+                    "period": "30s",
+                    "http": {"url": "http://localhost:8080/"},
+                }
+            }
+        return layer
 
-            # Handle Ranger plugin
-            if self.state.ranger_enabled:
-                # No leadership check required as coordinator
-                # and single node cannot scale.
-                self.policy._configure_ranger_plugin(container)
+    def _reconcile(self):  # noqa: C901
+        """Converge the Trino workload to the desired state read from the model.
 
+        Idempotent: applies configuration, reconciles truststores in place, and
+        lets Pebble decide restarts via per-file content hashes in the plan.
+        Guards return early without deferring; convergence resumes on the next
+        hook and terminal status is reported by collect-unit-status.
+        """
+        container = self.unit.get_container(self.name)
+        if not container.can_connect():
+            return
+
+        try:
+            cfg = self.config
+        except ValidationError:
+            return
+
+        if not self.state.is_ready():
+            return
+
+        function = cfg.charm_function
+        is_coordinator = function in ("coordinator", "all")
+
+        # A worker with no coordinator relation has nothing to serve; drop any
+        # stale catalogs and stop. This runs before relation validation, which
+        # treats a missing coordinator relation as a blocking error.
+        if function == "worker" and not self.model.relations[TRINO_WORKER_RELATION_NAME]:
+            self._clean_catalog_dir(container)
+            return
+
+        try:
+            self._validate_relations()
+        except (RuntimeError, ValueError):
+            return
+
+        self._warn_deprecated_config()
+
+        # Gather desired state from the model.
+        if is_coordinator:
+            self.state.discovery_uri = self._coordinator_discovery_uri
+            self.state.catalog_config = cfg.catalog_config or ""
+            self.state.user_secret_id = cfg.user_secret_id or ""
+        if function == "worker":
+            self.trino_worker.gather_from_coordinator()
+
+        int_comms_secret = self._get_int_comms_secret_value()
+        if is_coordinator and int_comms_secret is None:
+            return
+        if (
+            function == "worker"
+            and self.model.relations[TRINO_WORKER_RELATION_NAME]
+            and int_comms_secret is None
+        ):
+            return
+
+        truststore_pwd = self._ensure_truststore_password()
+        if truststore_pwd is None:
+            return
+        self.set_java_truststore_password(truststore_pwd)
+
+        if is_coordinator:
+            self._reconcile_relation_state()
+
+        # Per-relation users must exist before password.db is rebuilt.
+        self.trino_catalog.reconcile_trino_catalog_relations()
+
+        # Static catalog files and truststore contents.
+        file_hashes, conf_certs = self._configure_catalogs(container, truststore_pwd)
+        conf_certs.update(self.postgresql_catalog_handler.get_desired_tls_certs())
+        file_hashes.update(self._reconcile_truststores(container, truststore_pwd, conf_certs))
+
+        # Render and push managed config files, hashing each for the plan.
+        env = self._build_base_environment(truststore_pwd, int_comms_secret)
+        file_hashes.update(self._configure_trino(container, env))
+        file_hashes.update(self._configure_resource_groups(container, env))
+        file_hashes.update(self._configure_session_property_manager(container, env))
+
+        try:
+            credentials = self._compute_credentials()
+        except ValueError as err:
+            logger.error(err)
+            return
+        self._write_password_db(container, credentials)
+        file_hashes["HASH_PASSWORD_DB"] = content_hash(json.dumps(credentials, sort_keys=True))
+
+        if is_coordinator and self.state.ranger_enabled:
+            rendered = self.policy._configure_ranger_plugin(container)
+            for name, content in (rendered or {}).items():
+                file_hashes[self._hash_key(name)] = content_hash(content)
+
+        env.update(file_hashes)
+
+        if is_coordinator:
             self.model.unit.open_port(port=8080, protocol="tcp")
         else:
             self.model.unit.close_port(port=8080, protocol="tcp")
 
-        container.add_layer(self.name, pebble_layer, combine=True)
+        # The service environment embeds every managed file's content hash, so a
+        # change here means replan will restart the workload. Live reconciliation
+        # would then race the restart, so defer it to the next hook in that case.
+        current = container.get_plan().services.get(self.name)
+        restarting = current is None or current.environment != env
+
+        container.add_layer(self.name, self._pebble_layer(env, is_coordinator), combine=True)
         container.replan()
 
-        self.unit.status = MaintenanceStatus("replanning application")
+        # Publishing coordinator relation data is a pure databag write and is
+        # always safe; the PostgreSQL live reconcile needs a running workload.
+        if is_coordinator:
+            if self.unit.is_leader():
+                self.trino_coordinator.update_coordinator_relation_data()
+            if not restarting:
+                self.postgresql_catalog_handler.reconcile_postgresql_catalogs()
 
 
 if __name__ == "__main__":

--- a/src/charm.py
+++ b/src/charm.py
@@ -58,6 +58,7 @@ from literals import (
     INT_COMMS_SECRET_LABEL,
     JAVA_HOME,
     JMX_PORT,
+    LEGACY_STATE_KEYS,
     METRICS_PORT,
     OPENSEARCH_RELATION_NAME,
     PASSWORD_DB,
@@ -416,7 +417,7 @@ class TrinoK8SCharm(TypedCharmBase[CharmConfig]):
         Args:
             event: The event triggered by the list-system-users action.
         """
-        secret_id = self.state.user_secret_id
+        secret_id = self._effective_user_secret_id()
         if secret_id:
             try:
                 content = self._get_secret_content(secret_id)
@@ -495,6 +496,44 @@ class TrinoK8SCharm(TypedCharmBase[CharmConfig]):
                 return
             logger.debug(f"Unable to update truststore password {e.stderr}")
 
+    def _purge_legacy_state_values(self):
+        """Remove obsolete peer-state keys left over from before the reconciler.
+
+        Leader-only. Inert keys (now read from config or live relations) are
+        dropped unconditionally. The two upgrade-fallback keys are dropped only
+        once their backing app Juju secret is confirmed, so a partially migrated
+        unit never discards a fallback before its replacement exists.
+
+        NOTE: Dropping the fallbacks means a downgrade to a pre-secret charm
+        revision would rotate the secret/password rather than reuse the old peer
+        value. This is an accepted trade-off; downgrades across the secret
+        boundary are already unsupported.
+        """
+        if not self.unit.is_leader():
+            return
+
+        for key in LEGACY_STATE_KEYS:
+            if getattr(self.state, key) is not None:
+                delattr(self.state, key)
+
+        self._purge_confirmed_fallback(TRUSTSTORE_SECRET_LABEL, "java_truststore_pwd")
+        self._purge_confirmed_fallback(INT_COMMS_SECRET_LABEL, "int_comms_secret")
+
+    def _purge_confirmed_fallback(self, secret_label, state_key):
+        """Delete a legacy fallback peer key once its app secret is confirmed.
+
+        Args:
+            secret_label: The app Juju secret label whose presence gates deletion.
+            state_key: The peer-state attribute to remove.
+        """
+        if getattr(self.state, state_key) is None:
+            return
+        try:
+            self.model.get_secret(label=secret_label)
+        except SecretNotFoundError:
+            return
+        delattr(self.state, state_key)
+
     def _get_secret_content(self, secret_id):
         """Get the content of a Juju secret.
 
@@ -555,7 +594,7 @@ class TrinoK8SCharm(TypedCharmBase[CharmConfig]):
         Raises:
             ValueError: if the configured user secret is malformed.
         """
-        secret_id = self.state.user_secret_id
+        secret_id = self._effective_user_secret_id()
         if secret_id:
             try:
                 credentials = yaml.safe_load(self._get_secret_content(secret_id)["users"])
@@ -592,7 +631,7 @@ class TrinoK8SCharm(TypedCharmBase[CharmConfig]):
             A tuple of (per-file content hashes for the Pebble plan, desired
             truststore certificates keyed by alias).
         """
-        catalog_index = yaml.safe_load(self.state.catalog_config or "")
+        catalog_index = yaml.safe_load(self._effective_catalog_config() or "")
         if catalog_index is None:
             catalog_index = {
                 "catalogs": {},
@@ -830,18 +869,58 @@ class TrinoK8SCharm(TypedCharmBase[CharmConfig]):
                 return None
             return secret.get_content(refresh=True).get("secret")
         elif cfg.charm_function == "worker":
-            secret_id = self.state.int_comms_secret_id
+            secret_id = self.trino_worker.get_coordinator_data()["int_comms_secret_id"]
             if not secret_id:
                 return None
             return self.trino_worker._resolve_int_comms_secret(secret_id)
         return None
 
-    def _build_base_environment(self, truststore_pwd, int_comms_secret):
+    def _effective_discovery_uri(self):
+        """Return the discovery URI for this unit's role.
+
+        Coordinators advertise their own discovery URI; workers read the value
+        published by the coordinator on the trino-worker relation.
+
+        Returns:
+            The discovery URI, or None when a worker has no coordinator data yet.
+        """
+        if self.config.charm_function == "worker":
+            return self.trino_worker.get_coordinator_data()["discovery_uri"]
+        return self._coordinator_discovery_uri
+
+    def _effective_catalog_config(self):
+        """Return the catalog config for this unit's role.
+
+        Coordinators use their own config value; workers read the catalogs
+        published by the coordinator on the trino-worker relation.
+
+        Returns:
+            The catalog config string (possibly empty or None).
+        """
+        if self.config.charm_function == "worker":
+            return self.trino_worker.get_coordinator_data()["catalog_config"]
+        return self.config.catalog_config or ""
+
+    def _effective_user_secret_id(self):
+        """Return the user secret id for this unit's role.
+
+        Coordinators use their own config value; workers read the id published
+        by the coordinator on the trino-worker relation.
+
+        Returns:
+            The user secret id string (possibly empty or None).
+        """
+        if self.config.charm_function == "worker":
+            return self.trino_worker.get_coordinator_data()["user_secret_id"]
+        return self.config.user_secret_id or ""
+
+    def _build_base_environment(self, truststore_pwd, int_comms_secret, ranger_enabled):
         """Build the Trino service environment without per-file hash triggers.
 
         Args:
             truststore_pwd: The stable truststore password.
             int_comms_secret: The internal communication shared secret value.
+            ranger_enabled: Whether a Ranger policy relation is active.
 
         Returns:
             env: a dictionary of trino environment variables.
@@ -862,13 +941,13 @@ class TrinoK8SCharm(TypedCharmBase[CharmConfig]):
             "OAUTH_USER_MAPPING": cfg.oauth_user_mapping,
             "WEB_PROXY": cfg.web_proxy,
             "CHARM_FUNCTION": cfg.charm_function,
-            "DISCOVERY_URI": self.state.discovery_uri or self._coordinator_discovery_uri,
+            "DISCOVERY_URI": self._effective_discovery_uri() or self._coordinator_discovery_uri,
             "APPLICATION_NAME": self.app.name,
             "PASSWORD_DB_PATH": str(db_path),
             "TRINO_HOME": str(self.trino_abs_path),
             "METRICS_PORT": METRICS_PORT,
             "JMX_PORT": JMX_PORT,
-            "RANGER_RELATION": self.state.ranger_enabled or False,
+            "RANGER_RELATION": ranger_enabled,
             "ACL_ACCESS_MODE": cfg.acl_mode_default,
             "ACL_USER_PATTERN": cfg.acl_user_pattern,
             "ACL_CATALOG_PATTERN": cfg.acl_catalog_pattern,
@@ -902,26 +981,6 @@ class TrinoK8SCharm(TypedCharmBase[CharmConfig]):
 
         return env
 
-    def _reconcile_relation_state(self):
-        """Persist Ranger and OpenSearch state derived from related applications."""
-        if not self.unit.is_leader():
-            return
-
-        self.policy.publish_service_data()
-        policy_url = self.policy.read_policy_manager_url()
-        self.state.policy_manager_url = policy_url or ""
-        self.state.ranger_enabled = bool(policy_url)
-
-        conn = self.opensearch_relation_handler.gather_connection()
-        if conn.get("is_enabled"):
-            self.state.opensearch = conn
-            self.state.opensearch_certificate = (
-                self.opensearch_relation_handler.gather_certificate() or ""
-            )
-        else:
-            self.state.opensearch = {"is_enabled": False}
-            self.state.opensearch_certificate = ""
-
     def _reconcile_truststores(self, container, truststore_pwd, conf_certs):
         """Reconcile both truststores in place and return their plan hashes.
 
@@ -943,8 +1002,8 @@ class TrinoK8SCharm(TypedCharmBase[CharmConfig]):
         )
 
         cacerts_certs = {}
-        opensearch = self.state.opensearch or {}
-        certificate = self.state.opensearch_certificate
+        opensearch = self.opensearch_relation_handler.gather_connection()
+        certificate = self.opensearch_relation_handler.gather_certificate()
         if opensearch.get("is_enabled") and certificate:
             cacerts_certs[CERTIFICATE_NAME] = certificate
 
@@ -1044,14 +1103,6 @@ class TrinoK8SCharm(TypedCharmBase[CharmConfig]):
 
         self._warn_deprecated_config()
 
-        # Gather desired state from the model.
-        if is_coordinator:
-            self.state.discovery_uri = self._coordinator_discovery_uri
-            self.state.catalog_config = cfg.catalog_config or ""
-            self.state.user_secret_id = cfg.user_secret_id or ""
-        if function == "worker":
-            self.trino_worker.gather_from_coordinator()
-
         int_comms_secret = self._get_int_comms_secret_value()
         if is_coordinator and int_comms_secret is None:
             return
@@ -1074,8 +1125,15 @@ class TrinoK8SCharm(TypedCharmBase[CharmConfig]):
             return
         self.set_java_truststore_password(truststore_pwd)
 
+        # Obsolete peer-state keys are removed now that all values come from
+        # config or live relations; the two upgrade fallbacks are dropped only
+        # once their backing app secret exists.
+        self._purge_legacy_state_values()
+
         if is_coordinator:
-            self._reconcile_relation_state()
+            self.policy.publish_service_data()
+
+        ranger_enabled = bool(self.policy.read_policy_manager_url()) if is_coordinator else False
 
         # Per-relation users must exist before password.db is rebuilt.
         self.trino_catalog.reconcile_trino_catalog_relations()
@@ -1086,7 +1144,7 @@ class TrinoK8SCharm(TypedCharmBase[CharmConfig]):
         file_hashes.update(self._reconcile_truststores(container, truststore_pwd, conf_certs))
 
         # Render and push managed config files, hashing each for the plan.
-        env = self._build_base_environment(truststore_pwd, int_comms_secret)
+        env = self._build_base_environment(truststore_pwd, int_comms_secret, ranger_enabled)
         file_hashes.update(self._configure_trino(container, env))
         file_hashes.update(self._configure_resource_groups(container, env))
         file_hashes.update(self._configure_session_property_manager(container, env))
@@ -1099,7 +1157,7 @@ class TrinoK8SCharm(TypedCharmBase[CharmConfig]):
         self._write_password_db(container, credentials)
         file_hashes["HASH_PASSWORD_DB"] = content_hash(json.dumps(credentials, sort_keys=True))
 
-        if is_coordinator and self.state.ranger_enabled:
+        if is_coordinator and ranger_enabled:
             rendered = self.policy._configure_ranger_plugin(container)
             for name, content in (rendered or {}).items():
                 file_hashes[self._hash_key(name)] = content_hash(content)

--- a/src/charm.py
+++ b/src/charm.py
@@ -349,6 +349,12 @@ class TrinoK8SCharm(TypedCharmBase[CharmConfig]):
             event.add_status(BlockedStatus(str(err)))
             return
 
+        try:
+            self._resolve_oidc_credentials()
+        except ValueError as err:
+            event.add_status(BlockedStatus(str(err)))
+            return
+
         if cfg.charm_function in ("coordinator", "all"):
             if self._get_int_comms_secret_value() is None:
                 event.add_status(
@@ -502,6 +508,34 @@ class TrinoK8SCharm(TypedCharmBase[CharmConfig]):
             logger.error(f"secret {secret_id!r} not found.")
             raise
         return content
+
+    def _resolve_oidc_credentials(self) -> tuple[str | None, str | None]:
+        """Resolve Google OIDC credentials from the configured Juju secret.
+
+        Returns:
+            A (client_id, client_secret) tuple, or (None, None) when
+            oidc-secret-id is unset (OAuth2 disabled).
+
+        Raises:
+            ValueError: if oidc-secret-id is set but the secret cannot be
+                resolved or is missing the required keys.
+        """
+        secret_id = self.config.oidc_secret_id
+        if not secret_id:
+            return None, None
+        try:
+            content = self._get_secret_content(secret_id)
+        except SecretNotFoundError:
+            raise ValueError(
+                f"oidc-secret-id {secret_id!r} could not be resolved; ensure the "
+                "secret exists and is granted to this application"
+            ) from None
+        try:
+            return content["google-client-id"], content["google-client-secret"]
+        except KeyError:
+            raise ValueError(
+                "oidc secret must contain 'google-client-id' and 'google-client-secret' keys"
+            ) from None
 
     def _compute_credentials(self):
         """Return the full set of authentication credentials for `password.db`.
@@ -811,10 +845,12 @@ class TrinoK8SCharm(TypedCharmBase[CharmConfig]):
 
         jvm_opts = update_opts(default_opts, user_opts) if user_opts else default_opts
 
+        oauth_client_id, oauth_client_secret = self._resolve_oidc_credentials()
+
         env = {
             "LOG_LEVEL": cfg.log_level,
-            "OAUTH_CLIENT_ID": cfg.google_client_id,
-            "OAUTH_CLIENT_SECRET": cfg.google_client_secret,
+            "OAUTH_CLIENT_ID": oauth_client_id,
+            "OAUTH_CLIENT_SECRET": oauth_client_secret,
             "OAUTH_USER_MAPPING": cfg.oauth_user_mapping,
             "WEB_PROXY": cfg.web_proxy,
             "CHARM_FUNCTION": cfg.charm_function,
@@ -1016,6 +1052,13 @@ class TrinoK8SCharm(TypedCharmBase[CharmConfig]):
             and self.model.relations[TRINO_WORKER_RELATION_NAME]
             and int_comms_secret is None
         ):
+            return
+
+        # A misconfigured OIDC secret must not converge with broken auth; the
+        # blocking status is reported by collect-unit-status.
+        try:
+            self._resolve_oidc_credentials()
+        except ValueError:
             return
 
         truststore_pwd = self._ensure_truststore_password()

--- a/src/charm.py
+++ b/src/charm.py
@@ -1060,26 +1060,18 @@ class TrinoK8SCharm(TypedCharmBase[CharmConfig]):
         else:
             self.model.unit.close_port(port=8080, protocol="tcp")
 
-        # The service environment embeds every managed file's content hash, so a
-        # change here means replan will restart the workload. Live reconciliation
-        # would then race the restart, so defer it to the next hook in that case.
-        current = container.get_plan().services.get(self.name)
-        restarting = current is None or current.environment != env
-
         container.add_layer(self.name, self._pebble_layer(env, is_coordinator), combine=True)
         container.replan()
 
         # Publishing coordinator relation data is a pure databag write and is
-        # always safe; the PostgreSQL live reconcile needs a running workload.
+        # always safe. reconcile_postgresql_catalogs writes its request databag
+        # unconditionally and self-guards the live CREATE/DROP CATALOG SQL with a
+        # reachability check, so calling it during a workload restart still lets
+        # the provider start provisioning; the live SQL converges on a later hook.
         if is_coordinator:
             if self.unit.is_leader():
                 self.trino_coordinator.update_coordinator_relation_data()
-            if not restarting:
-                self.postgresql_catalog_handler.reconcile_postgresql_catalogs()
-            else:
-                logger.info(
-                    "Workload restarting; deferring PostgreSQL catalog reconcile to next hook"
-                )
+            self.postgresql_catalog_handler.reconcile_postgresql_catalogs()
 
 
 if __name__ == "__main__":

--- a/src/config.py
+++ b/src/config.py
@@ -87,6 +87,7 @@ class CharmConfig(BaseConfigModel):
     log_level: str = "info"
     google_client_id: Optional[str] = None
     google_client_secret: Optional[str] = None
+    oidc_secret_id: Optional[str] = None
     web_proxy: Optional[str] = None
     ranger_service_name: Optional[str] = None
     external_hostname: Optional[str] = None
@@ -148,6 +149,17 @@ class CharmConfig(BaseConfigModel):
         return v
 
     # ── String sanity validators ───────────────────────────────────────────
+
+    @validator("google_client_id", "google_client_secret")
+    def reject_deprecated_oidc_plaintext(cls, v, field):
+        """Block plaintext OIDC credentials; require a Juju secret instead."""
+        if v is not None:
+            option = field.name.replace("_", "-")
+            raise ValueError(
+                f"{option} is deprecated; store the Google OIDC credentials in a "
+                "Juju secret and set oidc-secret-id instead, then unset this option"
+            )
+        return v
 
     @validator("web_proxy")
     def validate_web_proxy(cls, v):

--- a/src/literals.py
+++ b/src/literals.py
@@ -74,6 +74,8 @@ USER_SECRET_LABEL = "trino-user-management"  # nosec
 TRINO_CATALOG_SECRET_PREFIX = "trino-catalog-user-"  # nosec
 INT_COMMS_SECRET_LABEL = "trino-int-comms-secret"  # nosec
 INT_COMMS_SECRET_RELATION_KEY = "int-comms-secret-id"  # nosec
+POSTGRESQL_SECRET_LABEL = "trino-postgresql-secrets"  # nosec
+POSTGRESQL_SECRET_RELATION_KEY = "postgresql-secrets-id"  # nosec
 TRUSTSTORE_SECRET_LABEL = "trino-truststore-password"  # nosec
 
 # Sidecar manifests tracking managed truststore aliases (under CONF_DIR).

--- a/src/literals.py
+++ b/src/literals.py
@@ -5,7 +5,14 @@
 """Literals used by the Trino K8s charm."""
 
 APP_NAME = "trino-k8s"
+PEER_RELATION_NAME = "peer"
 POSTGRESQL_RELATION_NAME = "postgresql"
+TRINO_COORDINATOR_RELATION_NAME = "trino-coordinator"
+TRINO_WORKER_RELATION_NAME = "trino-worker"
+TRINO_CATALOG_RELATION_NAME = "trino-catalog"
+POLICY_RELATION_NAME = "policy"
+OPENSEARCH_RELATION_NAME = "opensearch"
+INGRESS_RELATION_NAME = "ingress"
 TRINO_PORTS = {
     "HTTPS": 443,
     "HTTP": 8080,
@@ -17,6 +24,9 @@ JMX_PORT = 9081
 
 # Configuration literals
 TRINO_HOME = "/usr/lib/trino/etc"
+# JAVA_HOME is baked into the rock image (see trino_rock/rockcraft.yaml); update
+# this literal when the rock's bundled JDK version changes.
+JAVA_HOME = "/usr/lib/jvm/java-25-openjdk-amd64"
 CONFIG_FILES = {
     "config.jinja": "config.properties",
     "logging.jinja": "log.properties",
@@ -64,6 +74,12 @@ USER_SECRET_LABEL = "trino-user-management"  # nosec
 TRINO_CATALOG_SECRET_PREFIX = "trino-catalog-user-"  # nosec
 INT_COMMS_SECRET_LABEL = "trino-int-comms-secret"  # nosec
 INT_COMMS_SECRET_RELATION_KEY = "int-comms-secret-id"  # nosec
+TRUSTSTORE_SECRET_LABEL = "trino-truststore-password"  # nosec
+
+# Sidecar manifests tracking managed truststore aliases (under CONF_DIR).
+TRUSTSTORE_MANIFEST = ".truststore-manifest.json"  # nosec
+CACERTS_MANIFEST = ".cacerts-manifest.json"  # nosec
+CACERTS_PATH = "lib/security/cacerts"  # nosec
 CATALOG_SCHEMA = {
     "backend": {"type": "string"},
     "database": {"type": "string", "nullable": True},

--- a/src/literals.py
+++ b/src/literals.py
@@ -78,6 +78,21 @@ POSTGRESQL_SECRET_LABEL = "trino-postgresql-secrets"  # nosec
 POSTGRESQL_SECRET_RELATION_KEY = "postgresql-secrets-id"  # nosec
 TRUSTSTORE_SECRET_LABEL = "trino-truststore-password"  # nosec
 
+# Obsolete peer-state keys purged by the reconciler (leader-only) now that all
+# reads come from config or live relation data. The two upgrade-fallback keys
+# (java_truststore_pwd, int_comms_secret) are purged separately, gated on their
+# backing app secret existing, and so are intentionally absent from this list.
+LEGACY_STATE_KEYS = (
+    "opensearch",
+    "opensearch_certificate",
+    "discovery_uri",
+    "catalog_config",
+    "user_secret_id",
+    "int_comms_secret_id",
+    "ranger_enabled",
+    "policy_manager_url",
+)
+
 # Sidecar manifests tracking managed truststore aliases (under CONF_DIR).
 TRUSTSTORE_MANIFEST = ".truststore-manifest.json"  # nosec
 CACERTS_MANIFEST = ".cacerts-manifest.json"  # nosec

--- a/src/relations/opensearch.py
+++ b/src/relations/opensearch.py
@@ -6,19 +6,20 @@
 import logging
 import re
 
-from charms.data_platform_libs.v0.data_interfaces import IndexCreatedEvent
 from ops import framework
-from ops.model import BlockedStatus, WaitingStatus
-from ops.pebble import ExecError
 
-from literals import CERTIFICATE_NAME, INDEX_NAME
-from log import log_event_handler
+from literals import INDEX_NAME
 
 logger = logging.getLogger(__name__)
 
 
 class OpensearchRelationHandler(framework.Object):
-    """Client for ranger:postgresql relations."""
+    """Client for ranger:opensearch relations.
+
+    Event observation is centralized in the charm; this object exposes logic
+    methods invoked by the charm reconciler to read connection and certificate
+    data from the relation via the model.
+    """
 
     def __init__(self, charm, relation_name="opensearch"):
         """Construct.
@@ -31,105 +32,17 @@ class OpensearchRelationHandler(framework.Object):
         self.charm = charm
 
         super().__init__(charm, self.relation_name)
-        self.framework.observe(
-            self.charm.opensearch_relation.on.index_created,
-            self._on_index_created,
-        )
-        self.framework.observe(
-            self.charm.on[relation_name].relation_broken,
-            self._on_relation_broken,
-        )
 
-    @log_event_handler(logger)
-    def _on_index_created(self, event: IndexCreatedEvent) -> None:
-        """Handle openserach relation changed events.
+    def _get_relation(self):
+        """Return the opensearch relation, or None when absent.
 
-        Args:
-            event: The event triggered when the relation changed.
+        Returns:
+            The opensearch relation or None.
         """
-        if not self.charm.unit.is_leader():
-            return
-
-        if not self.charm.state.ranger_enabled:
-            self.charm.unit.status = BlockedStatus(
-                "A Ranger relation is required to use OpenSearch."
-            )
-            return
-
-        if self.charm.config.charm_function != "coordinator":
-            self.charm.unit.status = BlockedStatus(
-                "Only Trino coordinator can relate to Opensearch"
-            )
-            return
-
-        self.charm.unit.status = WaitingStatus(f"handling {self.relation_name} change")
-        self.update(event)
-
-    @log_event_handler(logger)
-    def _on_relation_broken(self, event) -> None:
-        """Handle broken relations with opensearch.
-
-        Args:
-            event: The event triggered when the relation changed.
-        """
-        if self.charm.config.charm_function != "coordinator":
-            return
-
-        if not self.charm.state.ranger_enabled:
-            return
-
-        if self.charm.unit.is_leader():
-            self.update(event, True)
-
-    def update_certificates(self, relation_broken=False) -> None:
-        """Add/remove the Opensearch certificate in the Java truststore.
-
-        Args:
-            relation_broken: If the event is a relation broken event.
-        """
-        container = self.charm.unit.get_container(self.charm.name)
-
-        if not self.charm.state.java_truststore_pwd:
-            return
-
-        certificate = self.charm.state.opensearch_certificate
-
-        out, _ = container.exec(["/bin/sh", "-c", "echo $JAVA_HOME"]).wait_output()
-        java_home = out.strip()
-
-        if certificate and not relation_broken:
-            container.push("/opensearch.crt", certificate)
-            command = [
-                "keytool",
-                "-importcert",
-                "-keystore",
-                f"{java_home}/lib/security/cacerts",
-                "-file",
-                "/opensearch.crt",
-                "-alias",
-                CERTIFICATE_NAME,
-                "-storepass",
-                self.charm.state.java_truststore_pwd,
-                "--no-prompt",
-            ]
-        else:
-            container.remove_path("/opensearch.crt")
-            command = [
-                "keytool",
-                "-delete",
-                "-keystore",
-                f"{java_home}/lib/security/cacerts",
-                "-alias",
-                CERTIFICATE_NAME,
-                "-storepass",
-                self.charm.state.java_truststore_pwd,
-            ]
-        try:
-            container.exec(command).wait_output()
-        except ExecError as e:
-            if e.stdout and "already exists" in e.stdout:
-                return
-            logger.error(e.stdout)
+        relation = self.charm.model.get_relation(self.relation_name)
+        if relation is None or relation.app is None:
+            return None
+        return relation
 
     def get_secret_content(self, secret_id) -> dict:
         """Get the content of a juju secret by id.
@@ -144,34 +57,42 @@ class OpensearchRelationHandler(framework.Object):
         content = secret.get_content(refresh=True)
         return content
 
-    def get_cert_value(self, event) -> None:
-        """Get certificate from opensearch secret.
+    def gather_certificate(self):
+        """Read the OpenSearch CA certificate from the relation via the model.
 
-        Args:
-            event: The index created event.
+        Returns:
+            The CA certificate (PEM), or None when unavailable.
         """
-        event_data = event.relation.data[event.app]
-        secret_id = event_data.get("secret-tls")
+        relation = self._get_relation()
+        if relation is None:
+            return None
+        secret_id = relation.data[relation.app].get("secret-tls")
+        if not secret_id:
+            return None
         content = self.get_secret_content(secret_id)
         tls_ca = content["tls-ca"]
         pattern = r"-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----"
         certificates_list = re.findall(pattern, tls_ca, re.DOTALL)
-        self.charm.state.opensearch_certificate = certificates_list[1]
+        return certificates_list[1]
 
-    def get_conn_values(self, event) -> dict:
-        """Get the connection values from the relation to Opensearch.
-
-        Args:
-            event: The event triggered by index created or relation broken events.
+    def gather_connection(self) -> dict:
+        """Read OpenSearch connection values from the relation via the model.
 
         Returns:
-            A dictionary of connection values.
+            A dictionary of connection values, disabled when unavailable.
         """
-        event_data = event.relation.data[event.app]
-        secret_id = event_data.get("secret-user")
-        user_credentials = self.get_secret_content(secret_id)
+        relation = self._get_relation()
+        if relation is None:
+            return {"is_enabled": False}
 
-        host, port = event_data.get("endpoints").split(",", 1)[0].split(":")
+        event_data = relation.data[relation.app]
+        secret_id = event_data.get("secret-user")
+        endpoints = event_data.get("endpoints")
+        if not secret_id or not endpoints:
+            return {"is_enabled": False}
+
+        user_credentials = self.get_secret_content(secret_id)
+        host, port = endpoints.split(",", 1)[0].split(":")
         return {
             "index": INDEX_NAME,
             "host": host,
@@ -180,19 +101,3 @@ class OpensearchRelationHandler(framework.Object):
             "username": user_credentials["username"],
             "is_enabled": True,
         }
-
-    def update(self, event, relation_broken=False) -> None:
-        """Assign nested value in peer relation.
-
-        Args:
-            event: The event triggered when the relation changed.
-            relation_broken: true if opensearch connection is broken.
-        """
-        env = {"is_enabled": False}
-        if not relation_broken:
-            env = self.get_conn_values(event)
-            self.get_cert_value(event)
-        self.update_certificates(relation_broken)
-        self.charm.state.opensearch = env
-
-        self.charm.policy.restart_ranger_plugin(event)

--- a/src/relations/opensearch.py
+++ b/src/relations/opensearch.py
@@ -7,6 +7,7 @@ import logging
 import re
 
 from ops import framework
+from ops.model import ModelError, SecretNotFoundError
 
 from literals import INDEX_NAME
 
@@ -69,10 +70,20 @@ class OpensearchRelationHandler(framework.Object):
         secret_id = relation.data[relation.app].get("secret-tls")
         if not secret_id:
             return None
-        content = self.get_secret_content(secret_id)
-        tls_ca = content["tls-ca"]
+        try:
+            content = self.get_secret_content(secret_id)
+            tls_ca = content["tls-ca"]
+        except (SecretNotFoundError, ModelError, KeyError) as e:
+            logger.warning("Could not read OpenSearch tls-ca secret: %s", e)
+            return None
         pattern = r"-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----"
         certificates_list = re.findall(pattern, tls_ca, re.DOTALL)
+        if len(certificates_list) < 2:
+            logger.warning(
+                "OpenSearch tls-ca bundle has %d certificate(s); expected at least 2",
+                len(certificates_list),
+            )
+            return None
         return certificates_list[1]
 
     def gather_connection(self) -> dict:
@@ -91,13 +102,17 @@ class OpensearchRelationHandler(framework.Object):
         if not secret_id or not endpoints:
             return {"is_enabled": False}
 
-        user_credentials = self.get_secret_content(secret_id)
-        host, port = endpoints.split(",", 1)[0].split(":")
-        return {
-            "index": INDEX_NAME,
-            "host": host,
-            "port": port,
-            "password": user_credentials["password"],
-            "username": user_credentials["username"],
-            "is_enabled": True,
-        }
+        try:
+            user_credentials = self.get_secret_content(secret_id)
+            host, port = endpoints.split(",", 1)[0].split(":")
+            return {
+                "index": INDEX_NAME,
+                "host": host,
+                "port": port,
+                "password": user_credentials["password"],
+                "username": user_credentials["username"],
+                "is_enabled": True,
+            }
+        except (SecretNotFoundError, ModelError, ValueError, KeyError) as e:
+            logger.warning("Could not read OpenSearch connection data: %s", e)
+            return {"is_enabled": False}

--- a/src/relations/policy.py
+++ b/src/relations/policy.py
@@ -6,18 +6,19 @@
 import logging
 
 from ops import framework
-from ops.model import MaintenanceStatus
-from ops.pebble import ExecError
 
 from literals import RANGER_PLUGIN_FILES, TRINO_HOME, TRINO_PORTS
-from log import log_event_handler
 from utils import handle_exec_error, render
 
 logger = logging.getLogger(__name__)
 
 
 class PolicyRelationHandler(framework.Object):
-    """Client for trino policy relations."""
+    """Client for trino policy relations.
+
+    Event observation is centralized in the charm; this object exposes logic
+    methods invoked by the charm reconciler.
+    """
 
     def __init__(self, charm, relation_name="policy"):
         """Construct.
@@ -30,66 +31,34 @@ class PolicyRelationHandler(framework.Object):
         self.charm = charm
         self.relation_name = relation_name
 
-        # Handle database relation.
-        self.framework.observe(
-            charm.on[self.relation_name].relation_created,
-            self._on_relation_created,
-        )
-        self.framework.observe(
-            charm.on[self.relation_name].relation_changed,
-            self._on_relation_changed,
-        )
-        self.framework.observe(
-            charm.on[self.relation_name].relation_broken,
-            self._on_relation_broken,
-        )
-
-    @log_event_handler(logger)
-    def _on_relation_created(self, event):
-        """Handle policy relation created.
-
-        Args:
-            event: The relation created event.
-        """
+    def publish_service_data(self):
+        """Publish the Trino service definition to related Ranger managers."""
         if not self.charm.unit.is_leader():
             return
 
-        service = self._prepare_service(event)
+        for relation in self.charm.model.relations[self.relation_name]:
+            service = self._prepare_service(relation)
+            relation.data[self.charm.app].update(service)
 
-        if event.relation:
-            event.relation.data[self.charm.app].update(service)
+    def read_policy_manager_url(self):
+        """Return the policy manager URL published by the Ranger provider.
 
-    @log_event_handler(logger)
-    def _on_relation_changed(self, event):
-        """Handle policy relation changed.
-
-        Args:
-            event: Relation changed event.
+        Returns:
+            The policy manager URL, or None when unavailable.
         """
-        if not self.charm.unit.is_leader():
-            return
+        for relation in self.charm.model.relations[self.relation_name]:
+            if relation.app is None:
+                continue
+            url = relation.data[relation.app].get("policy_manager_url")
+            if url:
+                return url
+        return None
 
-        container = self.charm.model.unit.get_container(self.charm.name)
-        if not container.can_connect():
-            event.defer()
-            return
-
-        self.charm.state.policy_manager_url = event.relation.data[event.app].get(
-            "policy_manager_url"
-        )
-        if not self.charm.state.policy_manager_url:
-            return
-
-        self.charm.state.policy_relation = f"relation_{event.relation.id}"
-        self._configure_ranger_plugin(container)
-
-        self.charm._restart_trino()
-
-    def _prepare_service(self, event):
+    def _prepare_service(self, relation):
         """Prepare service to be created in Ranger.
 
         Args:
-            event: Relation created event
+            relation: The policy relation.
 
         Returns:
             service: Service values to be set in relation databag
@@ -99,7 +68,7 @@ class PolicyRelationHandler(framework.Object):
         namespace = self.model.name
         uri = f"{host}.{namespace}.svc.cluster.local:{port}"
 
-        service_name = self.charm.config.ranger_service_name or f"relation_{event.relation.id}"
+        service_name = self.charm.config.ranger_service_name or f"relation_{relation.id}"
         service = {
             "name": service_name,
             "type": "trino",
@@ -108,46 +77,23 @@ class PolicyRelationHandler(framework.Object):
         }
         return service
 
-    @log_event_handler(logger)
-    def _on_relation_broken(self, event):
-        """Handle policy relation broken.
-
-        Args:
-            event: Relation broken event.
-
-        Raises:
-            ExecError: When failure to disable Ranger plugin.
-        """
-        if not self.charm.unit.is_leader():
-            return
-
-        container = self.charm.model.unit.get_container(self.charm.name)
-        if not container.can_connect():
-            event.defer()
-            return
-
-        try:
-            self.charm.state.ranger_enabled = False
-            logger.info("Ranger plugin disabled successfully")
-        except ExecError as err:
-            raise ExecError(f"Unable to disable Ranger plugin: {err}") from err
-
-        self.charm._update(event)
-
     @handle_exec_error
     def _configure_ranger_plugin(self, container):
-        """Enable the ranger plugin for Trino.
+        """Render and push the Ranger plugin files.
 
         Args:
             container: The application container.
+
+        Returns:
+            Mapping of pushed file name to rendered content, for plan hashing.
         """
-        self._push_plugin_files(
+        rendered = self._push_plugin_files(
             container,
             self.charm.state.policy_manager_url,
             self.charm.state.policy_relation,
         )
-        self.charm.state.ranger_enabled = True
         logger.info("Ranger plugin is enabled.")
+        return rendered
 
     def _push_plugin_files(self, container, policy_manager_url, policy_relation):
         """Configure the Ranger plugin install.properties file.
@@ -156,10 +102,11 @@ class PolicyRelationHandler(framework.Object):
             container: The application container
             policy_manager_url: The url of the policy manager
             policy_relation: The relation name and id of policy relation
+
+        Returns:
+            Mapping of pushed file name to rendered content.
         """
         opensearch = self.charm.state.opensearch or {}
-        if opensearch.get("is_enabled") and not container.exists("/opensearch.crt"):
-            self.charm.opensearch_relation_handler.update_certificates()
         policy_context = {
             "TRINO_HOME": TRINO_HOME,
             "POLICY_MGR_URL": policy_manager_url,
@@ -172,21 +119,10 @@ class PolicyRelationHandler(framework.Object):
             "OPENSEARCH_USER": opensearch.get("username"),
             "OPENSEARCH_ENABLED": opensearch.get("is_enabled"),
         }
+        rendered = {}
         for template, file in RANGER_PLUGIN_FILES.items():
             content = render(template, policy_context)
             path = self.charm.trino_abs_path.joinpath(file)
             container.push(path, content, make_dirs=True, permissions=0o744)
-
-    def restart_ranger_plugin(self, event):
-        """Restart Ranger plugin for Trino.
-
-        Args:
-            event: the relation changed event.
-        """
-        container = self.charm.model.unit.get_container(self.charm.name)
-        if not container.can_connect():
-            event.fail("Failed to connect to the container")
-            return
-
-        self.charm.unit.status = MaintenanceStatus("Restarting Ranger plugin")
-        self._configure_ranger_plugin(container)
+            rendered[file] = content
+        return rendered

--- a/src/relations/policy.py
+++ b/src/relations/policy.py
@@ -96,7 +96,7 @@ class PolicyRelationHandler(framework.Object):
         policy_relation = f"relation_{relations[0].id}"
         rendered = self._push_plugin_files(
             container,
-            self.charm.state.policy_manager_url,
+            self.read_policy_manager_url(),
             policy_relation,
         )
         logger.info("Ranger plugin is enabled.")
@@ -113,7 +113,7 @@ class PolicyRelationHandler(framework.Object):
         Returns:
             Mapping of pushed file name to rendered content.
         """
-        opensearch = self.charm.state.opensearch or {}
+        opensearch = self.charm.opensearch_relation_handler.gather_connection()
         policy_context = {
             "TRINO_HOME": TRINO_HOME,
             "POLICY_MGR_URL": policy_manager_url,

--- a/src/relations/policy.py
+++ b/src/relations/policy.py
@@ -87,10 +87,17 @@ class PolicyRelationHandler(framework.Object):
         Returns:
             Mapping of pushed file name to rendered content, for plan hashing.
         """
+        relations = self.charm.model.relations[self.relation_name]
+        if not relations:
+            return {}
+
+        # REPOSITORY_NAME must match the service name published by
+        # _prepare_service for the same relation.
+        policy_relation = f"relation_{relations[0].id}"
         rendered = self._push_plugin_files(
             container,
             self.charm.state.policy_manager_url,
-            self.charm.state.policy_relation,
+            policy_relation,
         )
         logger.info("Ranger plugin is enabled.")
         return rendered

--- a/src/relations/postgresql_catalog.py
+++ b/src/relations/postgresql_catalog.py
@@ -562,7 +562,7 @@ class PostgresqlCatalogRelationHandler(framework.Object):
         Returns:
             The Trino username.
         """
-        secret_id = self.charm.state.user_secret_id
+        secret_id = self.charm._effective_user_secret_id()
         if secret_id:
             try:
                 credentials = yaml.safe_load(self.charm._get_secret_content(secret_id)["users"])

--- a/src/relations/postgresql_catalog.py
+++ b/src/relations/postgresql_catalog.py
@@ -6,7 +6,6 @@
 import hashlib
 import json
 import logging
-import time
 from typing import Callable, Optional
 
 import pydantic
@@ -16,8 +15,6 @@ from ops import framework, pebble
 from ops.model import SecretNotFoundError
 
 from literals import DEFAULT_CREDENTIALS, POSTGRESQL_RELATION_NAME
-from log import log_event_handler
-from utils import add_cert_to_truststore
 
 REQUESTED_SECRETS = ["username", "password", "tls", "tls-ca"]
 PASS_ENV_VAR_PREFIX = "PG_PASS_"  # nosec
@@ -142,51 +139,8 @@ class PostgresqlCatalogRelationHandler(framework.Object):
         super().__init__(charm, relation_name)
         self.charm = charm
         self.relation_name = relation_name
-        self._current_wanted_envs = None
 
-        self.framework.observe(
-            charm.on[self.relation_name].relation_created,
-            self._on_relation_created,
-        )
-        self.framework.observe(
-            charm.on[self.relation_name].relation_changed,
-            self._on_relation_changed,
-        )
-        self.framework.observe(
-            charm.on[self.relation_name].relation_broken,
-            self._on_relation_broken,
-        )
-
-    @log_event_handler(logger)
-    def _on_relation_created(self, event):
-        """Handle relation created: trigger reconciliation.
-
-        Args:
-            event: The relation created event.
-        """
-        self.reconcile_postgresql_catalogs(event)
-
-    @log_event_handler(logger)
-    def _on_relation_changed(self, event):
-        """Handle relation changed: trigger reconciliation.
-
-        Args:
-            event: The relation changed event.
-        """
-        self.reconcile_postgresql_catalogs(event)
-        self.charm.trino_catalog.reconcile_trino_catalog_relations()
-
-    @log_event_handler(logger)
-    def _on_relation_broken(self, event):
-        """Handle relation broken: trigger reconciliation.
-
-        Args:
-            event: The relation broken event.
-        """
-        self.reconcile_postgresql_catalogs(event)
-        self.charm.trino_catalog.reconcile_trino_catalog_relations()
-
-    def reconcile_postgresql_catalogs(self, event=None):
+    def reconcile_postgresql_catalogs(self):
         """Reconcile wanted vs tracked catalog state via CREATE/DROP CATALOG.
 
         Compares what catalogs should exist (from relations and config) against
@@ -194,12 +148,10 @@ class PostgresqlCatalogRelationHandler(framework.Object):
         catalog marker), then issues CREATE/DROP CATALOG SQL to correct
         discrepancies.
 
-        Before issuing SQL statements, ensures pebble env vars carry the
-        current passwords so that `${ENV:…}` references in CREATE CATALOG
-        resolve correctly.  Delegates replanning to `self.charm._update()`.
-
-        Args:
-            event: The Juju event that triggered reconciliation (optional).
+        Trino must already be running with the current password env vars (the
+        charm reconciler applies the Pebble plan before calling this). No-ops
+        when Trino is unreachable or still initializing; convergence happens on
+        the next hook.
         """
         # While invalid configuration is caught during config changes
         # other hooks can still fire afterwards even if the charm is blocked.
@@ -214,33 +166,19 @@ class PostgresqlCatalogRelationHandler(framework.Object):
 
         self._write_databag()
 
-        wanted_catalogs, wanted_envs = self._compute_wanted_catalogs()
-        self._current_wanted_envs = wanted_envs
+        wanted_catalogs, _ = self._compute_wanted_catalogs()
 
         if not self._is_trino_reachable():
             logger.warning("Trino not reachable, skipping catalog reconciliation")
-            self._current_wanted_envs = None
             return
 
         tracked_catalogs = self._read_tracked_catalogs()
 
-        # DROP catalogs that should no longer exist while Trino is still
-        # running with the current env vars (before any replan/restart).
+        # DROP catalogs that should no longer exist.
         to_drop = set(tracked_catalogs) - set(wanted_catalogs)
         for name in to_drop:
             logger.info("Dropping relation catalog %r", name)
             self._drop_catalog(name)
-
-        # Replan if password env vars changed so ${ENV:…} references resolve
-        if self._env_vars_changed(wanted_envs):
-            self.charm._update(event)
-            self.charm.trino_coordinator.update_coordinator_relation_data()
-
-        self._current_wanted_envs = None
-
-        if not self._wait_for_trino_ready():
-            logger.warning("Trino not ready after replan, skipping catalog creates")
-            return
 
         # CREATE new catalogs and UPDATE changed ones (drop + re-create)
         for name, props in wanted_catalogs.items():
@@ -260,6 +198,24 @@ class PostgresqlCatalogRelationHandler(framework.Object):
                 self._drop_catalog(name)
             self._create_catalog(name, props)
 
+    def get_desired_tls_certs(self) -> dict:
+        """Return the desired TLS CA certificates for PostgreSQL relations.
+
+        Returns:
+            Mapping of truststore alias to CA certificate (PEM) for each
+            TLS-enabled PostgreSQL relation.
+        """
+        if self.charm.config.charm_function not in ("coordinator", "all"):
+            return {}
+
+        certs = {}
+        for relation in self.charm.model.relations[self.relation_name]:
+            pg = self._load_relation_data(relation)
+            if pg is None or not pg.tls or not pg.tls_ca:
+                continue
+            certs[f"pg-relation-{relation.id}"] = pg.tls_ca
+        return certs
+
     def get_postgresql_relation_catalogs(self) -> list:
         """Return catalog names managed by this handler.
 
@@ -274,14 +230,9 @@ class PostgresqlCatalogRelationHandler(framework.Object):
     def get_postgresql_env_vars(self) -> dict:
         """Return password env vars derived from PG relations.
 
-        If called during a `reconcile_postgresql_catalogs()` run, returns the cached value
-        to avoid recomputing.  Otherwise computes fresh from relations.
-
         Returns:
             Dict mapping env var names to password values.
         """
-        if getattr(self, "_current_wanted_envs", None) is not None:
-            return self._current_wanted_envs
         if self.charm.config.charm_function not in ("coordinator", "all"):
             return {}
         _, env_vars = self._compute_wanted_catalogs()
@@ -336,29 +287,6 @@ class PostgresqlCatalogRelationHandler(framework.Object):
                 props.pop("connector.name", None)
                 tracked[catalog_name] = self._hash_properties(props)
         return tracked
-
-    def _env_vars_changed(self, wanted_envs) -> bool:
-        """Check if PG password env vars differ from the current pebble plan.
-
-        Args:
-            wanted_envs: Dict of wanted env var names to values.
-
-        Returns:
-            True if any PG password env var is missing or changed.
-        """
-        container = self.charm.unit.get_container(self.charm.name)
-        if not container.can_connect():
-            return bool(wanted_envs)
-
-        try:
-            plan = container.get_plan().to_dict()
-            services = plan.get("services", {})
-            current_env = services.get(self.charm.name, {}).get("environment", {})
-        except Exception:
-            return bool(wanted_envs)
-
-        current_pg = {k: v for k, v in current_env.items() if k.startswith(PASS_ENV_VAR_PREFIX)}
-        return current_pg != (wanted_envs or {})
 
     @staticmethod
     def _parse_properties(raw: str) -> dict:
@@ -571,7 +499,6 @@ class PostgresqlCatalogRelationHandler(framework.Object):
             params.append("ssl=true")
             params.append("sslmode=require")
             if pg.tls_ca:
-                self._import_tls_cert(relation_id, pg.tls_ca)
                 params.append(f"sslrootcert={self.charm.truststore_abs_path}")
                 params.append("sslrootcertpassword=${ENV:JAVA_TRUSTSTORE_PWD}")
         else:
@@ -579,33 +506,6 @@ class PostgresqlCatalogRelationHandler(framework.Object):
 
         url = f"jdbc:postgresql://{pg.all_endpoints}/{database}"
         return f"{url}?{'&'.join(params)}"
-
-    def _import_tls_cert(self, relation_id, tls_ca):
-        """Import TLS CA certificate into the Java truststore.
-
-        Args:
-            relation_id: The relation ID (used as cert alias).
-            tls_ca: The CA certificate content.
-        """
-        container = self.charm.unit.get_container(self.charm.name)
-        if not container.can_connect():
-            return
-
-        truststore_pwd = self.charm.state.java_truststore_pwd
-        if not truststore_pwd:
-            return
-
-        alias = f"pg-relation-{relation_id}"
-        try:
-            add_cert_to_truststore(
-                container,
-                alias,
-                tls_ca,
-                truststore_pwd,
-                str(self.charm.conf_abs_path),
-            )
-        except Exception as e:
-            logger.error("Failed to import TLS cert for relation %s: %s", relation_id, e)
 
     def _is_trino_reachable(self) -> bool:
         """Check if Trino is reachable and finished initializing.
@@ -623,28 +523,6 @@ class PostgresqlCatalogRelationHandler(framework.Object):
             return resp.json().get("starting") is False
         except Exception:
             return False
-
-    def _wait_for_trino_ready(self, timeout: float = 300.0, interval: float = 5.0) -> bool:
-        """Poll Trino until it has finished initializing or the timeout elapses.
-
-        After an env-var replan Trino is restarted and briefly reports
-        `SERVER_STARTING_UP` for any query. Wait until it is ready before
-        issuing catalog statements.
-
-        Args:
-            timeout: Maximum total seconds to wait for readiness.
-            interval: Seconds to wait between checks.
-
-        Returns:
-            True if Trino became ready within the timeout, False otherwise.
-        """
-        deadline = time.monotonic() + timeout
-        while True:
-            if self._is_trino_reachable():
-                return True
-            if time.monotonic() >= deadline:
-                return False
-            time.sleep(interval)
 
     def _get_trino_user(self) -> str:
         """Get the Trino user for HTTP API calls.

--- a/src/relations/postgresql_catalog.py
+++ b/src/relations/postgresql_catalog.py
@@ -318,6 +318,11 @@ class PostgresqlCatalogRelationHandler(framework.Object):
         for relation in self.charm.model.relations[self.relation_name]:
             app_databag = relation.data.get(self.charm.app, {})
             if app_databag.get("database"):
+                logger.debug(
+                    "PG relation %s already requests database prefix %r",
+                    relation.app.name,
+                    app_databag.get("database"),
+                )
                 continue
 
             config_entry = self._find_config_for_relation(relation)
@@ -331,6 +336,11 @@ class PostgresqlCatalogRelationHandler(framework.Object):
             app_databag = relation.data[self.charm.app]
             app_databag["database"] = config_entry["database_prefix"]
             app_databag["requested-secrets"] = json.dumps(REQUESTED_SECRETS)
+            logger.info(
+                "Requested PG database prefix %r on relation %s",
+                config_entry["database_prefix"],
+                relation.app.name,
+            )
 
     def _find_config_for_relation(self, relation) -> Optional[dict]:
         """Find the postgresql-catalog-config entry matching a relation.
@@ -445,7 +455,19 @@ class PostgresqlCatalogRelationHandler(framework.Object):
                 relation.app,
                 decoder=PostgresqlRelationModel.decode(self.charm),
             )
-        except (pydantic.ValidationError, SecretNotFoundError):
+        except pydantic.ValidationError as err:
+            # Log which provider keys are present (names only, not secret
+            # values) to distinguish an incomplete handshake from a missing
+            # secret when diagnosing why no catalog is created.
+            logger.warning(
+                "PG relation %s databag incomplete; provider keys present=%s; error=%s",
+                relation.app.name,
+                sorted(relation.data[relation.app].keys()),
+                err,
+            )
+            return None
+        except SecretNotFoundError as err:
+            logger.warning("PG relation %s secret not yet available: %s", relation.app.name, err)
             return None
 
     def _build_catalog_props(self, pg, database, config_entry, relation_id, target_server_type):

--- a/src/relations/trino_catalog.py
+++ b/src/relations/trino_catalog.py
@@ -55,40 +55,26 @@ class TrinoCatalogRelationHandler(Object):
         # Initialize the provider library
         self.provider = TrinoCatalogProvider(self.charm)
 
-        # Observe relation events
-        self.framework.observe(
-            charm.on[self.relation_name].relation_created,
-            self._on_relation_created,
-        )
-        self.framework.observe(
-            charm.on[self.relation_name].relation_broken,
-            self._on_relation_broken,
-        )
-
-    def _on_relation_created(self, event):
-        """Handle trino-catalog relation created."""
-        if not self.charm.state.is_ready():
-            event.defer()
-            return
-
-        self.reconcile_trino_catalog_relations()
-
     @staticmethod
     def _secret_label(relation_id: int) -> str:
         """Build the label of the secret for the relation."""
         return f"{TRINO_CATALOG_SECRET_PREFIX}{relation_id}"
 
-    def _on_relation_broken(self, event):
-        """Handle trino-catalog relation broken: clean up the per-relation secret."""
-        label = self._secret_label(event.relation.id)
+    def remove_relation_secret(self, relation_id: int) -> None:
+        """Remove the per-relation secret for a departing trino-catalog relation.
+
+        Args:
+            relation_id: The ID of the relation being removed.
+        """
+        if not self.charm.unit.is_leader():
+            return
+        label = self._secret_label(relation_id)
         try:
             secret = self.charm.model.get_secret(label=label)
             secret.remove_all_revisions()
-            logger.info("Removed secret for broken relation %s", event.relation.id)
+            logger.info("Removed secret for departed relation %s", relation_id)
         except SecretNotFoundError:
             pass
-
-        self.charm._update_password_db_and_restart()
 
     def _get_url(self) -> Optional[str]:
         """Get the Trino URL from the stored ingress URL or fall back to the internal service URL.
@@ -270,43 +256,6 @@ class TrinoCatalogRelationHandler(Object):
         )
         return secret, True
 
-    def _update_relation(self, event) -> None:
-        """Update a specific trino-catalog relation.
-
-        Creates a per-relation secret if needed, then updates the databag.
-
-        Args:
-            event: The relation created event.
-        """
-        if not self.charm.state.is_ready():
-            event.defer()
-            return
-
-        if not self.charm.unit.is_leader():
-            return
-
-        # Get Trino URL
-        url = self._get_url()
-        if not url:
-            logger.debug("Trino external-hostname not configured")
-            return
-
-        # Get structured catalog information
-        catalogs = self._get_catalogs()
-
-        # Get per-relation user and secret
-        secret, _created = self._get_relation_secret(event.relation)
-        if secret is None:
-            return
-
-        # Update relation via library
-        self.provider.update_relation_data(
-            relation=event.relation,
-            trino_url=url,
-            trino_catalogs=catalogs,
-            trino_credentials_secret_id=secret.id,
-        )
-
     def _parse_exclusions(self) -> dict:
         """Parse the catalog-exclusions config.
 
@@ -332,9 +281,11 @@ class TrinoCatalogRelationHandler(Object):
     def reconcile_trino_catalog_relations(self) -> None:
         """Reconcile all trino-catalog relations.
 
-        Creates per-relation users and app-owned secrets, then updates
-        each relation databag with current URL, catalogs, and secret ID.
-        If new users were created, triggers password.db update and restart.
+        Creates per-relation users and app-owned secrets, updates each relation
+        databag with current URL, catalogs, and secret ID. Secrets for departed
+        relations are removed by the relation-broken handler. The charm
+        reconciler rebuilds password.db from the resulting credentials, so no
+        restart is triggered here.
         """
         if not self.charm.state.is_ready():
             return
@@ -348,6 +299,8 @@ class TrinoCatalogRelationHandler(Object):
             logger.warning("Skipping trino catalog reconciliation: charm config is invalid")
             return
 
+        active_relations = self.charm.model.relations.get(self.relation_name, [])
+
         # Get Trino URL
         url = self._get_url()
         if not url:
@@ -358,16 +311,11 @@ class TrinoCatalogRelationHandler(Object):
         catalogs = self._get_catalogs()
         exclusions = self._parse_exclusions()
 
-        users_changed = False
-
-        for relation in self.charm.model.relations.get(self.relation_name, []):
+        for relation in active_relations:
             # Get per-relation user and secret
-            secret, created = self._get_relation_secret(relation)
+            secret, _created = self._get_relation_secret(relation)
             if secret is None:
                 continue
-
-            if created:
-                users_changed = True
 
             # Filter catalogs based on per-app exclusions
             app_name = relation.data[relation.app].get("app_name") if relation.app else None
@@ -383,9 +331,6 @@ class TrinoCatalogRelationHandler(Object):
                 trino_catalogs=filtered_catalogs,
                 trino_credentials_secret_id=secret.id,
             )
-
-        if users_changed:
-            self.charm._update_password_db_and_restart()
 
     def get_relation_credentials(self) -> dict:
         """Get credentials for all per-relation users.

--- a/src/relations/trino_coordinator.py
+++ b/src/relations/trino_coordinator.py
@@ -11,7 +11,6 @@ from ops.framework import Object
 from ops.model import SecretNotFoundError
 
 from literals import INT_COMMS_SECRET_LABEL, INT_COMMS_SECRET_RELATION_KEY
-from log import log_event_handler
 from utils import generate_password
 
 logger = logging.getLogger(__name__)
@@ -20,10 +19,8 @@ logger = logging.getLogger(__name__)
 class TrinoCoordinator(Object):
     """Defines coordinator functionality for the relation between the Trino coordinator and worker.
 
-    Hook events observed:
-        - relation-created
-        - relation-updated
-        - relation-broken
+    Event observation is centralized in the charm; this object exposes logic
+    methods invoked by the charm reconciler.
     """
 
     def __init__(self, charm: CharmBase, relation_name: str = "trino-coordinator") -> None:
@@ -37,44 +34,6 @@ class TrinoCoordinator(Object):
         self.relation_name = relation_name
 
         super().__init__(charm, self.relation_name)
-        self.framework.observe(
-            charm.on[self.relation_name].relation_created,
-            self._on_relation_changed,
-        )
-        self.framework.observe(
-            charm.on[self.relation_name].relation_changed,
-            self._on_relation_changed,
-        )
-        self.framework.observe(
-            charm.on[self.relation_name].relation_broken,
-            self._on_relation_broken,
-        )
-
-    @log_event_handler(logger)
-    def _on_relation_changed(self, event):
-        """Handle the relation changed event.
-
-        Args:
-            event: the relation changed or update config event.
-        """
-        if not self.charm.state.is_ready():
-            event.defer()
-            return
-
-        self._update_coordinator_relation_data(event)
-        self.charm._update(event)
-
-    def _update_coordinator_relation_data(self, event):
-        """Update the `trino-coordinator` relation databag.
-
-        Args:
-            event: the relation changed or config changed event.
-        """
-        if not self.charm.state.is_ready():
-            event.defer()
-            return
-
-        self.update_coordinator_relation_data()
 
     def _get_or_create_int_comms_secret(self):
         """Get or create the singleton app-owned Juju secret for internal communication.
@@ -135,14 +94,6 @@ class TrinoCoordinator(Object):
                 int_comms_secret.grant(relation)
                 relation_data[INT_COMMS_SECRET_RELATION_KEY] = int_comms_secret.id
             relation.data[self.charm.app].update(relation_data)
-
-    def _on_relation_broken(self, event):
-        """Coordinator updates and re-validates relations on relation broken.
-
-        Args:
-            event: the relation broken event.
-        """
-        self.charm._update(event)
 
     def _validate(self):
         """Check if the trino coordinator relation is available.

--- a/src/relations/trino_coordinator.py
+++ b/src/relations/trino_coordinator.py
@@ -10,7 +10,12 @@ from ops.charm import CharmBase
 from ops.framework import Object
 from ops.model import SecretNotFoundError
 
-from literals import INT_COMMS_SECRET_LABEL, INT_COMMS_SECRET_RELATION_KEY
+from literals import (
+    INT_COMMS_SECRET_LABEL,
+    INT_COMMS_SECRET_RELATION_KEY,
+    POSTGRESQL_SECRET_LABEL,
+    POSTGRESQL_SECRET_RELATION_KEY,
+)
 from utils import generate_password
 
 logger = logging.getLogger(__name__)
@@ -64,6 +69,38 @@ class TrinoCoordinator(Object):
         logger.info("Created Juju secret for internal comms")
         return secret
 
+    def _get_or_create_pg_secret(self, env_vars: dict):
+        """Get or refresh the app-owned Juju secret holding PostgreSQL passwords.
+
+        Unlike the internal-comms secret, the PostgreSQL password map is dynamic:
+        it changes as the provider rotates credentials or catalogs are added and
+        removed. The content is refreshed so workers converge on the new revision
+        via secret-changed.
+
+        Args:
+            env_vars: Mapping of env var name to password. An empty map means no
+                PostgreSQL catalogs, so no secret is managed.
+
+        Returns:
+            The Juju secret object, or None when the unit is not the leader or
+            there are no PostgreSQL passwords to share.
+        """
+        if not self.charm.unit.is_leader() or not env_vars:
+            return None
+
+        # Juju secret keys must be lowercase alphanumerics, but env var names
+        # (e.g. PG_PASS_MYDB) are not, so the map is JSON-encoded under one key.
+        content = {"envvars": json.dumps(env_vars, sort_keys=True)}
+        try:
+            secret = self.charm.model.get_secret(label=POSTGRESQL_SECRET_LABEL)
+            if secret.get_content(refresh=True) != content:
+                secret.set_content(content)
+            return secret
+        except SecretNotFoundError:
+            secret = self.charm.app.add_secret(content, label=POSTGRESQL_SECRET_LABEL)
+            logger.info("Created Juju secret for PostgreSQL catalog passwords")
+            return secret
+
     def update_coordinator_relation_data(self):
         """Write coordinator data to the relation databag for workers."""
         if not self.charm.state.is_ready():
@@ -79,21 +116,28 @@ class TrinoCoordinator(Object):
         pg_env_vars = self.charm.postgresql_catalog_handler.get_postgresql_env_vars()
 
         int_comms_secret = None
+        pg_secret = None
         if self.charm.unit.is_leader():
             int_comms_secret = self._get_or_create_int_comms_secret()
+            pg_secret = self._get_or_create_pg_secret(pg_env_vars)
 
         relation_data = {
             "discovery-uri": self.charm._coordinator_discovery_uri,
             "user-secret-id": self.charm.config.user_secret_id or "",
             "catalogs": self.charm.config.catalog_config or "",
-            "postgresql-secrets": json.dumps(pg_env_vars),
         }
 
         for relation in coordinator_relations:
+            app_databag = relation.data[self.charm.app]
             if int_comms_secret is not None:
                 int_comms_secret.grant(relation)
                 relation_data[INT_COMMS_SECRET_RELATION_KEY] = int_comms_secret.id
-            relation.data[self.charm.app].update(relation_data)
+            if pg_secret is not None:
+                pg_secret.grant(relation)
+                relation_data[POSTGRESQL_SECRET_RELATION_KEY] = pg_secret.id
+            else:
+                app_databag.pop(POSTGRESQL_SECRET_RELATION_KEY, None)
+            app_databag.update(relation_data)
 
     def _validate(self):
         """Check if the trino coordinator relation is available.

--- a/src/relations/trino_worker.py
+++ b/src/relations/trino_worker.py
@@ -34,25 +34,32 @@ class TrinoWorker(Object):
 
         super().__init__(charm, self.relation_name)
 
-    def gather_from_coordinator(self):
-        """Persist coordinator-published data from the relation databag.
+    def get_coordinator_data(self) -> dict:
+        """Read coordinator-published data live from the trino-worker relation.
 
-        Reads the `trino-worker` relation databag via the model so the worker
-        can be reconciled from current state rather than an event payload.
-        Only the leader persists to peer state.
+        Every worker unit can read the coordinator's app databag directly, so
+        the values are resolved on demand rather than cached in peer state.
+
+        Returns:
+            Mapping with discovery_uri, user_secret_id, catalog_config and
+            int_comms_secret_id; values are None/"" when unavailable.
         """
-        if not self.charm.unit.is_leader():
-            return
-
         relation = self.charm.model.get_relation(self.relation_name)
         if relation is None or relation.app is None:
-            return
+            return {
+                "discovery_uri": None,
+                "user_secret_id": None,  # nosec B105
+                "catalog_config": None,
+                "int_comms_secret_id": "",  # nosec B105
+            }
 
-        event_data = relation.data[relation.app]
-        self.charm.state.discovery_uri = event_data.get("discovery-uri")
-        self.charm.state.user_secret_id = event_data.get("user-secret-id")
-        self.charm.state.catalog_config = event_data.get("catalogs")
-        self.charm.state.int_comms_secret_id = event_data.get(INT_COMMS_SECRET_RELATION_KEY, "")
+        databag = relation.data[relation.app]
+        return {
+            "discovery_uri": databag.get("discovery-uri"),
+            "user_secret_id": databag.get("user-secret-id"),
+            "catalog_config": databag.get("catalogs"),
+            "int_comms_secret_id": databag.get(INT_COMMS_SECRET_RELATION_KEY, ""),
+        }
 
     def _resolve_int_comms_secret(self, secret_id: str) -> str | None:
         """Resolve the internal communication secret value by Juju secret ID.

--- a/src/relations/trino_worker.py
+++ b/src/relations/trino_worker.py
@@ -10,8 +10,7 @@ from ops.charm import CharmBase
 from ops.framework import Object
 from ops.model import SecretNotFoundError
 
-from literals import CATALOG_DIR, INT_COMMS_SECRET_RELATION_KEY
-from log import log_event_handler
+from literals import INT_COMMS_SECRET_RELATION_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -19,10 +18,8 @@ logger = logging.getLogger(__name__)
 class TrinoWorker(Object):
     """Defines worker functionality for the relation between the Trino coordinator and worker.
 
-    Hook events observed:
-        - relation-created
-        - relation-updated
-        - relation-broken
+    Event observation is centralized in the charm; this object exposes logic
+    methods invoked by the charm reconciler.
     """
 
     def __init__(self, charm: CharmBase, relation_name: str = "trino-worker") -> None:
@@ -36,40 +33,26 @@ class TrinoWorker(Object):
         self.relation_name = relation_name
 
         super().__init__(charm, self.relation_name)
-        self.framework.observe(
-            charm.on[self.relation_name].relation_created,
-            self._on_relation_changed,
-        )
-        self.framework.observe(
-            charm.on[self.relation_name].relation_changed,
-            self._on_relation_changed,
-        )
-        self.framework.observe(
-            charm.on[self.relation_name].relation_broken,
-            self._on_relation_broken,
-        )
 
-    @log_event_handler(logger)
-    def _on_relation_changed(self, event):
-        """Worker updates `state` based on relation event data.
+    def gather_from_coordinator(self):
+        """Persist coordinator-published data from the relation databag.
 
-        Args:
-            event: the relation changed event.
+        Reads the `trino-worker` relation databag via the model so the worker
+        can be reconciled from current state rather than an event payload.
+        Only the leader persists to peer state.
         """
-        if not self.charm.state.is_ready():
-            event.defer()
+        if not self.charm.unit.is_leader():
             return
 
-        if self.charm.unit.is_leader():
-            event_data = event.relation.data[event.app]
-            self.charm.state.discovery_uri = event_data.get("discovery-uri")
-            self.charm.state.user_secret_id = event_data.get("user-secret-id")
-            self.charm.state.catalog_config = event_data.get("catalogs")
+        relation = self.charm.model.get_relation(self.relation_name)
+        if relation is None or relation.app is None:
+            return
 
-            int_comms_secret_id = event_data.get(INT_COMMS_SECRET_RELATION_KEY, "")
-            self.charm.state.int_comms_secret_id = int_comms_secret_id
-
-        self.charm._update(event)
+        event_data = relation.data[relation.app]
+        self.charm.state.discovery_uri = event_data.get("discovery-uri")
+        self.charm.state.user_secret_id = event_data.get("user-secret-id")
+        self.charm.state.catalog_config = event_data.get("catalogs")
+        self.charm.state.int_comms_secret_id = event_data.get(INT_COMMS_SECRET_RELATION_KEY, "")
 
     def _resolve_int_comms_secret(self, secret_id: str) -> str | None:
         """Resolve the internal communication secret value by Juju secret ID.
@@ -89,33 +72,6 @@ class TrinoWorker(Object):
         except SecretNotFoundError:
             logger.warning("int-comms-secret id %r could not be resolved", secret_id)
             return None
-
-    def _on_relation_broken(self, event):
-        """Worker updates `state` following relation broken event.
-
-        Args:
-            event: the relation broken event.
-        """
-        if not self.charm.state.is_ready():
-            return
-
-        container = self.charm.model.unit.get_container(self.charm.name)
-        if not container.can_connect():
-            event.defer()
-            return
-
-        catalog_path = self.charm.trino_abs_path.joinpath(CATALOG_DIR)
-        if container.exists(catalog_path):
-            container.remove_path(catalog_path, recursive=True)
-
-        if not self.charm.unit.is_leader():
-            return
-
-        self.charm.state.discovery_uri = ""
-        self.charm.state.catalog_config = ""
-        self.charm.state.catalog_config = ""
-
-        self.charm._update(event)
 
     def get_postgresql_secrets_from_coordinator(self) -> dict:
         """Read PG password env vars from the coordinator relation databag.

--- a/src/relations/trino_worker.py
+++ b/src/relations/trino_worker.py
@@ -10,7 +10,7 @@ from ops.charm import CharmBase
 from ops.framework import Object
 from ops.model import SecretNotFoundError
 
-from literals import INT_COMMS_SECRET_RELATION_KEY
+from literals import INT_COMMS_SECRET_RELATION_KEY, POSTGRESQL_SECRET_RELATION_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -74,19 +74,28 @@ class TrinoWorker(Object):
             return None
 
     def get_postgresql_secrets_from_coordinator(self) -> dict:
-        """Read PG password env vars from the coordinator relation databag.
+        """Resolve PG password env vars from the coordinator's Juju secret.
+
+        The coordinator publishes the secret id in the relation databag and
+        grants the secret to the relation, so only the id crosses the databag.
 
         Returns:
-            Dict mapping env var names to password values.
+            Dict mapping env var names to password values, empty if unavailable.
         """
         relation = self.charm.model.get_relation(self.relation_name)
         if relation is None or relation.app is None:
             return {}
-        raw = relation.data[relation.app].get("postgresql-secrets", "{}")
-        try:
-            return json.loads(raw)
-        except (json.JSONDecodeError, TypeError):
+        secret_id = relation.data[relation.app].get(POSTGRESQL_SECRET_RELATION_KEY)
+        if not secret_id:
             return {}
+        try:
+            secret = self.charm.model.get_secret(id=secret_id)
+            content = secret.get_content(refresh=True)
+        except SecretNotFoundError:
+            logger.warning("postgresql-secrets id %r could not be resolved", secret_id)
+            return {}
+        # The env var map is JSON-encoded under a single Juju-valid secret key.
+        return json.loads(content.get("envvars", "{}"))
 
     def _validate(self):
         """Check if the trino worker relation is available.

--- a/src/utils.py
+++ b/src/utils.py
@@ -4,6 +4,8 @@
 
 """Collection of helper methods for Trino Charm."""
 
+import hashlib
+import json
 import logging
 import os
 import re
@@ -14,6 +16,7 @@ import textwrap
 
 from cerberus import Validator
 from jinja2 import Environment, FileSystemLoader
+from ops.pebble import Error as PebbleError
 from ops.pebble import ExecError
 
 from literals import REPLICA_SCHEMA
@@ -28,6 +31,173 @@ def generate_password() -> str:
         String of 32 randomized letter+digit characters
     """
     return "".join([secrets.choice(string.ascii_letters + string.digits) for _ in range(32)])
+
+
+def content_hash(content: str) -> str:
+    """Return a stable SHA-256 hex digest of file content.
+
+    Used to encode a managed file's desired content into the Pebble plan so
+    that Pebble's own change detection triggers a restart only when the
+    content actually changes.
+
+    Args:
+        content: The rendered desired file content.
+
+    Returns:
+        Hex-encoded SHA-256 digest of the content.
+    """
+    return hashlib.sha256(content.encode()).hexdigest()
+
+
+def _certificate_fingerprint(cert: str) -> str:
+    """Return a stable identity for a certificate for change detection.
+
+    Hashes the PEM text directly: matching the exact bytes keytool records is
+    unnecessary because reconciliation tracks its own manifest of what it
+    installed rather than reading back the keystore.
+
+    Args:
+        cert: The certificate content (PEM).
+
+    Returns:
+        Hex-encoded SHA-256 digest of the certificate text.
+    """
+    return hashlib.sha256(cert.encode()).hexdigest()
+
+
+def truststore_manifest_hash(certs: dict) -> str:
+    """Return a deterministic hash of a desired truststore cert set.
+
+    JKS files embed per-entry timestamps, so hashing the keystore bytes is not
+    reproducible. Hashing a sorted `alias:fingerprint` manifest instead yields
+    a stable value that changes only when the desired cert set changes, making
+    it safe to place in the Pebble plan as a restart trigger.
+
+    Args:
+        certs: Mapping of alias to certificate content (PEM).
+
+    Returns:
+        Hex-encoded SHA-256 digest of the sorted manifest.
+    """
+    manifest = sorted(f"{alias}:{_certificate_fingerprint(cert)}" for alias, cert in certs.items())
+    return hashlib.sha256("\n".join(manifest).encode()).hexdigest()
+
+
+def _read_truststore_manifest(container, manifest_path) -> dict:
+    """Read the tracked truststore manifest, or an empty dict if absent.
+
+    Args:
+        container: The Trino container.
+        manifest_path: Path to the sidecar manifest file.
+
+    Returns:
+        Mapping of alias to fingerprint of the last-installed certs.
+    """
+    try:
+        return json.loads(container.pull(manifest_path).read())
+    except PebbleError:
+        return {}
+    except (json.JSONDecodeError, TypeError):
+        logger.warning("Corrupt truststore manifest at %s, treating as empty", manifest_path)
+        return {}
+
+
+def _keytool_delete_alias(container, keystore_path, storepass, alias) -> None:
+    """Delete an alias from a keystore, ignoring a missing entry.
+
+    Args:
+        container: The Trino container.
+        keystore_path: Path to the JKS/PKCS12 keystore.
+        storepass: The keystore password.
+        alias: The alias to delete.
+    """
+    command = [
+        "keytool",
+        "-delete",
+        "-alias",
+        alias,
+        "-keystore",
+        keystore_path,
+        "-storepass",
+        storepass,
+        "-noprompt",
+    ]
+    try:
+        container.exec(command).wait_output()
+    except ExecError as e:
+        if e.stderr and "does not exist" in e.stderr:
+            return
+        logger.warning("Failed to delete alias %r from %s: %s", alias, keystore_path, e.stderr)
+
+
+def _keytool_import_cert(container, keystore_path, storepass, alias, cert, working_dir) -> None:
+    """Import a PEM certificate into a keystore under the given alias.
+
+    Args:
+        container: The Trino container.
+        keystore_path: Path to the JKS/PKCS12 keystore.
+        storepass: The keystore password.
+        alias: The alias to import under.
+        cert: The certificate content (PEM).
+        working_dir: Directory used to stage the certificate file.
+    """
+    cert_file = f"{alias}.crt"
+    container.push(os.path.join(working_dir, cert_file), cert, make_dirs=True)
+    command = [
+        "keytool",
+        "-import",
+        "-v",
+        "-alias",
+        alias,
+        "-file",
+        cert_file,
+        "-keystore",
+        keystore_path,
+        "-storepass",
+        storepass,
+        "-noprompt",
+    ]
+    try:
+        container.exec(command, working_dir=working_dir).wait_output()
+    finally:
+        try:
+            container.remove_path(os.path.join(working_dir, cert_file))
+        except PebbleError:
+            pass
+
+
+def reconcile_truststore(container, keystore_path, storepass, desired, working_dir, manifest_path):
+    """Reconcile a keystore's managed certificates to the desired set in place.
+
+    Adds missing or changed certificates, removes obsolete ones, and leaves
+    unchanged entries untouched. Only aliases recorded in the sidecar manifest
+    are considered managed, so default CA entries in a shared keystore (e.g.
+    the JVM `cacerts`) are never removed. Avoids the churn of deleting and
+    recreating the keystore on every reconcile.
+
+    Args:
+        container: The Trino container.
+        keystore_path: Path to the JKS/PKCS12 keystore.
+        storepass: The keystore password.
+        desired: Mapping of alias to certificate content (PEM) that should exist.
+        working_dir: Directory used to stage certificate files for import.
+        manifest_path: Path to the sidecar manifest tracking managed aliases.
+    """
+    tracked = _read_truststore_manifest(container, manifest_path)
+    desired_fps = {alias: _certificate_fingerprint(cert) for alias, cert in desired.items()}
+
+    # Remove certs that are managed but no longer desired, or whose content changed.
+    for alias, fingerprint in tracked.items():
+        if desired_fps.get(alias) != fingerprint:
+            _keytool_delete_alias(container, keystore_path, storepass, alias)
+
+    # Import certs that are new or whose content changed.
+    for alias, cert in desired.items():
+        if tracked.get(alias) == desired_fps[alias]:
+            continue
+        _keytool_import_cert(container, keystore_path, storepass, alias, cert, working_dir)
+
+    container.push(manifest_path, json.dumps(desired_fps), make_dirs=True)
 
 
 def render(template_name, env=None):

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -4,6 +4,7 @@
 
 """Trino charm integration test helpers."""
 
+import json
 import logging
 import os
 import subprocess  # nosec B404
@@ -263,6 +264,47 @@ def wait_for_app_gone(juju: jubilant.Juju, app: str, timeout: float = 600, delay
             return
         time.sleep(delay)
     raise TimeoutError(f"Application {app!r} still present after {timeout}s")
+
+
+def wait_for_requirer_catalogs(
+    juju: jubilant.Juju,
+    requirer_unit: str,
+    expected_count: int,
+    timeout: float = 300,
+    delay: float = 5.0,
+):
+    """Poll a requirer's trino-catalog relation data until it holds the expected count.
+
+    The provider keeps status "active" while it republishes the catalog databag, so
+    waiting on unit status cannot guarantee the catalogs have propagated. Poll the
+    requirer's get-relation-data action until the count settles.
+
+    Args:
+        juju: Jubilant Juju object.
+        requirer_unit: The requirer unit to query (e.g. "requirer-app/0").
+        expected_count: The number of catalogs expected in the relation data.
+        timeout: Maximum time to wait for the count to settle, in seconds.
+        delay: Delay between polls, in seconds.
+
+    Returns:
+        The parsed list of catalogs once the expected count is reached.
+
+    Raises:
+        TimeoutError: if the expected count is not reached within the timeout.
+    """
+    catalogs = []
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        action = juju.run(requirer_unit, "get-relation-data")
+        assert action.status == "completed"
+        catalogs = json.loads(action.results.get("trino-catalogs", "[]"))
+        if len(catalogs) == expected_count:
+            return catalogs
+        time.sleep(delay)
+    raise TimeoutError(
+        f"Requirer {requirer_unit!r} reported {len(catalogs)} catalogs, "
+        f"expected {expected_count} within {timeout}s"
+    )
 
 
 def get_unit_url(juju: jubilant.Juju, application, unit, port, protocol="http"):

--- a/tests/integration/test_pg_catalog_relation.py
+++ b/tests/integration/test_pg_catalog_relation.py
@@ -156,7 +156,7 @@ def set_pg_config(juju: jubilant.Juju, config_str, expect_blocked=False):
         wait_for_apps(juju, [APP_NAME, WORKER_NAME, POSTGRES_NAME], status="active", timeout=900)
 
 
-def wait_for_catalog(juju: jubilant.Juju, catalog_name, present=True, timeout=300):
+def wait_for_catalog(juju: jubilant.Juju, catalog_name, present=True, timeout=600):
     """Poll SHOW CATALOGS until catalog appears/disappears or timeout.
 
     Args:

--- a/tests/integration/test_trino_catalog_relation.py
+++ b/tests/integration/test_trino_catalog_relation.py
@@ -3,7 +3,6 @@
 
 """Integration tests for trino-catalog relation."""
 
-import ast
 import logging
 import time
 from pathlib import Path
@@ -20,6 +19,7 @@ from helpers import (
     get_unit,
     wait_for_app_gone,
     wait_for_apps,
+    wait_for_requirer_catalogs,
 )
 
 from literals import TRINO_PORTS
@@ -136,12 +136,7 @@ class TestTrinoCatalogRelation:
         wait_for_apps(juju, [APP_NAME, REQUIRER_APP], status="active", timeout=1000)
 
         # Verify the requirer received the catalogs
-        action = juju.run(f"{REQUIRER_APP}/0", "get-relation-data")
-        assert action.status == "completed"
-
-        # Parse the catalogs list from string representation
-        catalogs_str = action.results.get("trino-catalogs", "[]")
-        catalogs = ast.literal_eval(catalogs_str)
+        catalogs = wait_for_requirer_catalogs(juju, f"{REQUIRER_APP}/0", expected_count=5)
         catalogs_count = len(catalogs)
 
         assert catalogs_count == 5, f"Expected 5 catalogs, got {catalogs_count}"
@@ -174,11 +169,7 @@ class TestTrinoCatalogRelation:
         wait_for_apps(juju, [APP_NAME], status="active", timeout=1000)
 
         # Verify the requirer receives 4 catalogs (postgresql-1 excluded)
-        action = juju.run(f"{REQUIRER_APP}/0", "get-relation-data")
-        assert action.status == "completed"
-
-        catalogs_str = action.results.get("trino-catalogs", "[]")
-        catalogs = ast.literal_eval(catalogs_str)
+        catalogs = wait_for_requirer_catalogs(juju, f"{REQUIRER_APP}/0", expected_count=4)
         catalog_names = {cat["name"] for cat in catalogs}
 
         assert "postgresql-1" not in catalog_names, (
@@ -190,11 +181,7 @@ class TestTrinoCatalogRelation:
         juju.config(APP_NAME, reset=["catalog-exclusions"])
         wait_for_apps(juju, [APP_NAME], status="active", timeout=1000)
 
-        action = juju.run(f"{REQUIRER_APP}/0", "get-relation-data")
-        assert action.status == "completed"
-
-        catalogs_str = action.results.get("trino-catalogs", "[]")
-        catalogs = ast.literal_eval(catalogs_str)
+        catalogs = wait_for_requirer_catalogs(juju, f"{REQUIRER_APP}/0", expected_count=5)
         catalog_names = {cat["name"] for cat in catalogs}
 
         assert "postgresql-1" in catalog_names, (
@@ -280,12 +267,7 @@ class TestTrinoCatalogRelation:
         wait_for_apps(juju, [APP_NAME], status="active", timeout=1000)
 
         # Verify the requirer received the updated catalogs (without bigquery)
-        action = juju.run(f"{REQUIRER_APP}/0", "get-relation-data")
-        assert action.status == "completed"
-
-        # Parse the catalogs list from string representation
-        catalogs_str = action.results.get("trino-catalogs", "[]")
-        catalogs = ast.literal_eval(catalogs_str)
+        catalogs = wait_for_requirer_catalogs(juju, f"{REQUIRER_APP}/0", expected_count=4)
         catalogs_count = len(catalogs)
 
         assert catalogs_count == 4, (

--- a/tests/integration/trino_catalog_requirer_charm/src/charm.py
+++ b/tests/integration/trino_catalog_requirer_charm/src/charm.py
@@ -8,6 +8,7 @@ Demonstrates usage of the TrinoCatalogRequirer library to consume
 Trino catalog information via the trino-catalog relation.
 """
 
+import json
 import logging
 
 from charms.trino_k8s.v0.trino_catalog import TrinoCatalogRequirer
@@ -172,7 +173,7 @@ class TrinoCatalogRequirerCharm(CharmBase):
         event.set_results(
             {
                 "trino-url": trino_info["trino_url"],
-                "trino-catalogs": str(catalogs_info),
+                "trino-catalogs": json.dumps(catalogs_info),
                 "trino-username": trino_username,
                 "trino-password": trino_password,
             }

--- a/tests/integration/trino_client/trino_client.py
+++ b/tests/integration/trino_client/trino_client.py
@@ -13,19 +13,21 @@ from trino.dbapi import connect
 logger = logging.getLogger(__name__)
 
 
-def query_trino(host, user, query, max_wait=120, retry_interval=10) -> str:
+def query_trino(host, user, query, max_wait=300, retry_interval=10) -> str:
     """Trino catalogs.
 
-    Retries transient `SERVER_STARTING_UP` errors, which occur when the Trino
-    server process is up but still initializing (e.g. shortly after a restart
-    triggered by a config change). All other errors are raised immediately.
+    Retries while the coordinator is unavailable after a config-triggered
+    restart: connection-refused errors (process down, port 8080 not yet bound)
+    and transient `SERVER_STARTING_UP` errors (process up but initializing).
+    A cold JVM restart can take minutes, so the deadline is generous. All other
+    errors are raised immediately.
 
     Args:
         host: trino server address.
         user: the user with which to access Trino.
         query: query to execute.
         max_wait: maximum total seconds to keep retrying while the server is
-            still initializing.
+            unreachable or still initializing.
         retry_interval: seconds to wait between retries.
 
     Returns:
@@ -46,6 +48,13 @@ def query_trino(host, user, query, max_wait=120, retry_interval=10) -> str:
             cur.execute(query)
             result = cur.fetchall()
             return result
+        except trino.exceptions.TrinoConnectionError:
+            # Connection refused while Pebble restarts the service to apply a
+            # config change and port 8080 is not yet bound. Retry until it binds.
+            if time.monotonic() >= deadline:
+                raise
+            logger.info("Trino server is unreachable, retrying in %ss", retry_interval)
+            time.sleep(retry_interval)
         except trino.exceptions.TrinoQueryError as err:
             # While we are not past the deadline
             # retry after server initializing errors.

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -268,6 +268,7 @@ def build_worker_state(
     config=None,
     catalogs=None,
     include_int_comms=True,
+    postgresql_secrets=None,
     extra_relations=(),
     extra_secrets=(),
     container=None,
@@ -283,6 +284,8 @@ def build_worker_state(
         config: extra config options merged over the worker defaults.
         catalogs: explicit catalog-config to advertise (defaults to the standard one).
         include_int_comms: whether the coordinator has published an int-comms secret.
+        postgresql_secrets: mapping of PG password env vars the coordinator has
+            published via a granted Juju secret, or None to publish none.
         extra_relations: additional relations to include in the state.
         extra_secrets: additional secrets to include in the state.
         container: an explicit container to use instead of the default.
@@ -305,6 +308,14 @@ def build_worker_state(
         int_comms = observer_secret({"secret": "test-int-comms-secret"})  # nosec B105
         secrets.add(int_comms)
         remote_data["int-comms-secret-id"] = int_comms.id
+
+    pg_secret = None
+    if postgresql_secrets:
+        pg_secret = observer_secret(
+            {"envvars": json.dumps(dict(postgresql_secrets), sort_keys=True)}
+        )
+        secrets.add(pg_secret)
+        remote_data["postgresql-secrets-id"] = pg_secret.id
 
     worker_relation = Relation(
         "trino-worker",
@@ -333,6 +344,7 @@ def build_worker_state(
         gsheets=cats.gsheets.id,
         catalog_config=catalog_config,
         int_comms=int_comms,
+        pg_secret=pg_secret,
         worker_relation=worker_relation,
         peer_relation=peer_relation,
     )

--- a/tests/unit/test_catalog_freshness.py
+++ b/tests/unit/test_catalog_freshness.py
@@ -11,7 +11,7 @@
 import dataclasses
 import logging
 
-from ops.model import MaintenanceStatus
+from ops.model import ActiveStatus
 from ops.testing import Mount
 
 from tests.unit.helpers import (
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 
 def test_config_changed(ctx):
     """The pebble plan changes according to config changes."""
-    state_in, ids = build_coordinator_state(
+    state_in, _ = build_coordinator_state(
         config={
             "google-client-id": "test-client-id",
             "google-client-secret": "test-client-secret",
@@ -51,9 +51,8 @@ def test_config_changed(ctx):
             "summary": "trino server",
             "command": "./entrypoint.sh",
             "startup": "enabled",
-            "on-check-failure": {"up": "ignore"},
+            "on-check-failure": {"up": "restart"},
             "environment": {
-                "CATALOG_CONFIG": ids.catalog_config,
                 "PASSWORD_DB_PATH": "/usr/lib/trino/etc/password.db",  # nosec
                 "LOG_LEVEL": "info",
                 "OAUTH_CLIENT_ID": "test-client-id",
@@ -99,8 +98,15 @@ def test_config_changed(ctx):
     environment["INT_COMMS_SECRET"] = "int_comms_secret"  # nosec
     environment["USER_SECRET_ID"] = "secret:secret-id"  # nosec
 
+    # Per-file content hashes drive Pebble restarts; assert they are present as
+    # freshness triggers, then drop them to compare the stable environment.
+    hash_keys = {key for key in environment if key.startswith("HASH_")}
+    assert hash_keys
+    for key in hash_keys:
+        del environment[key]
+
     assert got_services == want_services
-    assert state_out.unit_status == MaintenanceStatus("replanning application")
+    assert state_out.unit_status == ActiveStatus("Status check: UP")
 
 
 def test_catalog_added(ctx):

--- a/tests/unit/test_catalog_freshness.py
+++ b/tests/unit/test_catalog_freshness.py
@@ -24,7 +24,6 @@ from tests.unit.helpers import (
     carry_forward,
     create_added_catalog_config,
     observer_secret,
-    peer_state_value,
     trino_container,
     workload_path,
 )
@@ -181,9 +180,9 @@ def test_worker_fetches_latest_catalog_on_relation_change(ctx):
     relations.add(worker_relation)
     state_in = dataclasses.replace(state_in, relations=relations)
 
-    state_out = ctx.run(ctx.on.relation_changed(worker_relation), state_in)
+    with ctx(ctx.on.relation_changed(worker_relation), state_in) as mgr:
+        mgr.run()
+        catalog_config = mgr.charm._effective_catalog_config()
 
-    peer_relation = state_out.get_relation(ids.peer_relation.id)
-    catalog_config = peer_state_value(peer_relation, "catalog_config")
     assert catalog_config == extended_catalog_config
     assert catalog_config != old_catalog

--- a/tests/unit/test_catalog_freshness.py
+++ b/tests/unit/test_catalog_freshness.py
@@ -23,6 +23,7 @@ from tests.unit.helpers import (
     build_worker_state,
     carry_forward,
     create_added_catalog_config,
+    observer_secret,
     peer_state_value,
     trino_container,
     workload_path,
@@ -33,14 +34,17 @@ logger = logging.getLogger(__name__)
 
 def test_config_changed(ctx):
     """The pebble plan changes according to config changes."""
+    oidc = observer_secret(
+        {"google-client-id": "test-client-id", "google-client-secret": "test-client-secret"}
+    )
     state_in, _ = build_coordinator_state(
         config={
-            "google-client-id": "test-client-id",
-            "google-client-secret": "test-client-secret",
+            "oidc-secret-id": oidc.id,
             "web-proxy": "proxy:port",
             "charm-function": "all",
             "additional-jvm-options": USER_JVM_STRING,
-        }
+        },
+        extra_secrets=(oidc,),
     )
 
     state_out = ctx.run(ctx.on.config_changed(), state_in)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -786,6 +786,19 @@ def test_oidc_secret_id_unresolvable_blocks(ctx):
     assert "oidc-secret-id" in state_out.unit_status.message
 
 
+def test_malformed_user_secret_blocks(ctx):
+    """A user secret whose `users` field is not a mapping blocks the charm."""
+    bad_user = observer_secret({"users": ""})
+    state_in, _ = build_coordinator_state(
+        config={"user-secret-id": bad_user.id}, extra_secrets=(bad_user,)
+    )
+
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    assert isinstance(state_out.unit_status, BlockedStatus)
+    assert "must be a mapping" in state_out.unit_status.message
+
+
 def test_coordinator_publishes_pg_secret_id(ctx):
     """Coordinator publishes a PG secret id, never the plaintext passwords."""
     state_in, ids = build_coordinator_state()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -71,19 +71,18 @@ def test_waiting_on_peer_relation_not_ready(ctx):
     # No plans are set yet.
     assert state_out.get_container("trino").plan.to_dict() == {}
 
-    # The BlockStatus is set with a message.
-    assert state_out.unit_status == BlockedStatus("peer relation not ready")
+    # The WaitingStatus is set with a message.
+    assert state_out.unit_status == WaitingStatus("waiting for peer relation")
 
 
 def test_ready(ctx):
     """The pebble plan is correctly generated when the charm is ready."""
-    state_in, ids = build_coordinator_state()
-    catalog_config = ids.catalog_config
+    state_in, _ = build_coordinator_state()
 
     state_out = ctx.run(ctx.on.config_changed(), state_in)
 
-    # Asserts status is set to replanning.
-    assert state_out.unit_status == MaintenanceStatus("replanning application")
+    # The status reflects the healthy `up` check reported by Scenario.
+    assert state_out.unit_status == ActiveStatus("Status check: UP")
 
     # The plan is generated after config is applied.
     want_plan = {
@@ -93,9 +92,8 @@ def test_ready(ctx):
                 "summary": "trino server",
                 "command": "./entrypoint.sh",
                 "startup": "enabled",
-                "on-check-failure": {"up": "ignore"},
+                "on-check-failure": {"up": "restart"},
                 "environment": {
-                    "CATALOG_CONFIG": catalog_config,
                     "PASSWORD_DB_PATH": "/usr/lib/trino/etc/password.db",  # nosec
                     "LOG_LEVEL": "info",
                     "OAUTH_CLIENT_ID": None,
@@ -137,6 +135,13 @@ def test_ready(ctx):
     environment["JAVA_TRUSTSTORE_PWD"] = "truststore_pwd"  # nosec
     environment["INT_COMMS_SECRET"] = "int_comms_secret"  # nosec
     environment["USER_SECRET_ID"] = "secret:secret-id"  # nosec
+
+    # Per-file content hashes drive Pebble restarts; assert they are present as
+    # freshness triggers, then drop them to compare the stable environment.
+    hash_keys = {key for key in environment if key.startswith("HASH_")}
+    assert hash_keys
+    for key in hash_keys:
+        del environment[key]
 
     assert got_services == want_plan["services"]
 
@@ -349,7 +354,7 @@ def test_incomplete_pebble_plan(ctx):
 
     state_out = ctx.run(ctx.on.update_status(), state_in)
 
-    assert state_out.unit_status == MaintenanceStatus("replanning application")
+    assert state_out.unit_status == ActiveStatus("Status check: UP")
     assert state_out.get_container("trino").plan.to_dict() != mock_incomplete_pebble_plan
 
 
@@ -446,8 +451,8 @@ def test_trino_single_node_deployment(ctx):
     # There is a valid pebble plan.
     assert _services(state_out)["trino"]["environment"]["CHARM_FUNCTION"] == "all"
 
-    # The MaintenanceStatus is set.
-    assert state_out.unit_status == MaintenanceStatus("replanning application")
+    # The status reflects the healthy `up` check reported by Scenario.
+    assert state_out.unit_status == ActiveStatus("Status check: UP")
 
 
 def test_resource_management_config(ctx):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -9,6 +9,7 @@
 # pylint:disable=protected-access,too-many-public-methods
 
 import dataclasses
+import json
 import logging
 from unittest import mock
 
@@ -37,6 +38,7 @@ from tests.unit.helpers import (
     build_worker_state,
     create_single_catalog_config,
     observer_secret,
+    peer_state_value,
     trino_container,
     workload_path,
 )
@@ -696,19 +698,68 @@ def test_coordinator_int_comms_secret_preserves_existing_value(ctx):
         assert content2["secret"] == "pre-existing-secret-value"  # nosec
 
 
+LEGACY_STATE_SEED = {
+    "opensearch": {"username": "u", "password": "p"},  # nosec B105 sensitive
+    "opensearch_certificate": "ca-cert",
+    "discovery_uri": "http://old-coordinator:8080",
+    "catalog_config": "old-catalog-config",
+    "user_secret_id": "secret:olduser",  # nosec B105
+    "int_comms_secret_id": "secret:oldid",  # nosec B105
+    "ranger_enabled": True,
+    "policy_manager_url": "http://old-ranger",
+    "java_truststore_pwd": "old-truststore-pw",  # nosec B105
+    "int_comms_secret": "old-int-comms-value",  # nosec B105
+}
+
+
+def _seed_peer_state(state_in, ids, values):
+    """Replace the peer relation with one pre-seeded with JSON-encoded state."""
+    seeded = PeerRelation(
+        "peer",
+        local_app_data={key: json.dumps(value) for key, value in values.items()},
+    )
+    relations = {rel for rel in state_in.relations if rel.id != ids.peer_relation.id}
+    relations.add(seeded)
+    return dataclasses.replace(state_in, relations=relations), seeded
+
+
+def test_leader_purges_legacy_state_on_reconcile(ctx):
+    """Leader drops obsolete and fallback peer keys once secrets are confirmed."""
+    state_in, ids = build_coordinator_state()
+    state_in, seeded = _seed_peer_state(state_in, ids, LEGACY_STATE_SEED)
+
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    peer = state_out.get_relation(seeded.id)
+    for key in LEGACY_STATE_SEED:
+        assert peer_state_value(peer, key) is None, f"{key!r} should be purged"
+
+
+def test_non_leader_keeps_legacy_state(ctx):
+    """A non-leader never mutates peer state, so legacy keys survive."""
+    state_in, ids = build_coordinator_state(leader=False)
+    state_in, seeded = _seed_peer_state(state_in, ids, LEGACY_STATE_SEED)
+
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    peer = state_out.get_relation(seeded.id)
+    for key, value in LEGACY_STATE_SEED.items():
+        assert peer_state_value(peer, key) == value, f"{key!r} must be preserved"
+
+
 def test_worker_resolves_int_comms_secret_from_coordinator(ctx):
     """Worker reads int-comms-secret from coordinator.
 
-    Worker reads int-comms-secret-id from relation, stores the ID in state, and
-    resolves the secret value at render time via _get_int_comms_secret_value.
+    Worker reads int-comms-secret-id live from the trino-worker relation databag
+    and resolves the secret value at render time via _get_int_comms_secret_value.
     """
     state_in, ids = build_worker_state()
 
     with ctx(ctx.on.relation_changed(ids.worker_relation), state_in) as mgr:
         mgr.run()
 
-        # The worker's peer state must carry the secret *ID* (not the plaintext value).
-        secret_id = mgr.charm.state.int_comms_secret_id
+        # The coordinator databag must carry the secret *ID* (not the plaintext value).
+        secret_id = mgr.charm.trino_worker.get_coordinator_data()["int_comms_secret_id"]
         assert secret_id is not None
         assert secret_id.startswith("secret:")
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -10,6 +10,7 @@
 
 import dataclasses
 import logging
+from unittest import mock
 
 import pytest
 import yaml
@@ -23,6 +24,7 @@ from ops.model import (
 from ops.pebble import CheckLevel, CheckStartup, CheckStatus, Layer
 from ops.testing import CheckInfo, Mount, PeerRelation, Relation, State
 
+from relations.postgresql_catalog import PostgresqlCatalogRelationHandler
 from tests.unit.helpers import (
     BIGQUERY_CATALOG_PATH,
     DEFAULT_JVM_STRING,
@@ -741,3 +743,95 @@ def test_worker_no_plaintext_secret_in_relation_databag(ctx):
             raise AssertionError(
                 f"Plaintext int-comms field {key!r} found in worker app relation data: {value!r}"
             )
+
+
+def test_oidc_credentials_resolved_from_secret(ctx):
+    """OAuth credentials are read from the oidc-secret-id Juju secret."""
+    oidc = observer_secret(
+        {"google-client-id": "client-123", "google-client-secret": "shhh"}  # nosec
+    )
+    state_in, _ = build_coordinator_state(
+        config={"oidc-secret-id": oidc.id}, extra_secrets=(oidc,)
+    )
+
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    environment = _services(state_out)["trino"]["environment"]
+    assert environment["OAUTH_CLIENT_ID"] == "client-123"
+    assert environment["OAUTH_CLIENT_SECRET"] == "shhh"  # nosec
+
+
+@pytest.mark.parametrize("option", ["google-client-id", "google-client-secret"])
+def test_deprecated_oidc_plaintext_blocks(ctx, option):
+    """Setting a deprecated plaintext OIDC option blocks the charm."""
+    state_in, _ = build_coordinator_state(config={option: "some-value"})
+
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    assert isinstance(state_out.unit_status, BlockedStatus)
+    assert "deprecated" in state_out.unit_status.message
+
+
+def test_oidc_secret_id_unresolvable_blocks(ctx):
+    """An oidc-secret-id that cannot be resolved blocks the charm."""
+    # The secret is referenced but never granted to (added to) the state.
+    oidc = observer_secret(
+        {"google-client-id": "client-123", "google-client-secret": "shhh"}  # nosec
+    )
+    state_in, _ = build_coordinator_state(config={"oidc-secret-id": oidc.id})
+
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    assert isinstance(state_out.unit_status, BlockedStatus)
+    assert "oidc-secret-id" in state_out.unit_status.message
+
+
+def test_coordinator_publishes_pg_secret_id(ctx):
+    """Coordinator publishes a PG secret id, never the plaintext passwords."""
+    state_in, ids = build_coordinator_state()
+
+    with mock.patch.object(
+        PostgresqlCatalogRelationHandler,
+        "get_postgresql_env_vars",
+        return_value={"PG_PASS_TESTDB": "super-secret-pw"},  # nosec
+    ):
+        state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    relation_data = state_out.get_relation(ids.coordinator_relation.id).local_app_data
+    assert relation_data["postgresql-secrets-id"].startswith("secret:")
+    for value in relation_data.values():
+        assert "super-secret-pw" not in value
+
+
+def test_coordinator_no_pg_secret_id_without_catalogs(ctx):
+    """Coordinator omits the PG secret id when there are no PostgreSQL catalogs."""
+    state_in, ids = build_coordinator_state()
+
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    relation_data = state_out.get_relation(ids.coordinator_relation.id).local_app_data
+    assert "postgresql-secrets-id" not in relation_data
+
+
+def test_worker_resolves_pg_secret_from_coordinator(ctx):
+    """Worker resolves PG password env vars from the coordinator's granted secret."""
+    state_in, ids = build_worker_state(
+        postgresql_secrets={"PG_PASS_TESTDB": "super-secret-pw"}  # nosec
+    )
+
+    with ctx(ctx.on.relation_changed(ids.worker_relation), state_in) as mgr:
+        mgr.run()
+        resolved = mgr.charm.trino_worker.get_postgresql_secrets_from_coordinator()
+
+    assert resolved == {"PG_PASS_TESTDB": "super-secret-pw"}  # nosec
+
+
+def test_worker_pg_secret_empty_without_id(ctx):
+    """Worker returns an empty map when the coordinator publishes no PG secret."""
+    state_in, ids = build_worker_state()
+
+    with ctx(ctx.on.relation_changed(ids.worker_relation), state_in) as mgr:
+        mgr.run()
+        resolved = mgr.charm.trino_worker.get_postgresql_secrets_from_coordinator()
+
+    assert resolved == {}

--- a/tests/unit/test_pg_catalog_handler.py
+++ b/tests/unit/test_pg_catalog_handler.py
@@ -176,26 +176,22 @@ class TestBuildJdbcUrl(TestCase):
         handler._import_tls_cert.assert_not_called()
 
     def test_tls_with_ca(self):
-        """Verify TLS with CA cert imports cert and sets sslrootcert."""
+        """Verify TLS with CA cert sets sslrootcert to the shared truststore."""
         handler = self._make_handler()
         pg = self._make_pg("host:5432", tls=True, tls_ca="BEGIN CERT...")
         url = handler._build_jdbc_url(pg, "mydb", 1, "primary")
         self.assertIn("ssl=true", url)
         self.assertIn("sslrootcert=/path/to/truststore", url)
-        handler._import_tls_cert.assert_called_once_with(1, "BEGIN CERT...")
 
 
 class TestTrinoReadiness(TestCase):
-    """Tests for _is_trino_reachable and _wait_for_trino_ready."""
+    """Tests for _is_trino_reachable."""
 
     def _make_handler(self):
-        """Create a mock handler bound to the real readiness methods."""
+        """Create a mock handler bound to the real readiness method."""
         handler = mock.MagicMock()
         handler._is_trino_reachable = PostgresqlCatalogRelationHandler._is_trino_reachable.__get__(
             handler
-        )
-        handler._wait_for_trino_ready = (
-            PostgresqlCatalogRelationHandler._wait_for_trino_ready.__get__(handler)
         )
         return handler
 
@@ -229,30 +225,6 @@ class TestTrinoReadiness(TestCase):
         """Verify not reachable when the request raises."""
         handler = self._make_handler()
         self.assertFalse(handler._is_trino_reachable())
-
-    def test_wait_returns_true_when_ready(self):
-        """Verify wait returns True immediately when Trino is ready."""
-        handler = self._make_handler()
-        handler._is_trino_reachable = mock.MagicMock(return_value=True)
-        self.assertTrue(handler._wait_for_trino_ready(timeout=10, interval=0))
-
-    @mock.patch("relations.postgresql_catalog.time.sleep")
-    @mock.patch("relations.postgresql_catalog.time.monotonic")
-    def test_wait_returns_true_after_retry(self, mock_time, _mock_sleep):
-        """Verify wait retries until Trino becomes ready."""
-        mock_time.side_effect = [0.0, 0.0, 5.0]
-        handler = self._make_handler()
-        handler._is_trino_reachable = mock.MagicMock(side_effect=[False, True])
-        self.assertTrue(handler._wait_for_trino_ready(timeout=300, interval=5))
-
-    @mock.patch("relations.postgresql_catalog.time.sleep")
-    @mock.patch("relations.postgresql_catalog.time.monotonic")
-    def test_wait_returns_false_on_timeout(self, mock_time, _mock_sleep):
-        """Verify wait returns False when the timeout elapses."""
-        mock_time.side_effect = [0.0, 301.0]
-        handler = self._make_handler()
-        handler._is_trino_reachable = mock.MagicMock(return_value=False)
-        self.assertFalse(handler._wait_for_trino_ready(timeout=300, interval=5))
 
 
 def _pg_yaml(entries: dict) -> str:

--- a/tests/unit/test_policy.py
+++ b/tests/unit/test_policy.py
@@ -131,6 +131,26 @@ def test_policy_relation_changed(ctx):
     assert POLICY_MGR_URL in ranger_config
 
 
+def test_ranger_service_name_defaults_to_relation(ctx):
+    """Ranger service name falls back to `relation_<id>` when config is unset."""
+    policy_rel = Relation(
+        "policy",
+        remote_app_name="ranger-k8s",
+        remote_app_data={"policy_manager_url": POLICY_MGR_URL},
+    )
+    state_in, _ = build_coordinator_state(extra_relations=[policy_rel])
+    bootstrapped = carry_forward(ctx.run(ctx.on.config_changed(), state_in))
+
+    policy_rel = bootstrapped.get_relation(policy_rel.id)
+    state_out = ctx.run(ctx.on.relation_changed(policy_rel), bootstrapped)
+
+    ranger_config = workload_path(state_out, ctx, RANGER_SECURITY_PATH).read_text()
+    expected = (
+        f"<name>ranger.plugin.trino.service.name</name><value>relation_{policy_rel.id}</value>"
+    )
+    assert expected in re.sub(r"\s", "", ranger_config)
+
+
 def test_policy_relation_broken(ctx):
     """Removing the policy relation disables the Ranger plugin."""
     policy_rel = Relation("policy", remote_app_name="ranger-k8s")
@@ -170,6 +190,73 @@ def test_on_opensearch_relation_broken(ctx):
 
     ranger_config = workload_path(state, ctx, RANGER_AUDIT_PATH).read_text()
     assert "testuser" not in ranger_config
+
+    state = dataclasses.replace(state, containers={_up_check_container(state)})
+    state_out = ctx.run(ctx.on.update_status(), state)
+    assert state_out.unit_status == ActiveStatus("Status check: UP")
+
+
+def _opensearch_state(ctx, *, endpoints, tls_ca):
+    """Bootstrap a coordinator with a custom OpenSearch endpoint and tls-ca.
+
+    Args:
+        ctx: the Scenario `Context` for the charm.
+        endpoints: the raw `endpoints` value published on the relation.
+        tls_ca: the raw `tls-ca` bundle stored in the OpenSearch TLS secret.
+
+    Returns:
+        A `(State, Relation)` tuple ready for a relation-changed run.
+    """
+    user_secret = observer_secret({"username": "testuser", "password": "testpassword"})  # nosec B105
+    tls_secret = observer_secret({"tls-ca": tls_ca})
+    policy_rel = Relation(
+        "policy",
+        remote_app_name="ranger-k8s",
+        remote_app_data={"policy_manager_url": POLICY_MGR_URL},
+    )
+    opensearch_rel = Relation(
+        "opensearch",
+        remote_app_name="opensearch-app",
+        remote_app_data={
+            "secret-user": user_secret.id,
+            "secret-tls": tls_secret.id,
+            "endpoints": endpoints,
+        },
+    )
+    state_in, _ = build_coordinator_state(
+        extra_relations=[policy_rel, opensearch_rel],
+        extra_secrets=[user_secret, tls_secret],
+    )
+    state = carry_forward(ctx.run(ctx.on.config_changed(), state_in))
+    policy_rel = state.get_relation(policy_rel.id)
+    state = carry_forward(ctx.run(ctx.on.relation_changed(policy_rel), state))
+    return state, state.get_relation(opensearch_rel.id)
+
+
+def test_opensearch_portless_endpoint_disables(ctx):
+    """A malformed (portless) endpoint disables OpenSearch without erroring."""
+    state, opensearch_rel = _opensearch_state(
+        ctx, endpoints="opensearch-host", tls_ca=OPENSEARCH_TLS_CA
+    )
+
+    state_out = ctx.run(ctx.on.relation_changed(opensearch_rel), state)
+
+    ranger_config = workload_path(state_out, ctx, RANGER_AUDIT_PATH).read_text()
+    assert "testuser" not in ranger_config
+
+
+def test_opensearch_single_cert_bundle_no_error(ctx):
+    """A single-cert tls-ca bundle yields no certificate but does not error."""
+    single_ca = (
+        "-----BEGIN CERTIFICATE-----\n"
+        "MIIC+DCCAeCgAwIBAgIJAKJdWfG2zRAQMA0GCSqGSIb3DQEBCwUAMIGPMQswCQYD\n"
+        "-----END CERTIFICATE-----"
+    )
+    state, opensearch_rel = _opensearch_state(
+        ctx, endpoints="opensearch-host:port", tls_ca=single_ca
+    )
+
+    state = ctx.run(ctx.on.relation_changed(opensearch_rel), state)
 
     state = dataclasses.replace(state, containers={_up_check_container(state)})
     state_out = ctx.run(ctx.on.update_status(), state)

--- a/tests/unit/test_policy.py
+++ b/tests/unit/test_policy.py
@@ -12,7 +12,7 @@ import dataclasses
 import logging
 import re
 
-from ops.model import ActiveStatus, MaintenanceStatus
+from ops.model import ActiveStatus
 from ops.pebble import CheckLevel, CheckStartup, CheckStatus
 from ops.testing import CheckInfo, Relation
 
@@ -87,10 +87,12 @@ def _opensearch_setup(ctx):
     state = carry_forward(ctx.run(ctx.on.config_changed(), state_in))
 
     # Enable the Ranger plugin via the policy relation.
+    policy_rel = state.get_relation(policy_rel.id)
     state = carry_forward(ctx.run(ctx.on.relation_changed(policy_rel), state))
 
     # Create the OpenSearch index. The OpenSearch credentials and certificate
     # are resolved from real Juju secrets shared over the relation.
+    opensearch_rel = state.get_relation(opensearch_rel.id)
     state = ctx.run(ctx.on.relation_changed(opensearch_rel), state)
 
     return state, opensearch_rel
@@ -122,6 +124,7 @@ def test_policy_relation_changed(ctx):
     state_in, _ = build_coordinator_state(extra_relations=[policy_rel])
     bootstrapped = carry_forward(ctx.run(ctx.on.config_changed(), state_in))
 
+    policy_rel = bootstrapped.get_relation(policy_rel.id)
     state_out = ctx.run(ctx.on.relation_changed(policy_rel), bootstrapped)
 
     ranger_config = workload_path(state_out, ctx, RANGER_SECURITY_PATH).read_text()
@@ -134,6 +137,7 @@ def test_policy_relation_broken(ctx):
     state_in, _ = build_coordinator_state(extra_relations=[policy_rel])
     bootstrapped = carry_forward(ctx.run(ctx.on.config_changed(), state_in))
 
+    policy_rel = bootstrapped.get_relation(policy_rel.id)
     state_out = ctx.run(ctx.on.relation_broken(policy_rel), bootstrapped)
 
     relation_data = state_out.get_relation(policy_rel.id).local_app_data
@@ -143,9 +147,6 @@ def test_policy_relation_broken(ctx):
 def test_on_opensearch_index_created(ctx):
     """Test handling of opensearch relation changed events."""
     state, _ = _opensearch_setup(ctx)
-
-    assert state.unit_status == MaintenanceStatus("Restarting Ranger plugin")
-    assert workload_path(state, ctx, "/opensearch.crt").exists()
 
     ranger_config = workload_path(state, ctx, RANGER_AUDIT_PATH).read_text()
     ranger_config = re.sub(r"\s", "", ranger_config)
@@ -165,17 +166,7 @@ def test_on_opensearch_relation_broken(ctx):
     state = carry_forward(state)
     opensearch_rel = state.get_relation(opensearch_rel.id)
 
-    # The OpenSearch certificate was installed when the index was created; seed
-    # it so the broken handler can remove it (the workload filesystem is reset
-    # between Scenario runs).
-    with ctx(ctx.on.relation_broken(opensearch_rel), state) as mgr:
-        mgr.charm.unit.get_container("trino").push(
-            "/opensearch.crt", "certificate", make_dirs=True
-        )
-        state = mgr.run()
-
-    assert state.unit_status == MaintenanceStatus("Restarting Ranger plugin")
-    assert not workload_path(state, ctx, "/opensearch.crt").exists()
+    state = ctx.run(ctx.on.relation_broken(opensearch_rel), state)
 
     ranger_config = workload_path(state, ctx, RANGER_AUDIT_PATH).read_text()
     assert "testuser" not in ranger_config


### PR DESCRIPTION
## Changes
* Added Copilot instructions from https://github.com/canonical/copilot-collections .
* Reworked the charm into the reconciler pattern.
  * Static catalog hashes are injected into the Pebble plan to let Pebble handle the necessary restarts on need.
  * Truststore is reconciled now instead of being deleted and recreated with each change.
  * Up check is no longer ignored.
  * Unit status is tied to service status closer.
  * State is mostly phased out. Whatever remains is to keep upgrade compatibility.
* Sensitive configurations and relation data are moved into Juju secrets.
* Tests are updated and tuned to reduce flakiness.
* Relation names have been converted into constants.

I did my best to reduce test flakiness. I will re-run any failures until they pass. I will tackle the remaining flakiness at the final general improvements task.

## Notes for reviewers
This is more of a rewrite than a refactor with the size of converting a large charm into the reconciler pattern. I did my best to test and review this but local testing is unfeasible to match what happens on a live deployment.

I will do a final round of local testing before merging but this is the limit of QA I am able to do.